### PR TITLE
Add support for DocBlock template markers

### DIFF
--- a/src/phpDocumentor/Reflection/DocBlock.php
+++ b/src/phpDocumentor/Reflection/DocBlock.php
@@ -303,6 +303,24 @@ class DocBlock implements \Reflector
     }
 
     /**
+     * Returns whether this DocBlock is the start of a Template section.
+     *
+     * A Docblock may serve as template for a series of subsequent DocBlocks. This is indicated by a special marker
+     * (`#@+`) that is appended directly after the opening `/**` of a DocBlock.
+     *
+     * An example of such an opening is:
+     *
+     * ```
+     * /**#@+
+     *  * My DocBlock
+     *  * /
+     * ```
+     *
+     * The description and tags (not the summary!) are copied onto all subsequent DocBlocks and also applied to all
+     * elements that follow until another DocBlock is found that contains the closing marker (`#@-`).
+     *
+     * @see self::isTemplateEnd() for the check whether a closing marker was provided.
+     *
      * @return boolean
      */
     public function isTemplateStart()
@@ -311,6 +329,10 @@ class DocBlock implements \Reflector
     }
 
     /**
+     * Returns whether this DocBlock is the end of a Template section.
+     *
+     * @see self::isTemplateStart() for a more complete description of the Docblock Template functionality.
+     *
      * @return boolean
      */
     public function isTemplateEnd()

--- a/tests/phpDocumentor/Reflection/DocBlockTest.php
+++ b/tests/phpDocumentor/Reflection/DocBlockTest.php
@@ -71,8 +71,7 @@ DOCBLOCK;
 
     /**
      * @covers \phpDocumentor\Reflection\DocBlock::splitDocBlock
-     * @group test
-     * 
+     *
      * @return void
      */
     public function testConstructWithTagsOnly()
@@ -92,6 +91,9 @@ DOCBLOCK;
         $this->assertFalse($object->hasTag('category'));
     }
 
+    /**
+     * @covers \phpDocumentor\Reflection\DocBlock::isTemplateStart
+     */
     public function testIfStartOfTemplateIsDiscovered()
     {
         $fixture = <<<DOCBLOCK
@@ -110,6 +112,9 @@ DOCBLOCK;
         $this->assertTrue($object->isTemplateStart());
     }
 
+    /**
+     * @covers \phpDocumentor\Reflection\DocBlock::isTemplateEnd
+     */
     public function testIfEndOfTemplateIsDiscovered()
     {
         $fixture = <<<DOCBLOCK


### PR DESCRIPTION
DocBlocks may start with #@+ and #@- to indicate that they are (the start) of a DocBlock
template or the end of a template.

In this commit I have changed the way a DocBlock is parsed to interpret this information
and added tests to show for it. In addition I have added more comments to the Regular
Expression responsible for splitting a DocBlock to show the business rules more clearly.

This is the first step in implementing https://github.com/phpDocumentor/phpDocumentor2/issues/42.
