### PR TITLE
Preserve newlines in docblock tags

### DIFF
--- a/src/phpDocumentor/Reflection/DocBlock.php
+++ b/src/phpDocumentor/Reflection/DocBlock.php
@@ -209,20 +209,16 @@ class DocBlock implements \Reflector
                 );
             }
             foreach (explode("\n", $tags) as $tag_line) {
-                if (trim($tag_line) === '') {
-                    continue;
-                }
-
                 if (isset($tag_line[0]) && ($tag_line[0] === '@')) {
                     $result[] = $tag_line;
                 } else {
-                    $result[count($result) - 1] .= PHP_EOL . $tag_line;
+                    $result[count($result) - 1] .= "\n" . $tag_line;
                 }
             }
 
             // create proper Tag objects
             foreach ($result as $key => $tag_line) {
-                $result[$key] = Tag::createInstance($tag_line, $this);
+                $result[$key] = Tag::createInstance(trim($tag_line), $this);
             }
         }
 

--- a/tests/phpDocumentor/Reflection/DocBlockTest.php
+++ b/tests/phpDocumentor/Reflection/DocBlockTest.php
@@ -14,6 +14,7 @@ namespace phpDocumentor\Reflection;
 
 use phpDocumentor\Reflection\DocBlock\Context;
 use phpDocumentor\Reflection\DocBlock\Location;
+use phpDocumentor\Reflection\DocBlock\Tag\ReturnTag;
 
 /**
  * Test class for phpDocumentor\Reflection\DocBlock
@@ -272,7 +273,10 @@ DOCBLOCK;
  */
 DOCBLOCK;
         $object = new DocBlock($fixture);
-        $this->assertCount(1, $object->getTags());
+        $this->assertCount(1, $tags = $object->getTags());
+	    /** @var ReturnTag $tag */
+	    $tag = reset($tags);
+	    $this->assertEquals("Content on\n    multiple lines.\n\n    One more, after the break.", $tag->getDescription());
     }
 
     /**


### PR DESCRIPTION
This is especially important when using markdown.
Adding a blank line between text introduces a new paragraph.
Current implementation will result in all text staying in one paragraph
and also other elements like lists and code do not get recognized in
most cases.

There was already a test for multi line doc blocks but it does not verify correct ouput.
