### PR TITLE
fix for bug #1672 in phpDocumentor2

### DIFF
--- a/src/phpDocumentor/Reflection/DocBlock/Type/Collection.php
+++ b/src/phpDocumentor/Reflection/DocBlock/Type/Collection.php
@@ -161,12 +161,19 @@ class Collection extends \ArrayObject
             $namespace_aliases = $this->context->getNamespaceAliases();
             // if the first segment is not an alias; prepend namespace name and
             // return
-            if (!isset($namespace_aliases[$type_parts[0]])) {
+            if (!isset($namespace_aliases[$type_parts[0]]) &&
+                !isset($namespace_aliases[strstr($type_parts[0], '::', true)])) {
                 $namespace = $this->context->getNamespace();
                 if ('' !== $namespace) {
                     $namespace .= self::OPERATOR_NAMESPACE;
                 }
                 return self::OPERATOR_NAMESPACE . $namespace . $type;
+            }
+
+            if (strpos($type_parts[0], '::')) {
+                $type_parts[] = strstr($type_parts[0], '::');
+                $type_parts[0] = $namespace_aliases[strstr($type_parts[0], '::', true)];
+                return implode('', $type_parts);
             }
 
             $type_parts[0] = $namespace_aliases[$type_parts[0]];

--- a/tests/phpDocumentor/Reflection/DocBlock/Type/CollectionTest.php
+++ b/tests/phpDocumentor/Reflection/DocBlock/Type/CollectionTest.php
@@ -124,6 +124,26 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @param string $fixture
+     * @param array  $expected
+     *
+     * @dataProvider provideTypesToExpandWithPropertyOrMethod
+     * @covers phpDocumentor\Reflection\DocBlock\Type\Collection::add
+     *
+     * @return void
+     */
+    public function testAddMethodsAndProperties($fixture, $expected)
+    {
+        $collection = new Collection(
+            array(),
+            new Context(null, array('LinkDescriptor' => '\phpDocumentor\LinkDescriptor'))
+        );
+        $collection->add($fixture);
+
+        $this->assertSame($expected, $collection->getArrayCopy());
+    }
+
+    /**
      * @covers phpDocumentor\Reflection\DocBlock\Type\Collection::add
      * @expectedException InvalidArgumentException
      * 
@@ -177,6 +197,14 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
                 'DocBlock[]|int[]',
                 array($namespace.'DocBlock[]', 'int[]')
             ),
+            array(
+                'LinkDescriptor::setLink()',
+                array($namespace.'LinkDescriptor::setLink()')
+            ),
+            array(
+                'Alias\LinkDescriptor::setLink()',
+                array('\My\Space\Aliasing\LinkDescriptor::setLink()')
+            ),
         );
     }
 
@@ -191,5 +219,35 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     public function provideTypesToExpandWithoutNamespace($method)
     {
         return $this->provideTypesToExpand($method, '\\');
+    }
+
+    /**
+     * Returns the method and property types and their expected values to test
+     * the retrieval of types.
+     *
+     * @param string $method Name of the method consuming this data provider.
+     *
+     * @return string[]
+     */
+    public function provideTypesToExpandWithPropertyOrMethod($method)
+    {
+        return array(
+            array(
+                'LinkDescriptor::setLink()',
+                array('\phpDocumentor\LinkDescriptor::setLink()')
+            ),
+            array(
+                'phpDocumentor\LinkDescriptor::setLink()',
+                array('\phpDocumentor\LinkDescriptor::setLink()')
+            ),
+            array(
+                'LinkDescriptor::$link',
+                array('\phpDocumentor\LinkDescriptor::$link')
+            ),
+            array(
+                'phpDocumentor\LinkDescriptor::$link',
+                array('\phpDocumentor\LinkDescriptor::$link')
+            ),
+        );
     }
 }


### PR DESCRIPTION
When dealing with inline @see or @link tags and having a relative method or property type
like LinkDescriptor::setLink() and a namespace alias like phpDocumentor\Descriptor\Tag\LinkDescriptor
Collection::expand() was checking if LinkDescriptor::setLink() could be found in the namespace aliases.
This would never be true.
In this fix, the method or type (for instance ::setLink()) part is removed for comparison
and later re-added when generating the full name