### PR TITLE
Fix typo in "cotnent"

### DIFF
--- a/src/phpDocumentor/Reflection/DocBlock/Tag/ReturnTag.php
+++ b/src/phpDocumentor/Reflection/DocBlock/Tag/ReturnTag.php
@@ -33,13 +33,13 @@ class ReturnTag extends Tag
     /**
      * {@inheritdoc}
      */
-    public function getCotnent()
+    public function getContent()
     {
         if (null === $this->content) {
             $this->content = "{$this->type} {$this->description}";
         }
 
-        return $this->cotnent;
+        return $this->content;
     }
 
     /**


### PR DESCRIPTION
The ReturnTag class accidentally has "cotnent" instead of "content" in a couple of places.
