### PR TITLE
Broken markdown support for long descriptions

### DIFF
--- a/src/phpDocumentor/Reflection/DocBlock/LongDescription.php
+++ b/src/phpDocumentor/Reflection/DocBlock/LongDescription.php
@@ -78,7 +78,7 @@ class LongDescription implements \Reflector
             );
         }
 
-        if (class_exists('\dflydev\markdown\MarkdownExtraParser()')) {
+        if (class_exists('\dflydev\markdown\MarkdownExtraParser')) {
             $md = new \dflydev\markdown\MarkdownExtraParser();
             $result = $md->transformMarkdown($result);
         }


### PR DESCRIPTION
This pull request fixed the wrong `class_exists()` usage and brings back the markdown support for long descriptions.
