### PR TITLE
Small path fix

### DIFF
--- a/src/phpDocumentor/Reflection/DocBlock/Tag.php
+++ b/src/phpDocumentor/Reflection/DocBlock/Tag.php
@@ -59,7 +59,7 @@ class Tag implements \Reflector
         $tag_name = str_replace(
             ' ', '', ucwords(str_replace('-', ' ', $matches[1]))
         ).'Tag';
-        $class_name = '\\phpDocumentor\\Reflection\\DocBlock\\Tag\\' . $tag_name;
+        $class_name = 'phpDocumentor\\Reflection\\DocBlock\\Tag\\' . $tag_name;
 
         return (@class_exists($class_name))
             ? new $class_name($matches[1], isset($matches[2]) ? $matches[2] : '')


### PR DESCRIPTION
When the parser is run independently from a place that's not the current directory, then this fix is necessary so that the Tag subclasses are found in the include path.
