### PR TITLE
Fix phpDocumentor/phpDocumentor2#467

### DIFF
--- a/src/phpDocumentor/Reflection/DocBlock.php
+++ b/src/phpDocumentor/Reflection/DocBlock.php
@@ -127,11 +127,11 @@ class DocBlock implements \Reflector
             preg_match(
                 '/(?x)
         \A (
-          [^\n]+
+          [^\n.]+
           (?:
-            (?! (?<=\.) \n | \n{2} ) # disallow the first seperator here
-            \n (?! [ \t]* @\pL ) # disallow second seperator
-            [^\n]+
+            (?! \. \s | \n{2} ) # disallow the first seperator here
+            [\n.] (?! [ \t]* @\pL ) # disallow second seperator
+            [^\n.]+
           )*
           \.?
         )

--- a/tests/phpDocumentor/Reflection/DocBlockTest.php
+++ b/tests/phpDocumentor/Reflection/DocBlockTest.php
@@ -44,4 +44,22 @@ DOCBLOCK;
         $this->assertTrue($object->hasTag('see'));
         $this->assertTrue($object->hasTag('return'));
     }
+
+    public function testDotSeperation()
+    {
+        $fixture = <<<DOCBLOCK
+/**
+ * This is a short description. This is a long description.
+ * This is a continuation of the long description.
+ */
+DOCBLOCK;
+        $object = new DocBlock($fixture);
+        $this->assertEquals(
+            'This is a short description.', $object->getShortDescription()
+        );
+        $this->assertEquals(
+            "This is a long description.\nThis is a continuation of the long description.", $object->getLongDescription()->getContents()
+	        );
+    }
 }
+


### PR DESCRIPTION
The regular expression did not take generale whitespace into account, only newlines. A test case is added as well.
