### PR TITLE
Add mandatory description element to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name":    "phpdocumentor/reflection-docblock",
+    "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
     "type":    "library",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
composer validate gives the following warning: 

````
phpdocumentor/reflection-docblock is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
description : The property description is required
````