### PR TITLE
Abstracting away namespace (and other context dependent) information into a new object

### DIFF
--- a/src/phpDocumentor/Reflection/DocBlock.php
+++ b/src/phpDocumentor/Reflection/DocBlock.php
@@ -12,6 +12,9 @@
 
 namespace phpDocumentor\Reflection;
 
+use phpDocumentor\Reflection\DocBlock\Context;
+use phpDocumentor\Reflection\DocBlock\Location;
+
 /**
  * Parses the DocBlock for any structure.
  *
@@ -36,11 +39,11 @@ class DocBlock implements \Reflector
      */
     protected $tags = array();
 
-    /** @var string the current namespace */
-    protected $namespace = '\\';
+    /** @var Context Information about the context of this DocBlock. */
+    protected $context = null;
 
-    /** @var array List of namespace aliases => Fully Qualified Namespace */
-    protected $namespace_aliases = array();
+    /** @var Location Information about the location of this DocBlock. */
+    protected $location = null;
 
     /**
      * Parses the given docblock and populates the member fields.
@@ -49,21 +52,20 @@ class DocBlock implements \Reflector
      * current namespace and aliases. This information is used by some tags
      * (e.g. @return, @param, etc.) to turn a relative Type into a FQCN.
      *
-     * @param \Reflector|string $docblock          A docblock comment (including
+     * @param \Reflector|string $docblock A docblock comment (including
      *     asterisks) or reflector supporting the getDocComment method.
-     * @param string            $namespace         The namespace where this
-     *     DocBlock resides in; defaults to `\`.
-     * @param array             $namespace_aliases A list of namespace aliases
-     *     as provided by the `use` keyword; the key of the array is the alias
-     *     name or last part of the alias array if no alias name is provided.
+     * @param Context           $context  The context in which the DocBlock
+     *     occurs.
+     * @param Location          $location The location within the file that this
+     *     DocBlock occurs in.
      *
      * @throws \InvalidArgumentException if the given argument does not have the
      *     getDocComment method.
      */
     public function __construct(
         $docblock,
-        $namespace = '\\',
-        array $namespace_aliases = array()
+        Context $context = null,
+        Location $location = null
     ) {
         if (is_object($docblock)) {
             if (!method_exists($docblock, 'getDocComment')) {
@@ -83,8 +85,8 @@ class DocBlock implements \Reflector
         $this->long_description = new DocBlock\Description($long, $this);
         $this->parseTags($tags);
 
-        $this->namespace = $namespace;
-        $this->namespace_aliases = $namespace_aliases;
+        $this->context  = $context;
+        $this->location = $location;
     }
 
     /**
@@ -247,6 +249,26 @@ class DocBlock implements \Reflector
     }
 
     /**
+     * Returns the current context.
+     *
+     * @return Context
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+
+    /**
+     * Returns the current location.
+     *
+     * @return Location
+     */
+    public function getLocation()
+    {
+        return $this->location;
+    }
+
+    /**
      * Returns the tags for this DocBlock.
      *
      * @return \phpDocumentor\Reflection\DocBlock\Tag[]
@@ -323,21 +345,5 @@ class DocBlock implements \Reflector
     public function __toString()
     {
         return 'Not yet implemented';
-    }
-
-    /**
-     * @return string The namespace where this DocBlock resides in.
-     */
-    public function getNamespace()
-    {
-        return $this->namespace;
-    }
-
-    /**
-     * @return array List of namespace aliases => Fully Qualified Namespace.
-     */
-    public function getNamespaceAliases()
-    {
-        return $this->namespace_aliases;
     }
 }

--- a/src/phpDocumentor/Reflection/DocBlock/Context.php
+++ b/src/phpDocumentor/Reflection/DocBlock/Context.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * phpDocumentor
+ *
+ * PHP Version 5.3
+ *
+ * @author    Vasil Rangelov <boen.robot@gmail.com>
+ * @copyright 2010-2011 Mike van Riel / Naenius (http://www.naenius.com)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\DocBlock;
+
+/**
+ * The context in which a DocBlock occurs.
+ *
+ * @author  Vasil Rangelov <boen.robot@gmail.com>
+ * @license http://www.opensource.org/licenses/mit-license.php MIT
+ * @link    http://phpdoc.org
+ */
+class Context
+{
+    /** @var string The current namespace. */
+    protected $namespace = '';
+
+    /** @var array List of namespace aliases => Fully Qualified Namespace. */
+    protected $namespace_aliases = array();
+    
+    /** @var string Name of the structural element, within the namespace. */
+    protected $lsen = '';
+    
+    /**
+     * 
+     * @param string $namespace         The namespace where this DocBlock
+     *     resides in.
+     * @param array  $namespace_aliases List of namespace aliases => Fully
+     *     Qualified Namespace.
+     * @param string $lsen              Name of the structural element, within
+     *     the namespace.
+     */
+    public function __construct(
+        $namespace = '',
+        array $namespace_aliases = array(),
+        $lsen = ''
+    ) {
+        if (!empty($namespace)) {
+            $this->setNamespace($namespace);
+        }
+        $this->setNamespaceAliases($namespace_aliases);
+        $this->setLSEN($lsen);
+    }
+
+    /**
+     * @return string The namespace where this DocBlock resides in.
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * @return array List of namespace aliases => Fully Qualified Namespace.
+     */
+    public function getNamespaceAliases()
+    {
+        return $this->namespace_aliases;
+    }
+    
+    /**
+     * Returns the Local Structural Element Name.
+     * 
+     * @return string Name of the structural element, within the namespace.
+     */
+    public function getLSEN()
+    {
+        return $this->lsen;
+    }
+    
+    /**
+     * Sets a new namespace.
+     * 
+     * Sets a new namespace for the context. Leading and trailing slashes are
+     * trimmed, and the keywords "global" and "default" are treated as aliases
+     * to no namespace.
+     * 
+     * @param string $namespace The new namespace to set.
+     * 
+     * @return $this
+     */
+    public function setNamespace($namespace)
+    {
+        if ('global' !== $namespace
+            && 'default' !== $namespace
+        ) {
+            // Srip leading and trailing slash
+            $this->namespace = trim((string)$namespace, '\\');
+        } else {
+            $this->namespace = '';
+        }
+        return $this;
+    }
+    
+    /**
+     * Sets the namespace aliases, replacing all previous ones.
+     * 
+     * @param array $namespace_aliases List of namespace aliases => Fully
+     *     Qualified Namespace.
+     * 
+     * @return $this
+     */
+    public function setNamespaceAliases(array $namespace_aliases)
+    {
+        $this->namespace_aliases = array();
+        foreach ($namespace_aliases as $alias => $fqnn) {
+            $this->setNamespaceAlias($alias, $fqnn);
+        }
+        return $this;
+    }
+    
+    /**
+     * Adds a namespace alias to the context.
+     * 
+     * @param string $alias The alias name (the part after "as", or the last
+     *     part of the Fully Qualified Namespace Name) to add.
+     * @param string $fqnn  The Fully Qualified Namespace Name for this alias.
+     *     Any form of leading/trailing slashes are accepted, but what will be
+     *     stored is a name, prefixed with a slash, and no trailing slash.
+     * 
+     * @return $this
+     */
+    public function setNamespaceAlias($alias, $fqnn)
+    {
+        $this->namespace_aliases[$alias] = '\\' . trim((string)$fqnn, '\\');
+        return $this;
+    }
+    
+    /**
+     * Sets a new Local Structural Element Name.
+     * 
+     * Sets a new Local Structural Element Name. A local name also contains
+     * punctuation determining the kind of structural element (e.g. trailing "("
+     * and ")" for functions and methods).
+     * 
+     * @param string $lsen The new local name of a structural element.
+     * 
+     * @return $this
+     */
+    public function setLSEN($lsen)
+    {
+        $this->lsen = (string)$lsen;
+        return $this;
+    }
+}

--- a/src/phpDocumentor/Reflection/DocBlock/Location.php
+++ b/src/phpDocumentor/Reflection/DocBlock/Location.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * phpDocumentor
+ *
+ * PHP Version 5.3
+ *
+ * @author    Vasil Rangelov <boen.robot@gmail.com>
+ * @copyright 2010-2011 Mike van Riel / Naenius (http://www.naenius.com)
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\DocBlock;
+
+/**
+ * The location a DocBlock occurs within a file.
+ *
+ * @author  Vasil Rangelov <boen.robot@gmail.com>
+ * @license http://www.opensource.org/licenses/mit-license.php MIT
+ * @link    http://phpdoc.org
+ */
+class Location
+{
+    /** @var int Line where the DocBlock text starts. */
+    protected $line_number = 0;
+
+    /** @var int Column where the DocBlock text starts. */
+    protected $column_number = 0;
+    
+    public function __construct(
+        $line_number = 0,
+        $column_number = 0
+    ) {
+        $this->line_number = (int)$line_number;
+        $this->column_number = (int)$column_number;
+    }
+
+    /**
+     * @return int Line where the DocBlock text starts.
+     */
+    public function getLineNumber()
+    {
+        return $this->line_number;
+    }
+
+    /**
+     * @return int Column where the DocBlock text starts.
+     */
+    public function getColumnNumber()
+    {
+        return $this->column_number;
+    }
+}

--- a/src/phpDocumentor/Reflection/DocBlock/Tag.php
+++ b/src/phpDocumentor/Reflection/DocBlock/Tag.php
@@ -35,8 +35,8 @@ class Tag implements \Reflector
     /** @var array The description, as an array of strings and Tag objects. */
     protected $parsedDescription = null;
 
-    /** @var int Line number of the tag */
-    protected $line_number = 0;
+    /** @var Location Location of the tag. */
+    protected $location = null;
 
     /** @var DocBlock The DocBlock which this tag belongs to. */
     protected $docblock = null;
@@ -92,6 +92,7 @@ class Tag implements \Reflector
      *
      * @param string   $tag_line The text for this tag, including description.
      * @param DocBlock $docblock The DocBlock which this tag belongs to.
+     * @param Location $location Location of the tag.
      *
      * @throws \InvalidArgumentException if an invalid tag line was presented.
      *
@@ -99,7 +100,8 @@ class Tag implements \Reflector
      */
     final public static function createInstance(
         $tag_line,
-        DocBlock $docblock = null
+        DocBlock $docblock = null,
+        Location $location = null
     ) {
         if (!preg_match(
             '/^@([\w\-\_\\\\]+)(?:\s*([^\s].*)|$)?/us',
@@ -116,13 +118,15 @@ class Tag implements \Reflector
             return new $handler(
                 $matches[1],
                 isset($matches[2]) ? $matches[2] : '',
-                $docblock
+                $docblock,
+                $location
             );
         }
         return new self(
             $matches[1],
             isset($matches[2]) ? $matches[2] : '',
-            $docblock
+            $docblock,
+            $location
         );
     }
 
@@ -164,13 +168,19 @@ class Tag implements \Reflector
      * @param string   $type     Name of the tag.
      * @param string   $content  The contents of the given tag.
      * @param DocBlock $docblock The DocBlock which this tag belongs to.
+     * @param Location $location Location of the tag.
      */
-    public function __construct($type, $content, DocBlock $docblock = null)
-    {
-        $this->tag = $type;
-        $this->content = $content;
+    public function __construct(
+        $type,
+        $content,
+        DocBlock $docblock = null,
+        Location $location = null
+    ) {
+        $this->tag         = $type;
+        $this->content     = $content;
         $this->description = trim($content);
-        $this->docblock = $docblock;
+        $this->docblock    = $docblock;
+        $this->location    = $location;
     }
 
     /**
@@ -219,25 +229,13 @@ class Tag implements \Reflector
     }
 
     /**
-     * Set the tag line number
+     * Get the location of the tag.
      *
-     * @param int $number the line number of the tag
-     *
-     * @return void
+     * @return Location Tag's location.
      */
-    public function setLineNumber($number)
+    public function getLocation()
     {
-        $this->line_number = (int)$number;
-    }
-
-    /**
-     * Get the line number of the tag
-     *
-     * @return int tag line number
-     */
-    public function getLineNumber()
-    {
-        return $this->line_number;
+        return $this->location;
     }
 
     /**

--- a/src/phpDocumentor/Reflection/DocBlock/Tag/AuthorTag.php
+++ b/src/phpDocumentor/Reflection/DocBlock/Tag/AuthorTag.php
@@ -36,10 +36,15 @@ class AuthorTag extends Tag
      * @param string   $type     Tag identifier for this tag (should be 'author').
      * @param string   $content  Contents for this tag.
      * @param DocBlock $docblock The DocBlock which this tag belongs to.
+     * @param Location $location Location of the tag.
      */
-    public function __construct($type, $content, DocBlock $docblock = null)
-    {
-        parent::__construct($type, $content, $docblock);
+    public function __construct(
+        $type,
+        $content,
+        DocBlock $docblock = null,
+        Location $location = null
+    ) {
+        parent::__construct($type, $content, $docblock, $location);
         if (preg_match(
             '/^([^\<]*)(\<([^\>]*)\>)?$/',
             $this->description,

--- a/src/phpDocumentor/Reflection/DocBlock/Tag/ExampleTag.php
+++ b/src/phpDocumentor/Reflection/DocBlock/Tag/ExampleTag.php
@@ -33,10 +33,15 @@ class ExampleTag extends SourceTag
      * @param string   $type     Tag identifier for this tag (should be 'example').
      * @param string   $content  Contents for this tag.
      * @param DocBlock $docblock The DocBlock which this tag belongs to.
+     * @param Location $location Location of the tag.
      */
-    public function __construct($type, $content, DocBlock $docblock = null)
-    {
-        Tag::__construct($type, $content, $docblock);
+    public function __construct(
+        $type,
+        $content,
+        DocBlock $docblock = null,
+        Location $location = null
+    ) {
+        Tag::__construct($type, $content, $docblock, $location);
         if (preg_match(
             '/^(?:\"([^\"]+)\"|(\S+))(?:\s+(.*))?$/su',
             $this->description,

--- a/src/phpDocumentor/Reflection/DocBlock/Tag/LinkTag.php
+++ b/src/phpDocumentor/Reflection/DocBlock/Tag/LinkTag.php
@@ -33,10 +33,15 @@ class LinkTag extends Tag
      * @param string   $type     Tag identifier for this tag (should be 'link').
      * @param string   $content  Contents for this tag.
      * @param DocBlock $docblock The DocBlock which this tag belongs to.
+     * @param Location $location Location of the tag.
      */
-    public function __construct($type, $content, DocBlock $docblock = null)
-    {
-        parent::__construct($type, $content, $docblock);
+    public function __construct(
+        $type,
+        $content,
+        DocBlock $docblock = null,
+        Location $location = null
+    ) {
+        parent::__construct($type, $content, $docblock, $location);
         $pieces = explode(' ', $this->description);
 
         if (count($pieces) > 1) {

--- a/src/phpDocumentor/Reflection/DocBlock/Tag/MethodTag.php
+++ b/src/phpDocumentor/Reflection/DocBlock/Tag/MethodTag.php
@@ -37,10 +37,15 @@ class MethodTag extends ReturnTag
      * @param string   $type     Tag identifier for this tag (should be 'method').
      * @param string   $content  Contents for this tag.
      * @param DocBlock $docblock The DocBlock which this tag belongs to.
+     * @param Location $location Location of the tag.
      */
-    public function __construct($type, $content, DocBlock $docblock = null)
-    {
-        Tag::__construct($type, $content, $docblock);
+    public function __construct(
+        $type,
+        $content,
+        DocBlock $docblock = null,
+        Location $location = null
+    ) {
+        Tag::__construct($type, $content, $docblock, $location);
 
         $matches = array();
         // 1. none or more whitespace

--- a/src/phpDocumentor/Reflection/DocBlock/Tag/ParamTag.php
+++ b/src/phpDocumentor/Reflection/DocBlock/Tag/ParamTag.php
@@ -35,10 +35,15 @@ class ParamTag extends ReturnTag
      * @param string   $type     Tag identifier for this tag (should be 'param').
      * @param string   $content  Contents for this tag.
      * @param DocBlock $docblock The DocBlock which this tag belongs to.
+     * @param Location $location Location of the tag.
      */
-    public function __construct($type, $content, DocBlock $docblock = null)
-    {
-        Tag::__construct($type, $content, $docblock);
+    public function __construct(
+        $type,
+        $content,
+        DocBlock $docblock = null,
+        Location $location = null
+    ) {
+        Tag::__construct($type, $content, $docblock, $location);
         $content = preg_split(
             '/(\s+)/u',
             $this->description,

--- a/src/phpDocumentor/Reflection/DocBlock/Tag/ReturnTag.php
+++ b/src/phpDocumentor/Reflection/DocBlock/Tag/ReturnTag.php
@@ -37,10 +37,15 @@ class ReturnTag extends Tag
      * @param string   $type     Tag identifier for this tag (should be 'return').
      * @param string   $content  Contents for this tag.
      * @param DocBlock $docblock The DocBlock which this tag belongs to.
+     * @param Location $location Location of the tag.
      */
-    public function __construct($type, $content, DocBlock $docblock = null)
-    {
-        parent::__construct($type, $content, $docblock);
+    public function __construct(
+        $type,
+        $content,
+        DocBlock $docblock = null,
+        Location $location = null
+    ) {
+        parent::__construct($type, $content, $docblock, $location);
         $content = preg_split('/\s+/u', $this->description, 2);
 
         // any output is considered a type
@@ -70,7 +75,7 @@ class ReturnTag extends Tag
         $this->refreshTypes();
         return (string) $this->types;
     }
-    
+
     /**
      * Parses the type, if needed.
      * 
@@ -81,8 +86,7 @@ class ReturnTag extends Tag
         if (null === $this->types) {
             $this->types = new Collection(
                 array($this->type),
-                $this->docblock ? $this->docblock->getNamespace() : null,
-                $this->docblock ? $this->docblock->getNamespaceAliases() : array()
+                $this->docblock ? $this->docblock->getContext() : null
             );
         }
     }

--- a/src/phpDocumentor/Reflection/DocBlock/Tag/SeeTag.php
+++ b/src/phpDocumentor/Reflection/DocBlock/Tag/SeeTag.php
@@ -33,10 +33,15 @@ class SeeTag extends Tag
      * @param string   $type     Tag identifier for this tag (should be 'see').
      * @param string   $content  Contents for this tag.
      * @param DocBlock $docblock The DocBlock which this tag belongs to.
+     * @param Location $location Location of the tag.
      */
-    public function __construct($type, $content, DocBlock $docblock = null)
-    {
-        parent::__construct($type, $content, $docblock);
+    public function __construct(
+        $type,
+        $content,
+        DocBlock $docblock = null,
+        Location $location = null
+    ) {
+        parent::__construct($type, $content, $docblock, $location);
         $content = preg_split('/\s+/u', $content);
 
         // any output is considered a type

--- a/src/phpDocumentor/Reflection/DocBlock/Tag/SourceTag.php
+++ b/src/phpDocumentor/Reflection/DocBlock/Tag/SourceTag.php
@@ -41,10 +41,15 @@ class SourceTag extends Tag
      * @param string   $type     Tag identifier for this tag (should be 'source').
      * @param string   $content  Contents for this tag.
      * @param DocBlock $docblock The DocBlock which this tag belongs to.
+     * @param Location $location Location of the tag.
      */
-    public function __construct($type, $content, DocBlock $docblock = null)
-    {
-        parent::__construct($type, $content, $docblock);
+    public function __construct(
+        $type,
+        $content,
+        DocBlock $docblock = null,
+        Location $location = null
+    ) {
+        parent::__construct($type, $content, $docblock, $location);
         if (preg_match(
             '/^([1-9]\d*)\s*(?:([1-9]\d*)\s+)?(.*)$/su',
             $this->description,

--- a/src/phpDocumentor/Reflection/DocBlock/Tag/VarTag.php
+++ b/src/phpDocumentor/Reflection/DocBlock/Tag/VarTag.php
@@ -30,10 +30,15 @@ class VarTag extends ParamTag
      * @param string   $type     Tag identifier for this tag (should be 'var').
      * @param string   $content  Contents for this tag.
      * @param DocBlock $docblock The DocBlock which this tag belongs to.
+     * @param Location $location Location of the tag.
      */
-    public function __construct($type, $content, DocBlock $docblock = null)
-    {
-        Tag::__construct($type, $content, $docblock);
+    public function __construct(
+        $type,
+        $content,
+        DocBlock $docblock = null,
+        Location $location = null
+    ) {
+        Tag::__construct($type, $content, $docblock, $location);
         $content = preg_split('/\s+/u', $this->description);
 
         if (count($content) == 0) {

--- a/src/phpDocumentor/Reflection/DocBlock/Tag/VersionTag.php
+++ b/src/phpDocumentor/Reflection/DocBlock/Tag/VersionTag.php
@@ -33,10 +33,15 @@ class VersionTag extends Tag
      * @param string   $type     Tag identifier for this tag (should be 'version').
      * @param string   $content  Contents for this tag.
      * @param DocBlock $docblock The DocBlock which this tag belongs to.
+     * @param Location $location Location of the tag.
      */
-    public function __construct($type, $content, DocBlock $docblock = null)
-    {
-        parent::__construct($type, $content, $docblock);
+    public function __construct(
+        $type,
+        $content,
+        DocBlock $docblock = null,
+        Location $location = null
+    ) {
+        parent::__construct($type, $content, $docblock, $location);
 
         if (preg_match(
             '/^

--- a/tests/phpDocumentor/Reflection/DocBlock/Type/CollectionTest.php
+++ b/tests/phpDocumentor/Reflection/DocBlock/Type/CollectionTest.php
@@ -12,6 +12,8 @@
 
 namespace phpDocumentor\Reflection\DocBlock\Type;
 
+use phpDocumentor\Reflection\DocBlock\Context;
+
 /**
  * Test class for \phpDocumentor\Reflection\DocBlock\Type\Collection
  * 
@@ -26,8 +28,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @covers phpDocumentor\Reflection\DocBlock\Type\Collection::__construct
-     * @covers phpDocumentor\Reflection\DocBlock\Type\Collection::getNamespace
-     * @covers phpDocumentor\Reflection\DocBlock\Type\Collection::getNamespaceAliases
+     * @covers phpDocumentor\Reflection\DocBlock\Type\Collection::getContext
      * 
      * @return void
      */
@@ -35,25 +36,8 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     {
         $collection = new Collection();
         $this->assertCount(0, $collection);
-        $this->assertEquals('\\', $collection->getNamespace());
-        $this->assertCount(0, $collection->getNamespaceAliases());
-    }
-
-    /**
-     * @covers phpDocumentor\Reflection\DocBlock\Type\Collection::__construct
-     * @covers phpDocumentor\Reflection\DocBlock\Type\Collection::setNamespace
-     * @covers phpDocumentor\Reflection\DocBlock\Type\Collection::getNamespace
-     * @covers phpDocumentor\Reflection\DocBlock\Type\Collection::getNamespaceAliases
-     * 
-     * @return void
-     */
-    public function testGlobalIgnore()
-    {
-        $collection = new Collection();
-        $collection->setNamespace('global');
-        $this->assertCount(0, $collection);
-        $this->assertEquals('\\', $collection->getNamespace());
-        $this->assertCount(0, $collection->getNamespaceAliases());
+        $this->assertEquals('', $collection->getContext()->getNamespace());
+        $this->assertCount(0, $collection->getContext()->getNamespaceAliases());
     }
 
     /**
@@ -69,69 +53,34 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers phpDocumentor\Reflection\DocBlock\Type\Collection::__construct
-     * @covers phpDocumentor\Reflection\DocBlock\Type\Collection::getNamespace
      * 
      * @return void
      */
     public function testConstructWithNamespace()
     {
-        $collection = new Collection(array(), '\My\Space');
-        $this->assertEquals('\My\Space\\', $collection->getNamespace());
+        $collection = new Collection(array(), new Context('\My\Space'));
+        $this->assertEquals('My\Space', $collection->getContext()->getNamespace());
 
-        $collection = new Collection(array(), 'My\Space');
-        $this->assertEquals('\My\Space\\', $collection->getNamespace());
+        $collection = new Collection(array(), new Context('My\Space'));
+        $this->assertEquals('My\Space', $collection->getContext()->getNamespace());
 
         $collection = new Collection(array(), null);
-        $this->assertEquals('\\', $collection->getNamespace());
+        $this->assertEquals('', $collection->getContext()->getNamespace());
     }
 
     /**
      * @covers phpDocumentor\Reflection\DocBlock\Type\Collection::__construct
-     * @covers phpDocumentor\Reflection\DocBlock\Type\Collection::getNamespaceAliases
      * 
      * @return void
      */
     public function testConstructWithNamespaceAliases()
     {
         $fixture = array('a' => 'b');
-        $collection = new Collection(array(), null, $fixture);
-        $this->assertEquals($fixture, $collection->getNamespaceAliases());
-    }
-
-    /**
-     * @covers phpDocumentor\Reflection\DocBlock\Type\Collection::setNamespace
-     * @covers phpDocumentor\Reflection\DocBlock\Type\Collection::getNamespace
-     * 
-     * @return void
-     */
-    public function testSetAndGetNamespace()
-    {
-        $collection = new Collection();
-        $this->assertEquals('\\', $collection->getNamespace());
-
-        $collection->setNamespace('My');
-        $this->assertEquals('\My\\', $collection->getNamespace());
-
-        $collection->setNamespace('\My');
-        $this->assertEquals('\My\\', $collection->getNamespace());
-
-        $collection->setNamespace('\My\\');
-        $this->assertEquals('\My\\', $collection->getNamespace());
-    }
-
-    /**
-     * @covers phpDocumentor\Reflection\DocBlock\Type\Collection::setNamespaceAliases
-     * @covers phpDocumentor\Reflection\DocBlock\Type\Collection::getNamespaceAliases
-     * 
-     * @return void
-     */
-    public function testSetAndGetNamespaceAliases()
-    {
-        $collection = new Collection();
-        $this->assertEmpty($collection->getNamespaceAliases());
-
-        $collection->setNamespaceAliases(array('My'));
-        $this->assertEquals(array('My'), $collection->getNamespaceAliases());
+        $collection = new Collection(array(), new Context(null, $fixture));
+        $this->assertEquals(
+            array('a' => '\b'),
+            $collection->getContext()->getNamespaceAliases()
+        );
     }
 
     /**
@@ -145,9 +94,10 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testAdd($fixture, $expected)
     {
-        $collection = new Collection();
-        $collection->setNamespace('\My\Space');
-        $collection->setNamespaceAliases(array('Alias' => '\My\Space\Aliasing'));
+        $collection = new Collection(
+            array(),
+            new Context('\My\Space', array('Alias' => '\My\Space\Aliasing'))
+        );
         $collection->add($fixture);
 
         $this->assertSame($expected, $collection->getArrayCopy());
@@ -164,8 +114,10 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testAddWithoutNamespace($fixture, $expected)
     {
-        $collection = new Collection();
-        $collection->setNamespaceAliases(array('Alias' => '\My\Space\Aliasing'));
+        $collection = new Collection(
+            array(),
+            new Context(null, array('Alias' => '\My\Space\Aliasing'))
+        );
         $collection->add($fixture);
 
         $this->assertSame($expected, $collection->getArrayCopy());

--- a/tests/phpDocumentor/Reflection/DocBlockTest.php
+++ b/tests/phpDocumentor/Reflection/DocBlockTest.php
@@ -12,6 +12,8 @@
 
 namespace phpDocumentor\Reflection;
 
+use phpDocumentor\Reflection\DocBlock\Context;
+
 /**
  * Test class for phpDocumentor\Reflection\DocBlock
  *
@@ -36,8 +38,7 @@ class DocBlockTest extends \PHPUnit_Framework_TestCase
 DOCBLOCK;
         $object = new DocBlock(
             $fixture,
-            '\MyNamespace',
-            array('PHPDoc' => '\phpDocumentor')
+            new Context('\MyNamespace', array('PHPDoc' => '\phpDocumentor'))
         );
         $this->assertEquals(
             'This is a short description.',
@@ -52,10 +53,10 @@ DOCBLOCK;
         $this->assertTrue($object->hasTag('return'));
         $this->assertFalse($object->hasTag('category'));
         
-        $this->assertSame('\MyNamespace', $object->getNamespace());
+        $this->assertSame('MyNamespace', $object->getContext()->getNamespace());
         $this->assertSame(
             array('PHPDoc' => '\phpDocumentor'),
-            $object->getNamespaceAliases()
+            $object->getContext()->getNamespaceAliases()
         );
     }
 


### PR DESCRIPTION
This patch introduces a new class called "Location", used to hold <del>the namespace, namespace aliases, the structural elements' name,</del> line and column numbers of the doc block components, <ins>while another new class, called "Context", holds the namespace, namespace alias and the structural element's local name.</ins>

The idea was born as a potential solution to a problem mentioned in [a discussion at the mailing list](https://groups.google.com/forum/#!topic/phpdocumentor/cDcbyNk3g40), without needlessly over-growing DocBlock's constructor.

This requires changes in PhpDocumentor, which is why it's proposed as a PR.

(Note: The Unit tests pass, but there's still some work to be done on tests for Location itself; This here is just for the purpose of discussing the idea)

EDIT: On second thought, it might be wise to separate line and namespace information. I've amended the commit accordingly.
