### PR TITLE
Markdown is not required, so move to suggest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,14 +6,16 @@
         {"name": "Mike van Riel", "email": "mike.vanriel@naenius.com"}
     ],
     "require": {
-        "php": ">=5.3.3",
-        "dflydev/markdown": "1.0.*"
+        "php": ">=5.3.3"
     },
     "autoload": {
         "psr-0": {"phpDocumentor": ["src/"]}
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*@stable"
+    },
+    "suggest": {
+        "dflydev/markdown": "1.0.*"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Markdown is only used once and a check is in place to see if the markdown classes exists. So perhaps it is better to move this to suggest instead of require, so the people who don't need it, don't have to download it.
