### PR TITLE
Allow only tags in Docblock argument

### DIFF
--- a/src/DocBlock.php
+++ b/src/DocBlock.php
@@ -61,6 +61,7 @@ final class DocBlock
         Assert::string($summary);
         Assert::boolean($isTemplateStart);
         Assert::boolean($isTemplateEnd);
+        Assert::allIsInstanceOf($tags, Tag::class);
 
         $this->summary = $summary;
         $this->description = $description ?: new DocBlock\Description('');

--- a/src/DocBlockFactory.php
+++ b/src/DocBlockFactory.php
@@ -14,6 +14,7 @@ namespace phpDocumentor\Reflection;
 
 use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
 use phpDocumentor\Reflection\DocBlock\StandardTagFactory;
+use phpDocumentor\Reflection\DocBlock\Tag;
 use phpDocumentor\Reflection\DocBlock\TagFactory;
 use phpDocumentor\Reflection\Types\Context;
 use Webmozart\Assert\Assert;
@@ -93,7 +94,9 @@ final class DocBlockFactory implements DocBlockFactoryInterface
         return new DocBlock(
             $summary,
             $description ? $this->descriptionFactory->create($description, $context) : null,
-            $this->parseTagBlock($tags, $context),
+            array_filter($this->parseTagBlock($tags, $context), function($tag) {
+                return $tag instanceof Tag;
+            }),
             $context,
             $location,
             $templateMarker === '#@+',

--- a/tests/unit/DocBlockFactoryTest.php
+++ b/tests/unit/DocBlockFactoryTest.php
@@ -239,6 +239,7 @@ DOCBLOCK
     /**
      * @covers ::__construct
      * @covers ::create
+     *
      * @uses   phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @uses   phpDocumentor\Reflection\DocBlock\Description
      * @uses   phpDocumentor\Reflection\Types\Context
@@ -246,11 +247,44 @@ DOCBLOCK
      */
     public function testTagsWithContextNamespace()
     {
-        $tagFactoryMock =  m::mock(TagFactory::class);
+        $tagFactoryMock = m::mock(TagFactory::class);
         $fixture = new DocBlockFactory(m::mock(DescriptionFactory::class), $tagFactoryMock);
         $context = new Context('MyNamespace');
 
         $tagFactoryMock->shouldReceive('create')->with(m::any(), $context)->andReturn(new Param('param'));
         $docblock = $fixture->create('/** @param MyType $param */', $context);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::create
+     *
+     * @uses phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses phpDocumentor\Reflection\DocBlock\Description
+     */
+    public function testTagsAreFilteredForNullValues()
+    {
+        $tagString = <<<TAG
+@author Mike van Riel <me@mikevanriel.com> This is with
+  multiline description.
+TAG;
+
+        $tagFactory = m::mock(TagFactory::class);
+        $tagFactory->shouldReceive('create')->with($tagString, m::any())->andReturn(null);
+
+        $fixture = new DocBlockFactory(new DescriptionFactory($tagFactory), $tagFactory);
+
+        $given = <<<DOCBLOCK
+/**
+ * This is a summary.
+ *
+ * @author Mike van Riel <me@mikevanriel.com> This is with
+ *   multiline description.
+ */
+DOCBLOCK;
+
+        $docblock = $fixture->create($given, new Context(''));
+
+        $this->assertEquals([], $docblock->getTags());
     }
 }

--- a/tests/unit/DocBlockTest.php
+++ b/tests/unit/DocBlockTest.php
@@ -102,6 +102,24 @@ class DocBlockTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers ::__construct
+     * @covers ::getTags
+     *
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\DocBlock\Tag
+     *
+     * @expectedException \InvalidArgumentException
+     */
+    public function testDocBlockAllowsOnlyTags()
+    {
+        $tags = [
+            null
+        ];
+
+        $fixture = new DocBlock('', null, $tags);
+    }
+
+    /**
+     * @covers ::__construct
      * @covers ::getTagsByName
      *
      * @uses \phpDocumentor\Reflection\DocBlock::getTags


### PR DESCRIPTION
The array of tags in the docblock constructor should only contain tags.
Some of the factory methods of the tags are returning a null when the tag could not be created.
This causes issues during parsing. By filtering these null values in the factory this use is resolved.