### PR TITLE
Bump php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": ">=5.5.9",
         "phpdocumentor/reflection-common": "~1.0@dev"
     },
     "autoload": {


### PR DESCRIPTION
Would you consider bumping the version to 5.5.9+? This would make sense to me as it encourages people to use newer php versions and 5.5.9 is also the version of php that ubuntu 14.04 LTS ships with. Symfony 3.0 will be requiring 5.5.9+ and Laravel 5.1 released a few days ago requires 5.5.9 too rather than 5.5.0.