### PR TITLE
Fix method name is empty when parenthesis is missing in @method

### DIFF
--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -101,7 +101,9 @@ final class Method extends BaseTag implements Factory\StaticMethod
                 # Method name
                 ([\w\|_\\\\]+)
                 # Arguments
-                \(([^\)]*)\)
+                (?:
+                    \(([^\)]*)\)
+                )?
                 \s*
                 # Description
                 (.*)
@@ -118,21 +120,25 @@ final class Method extends BaseTag implements Factory\StaticMethod
         $returnType  = $typeResolver->resolve($returnType, $context);
         $description = $descriptionFactory->create($description, $context);
 
-        $arguments = explode(',', $arguments);
-        foreach($arguments as &$argument) {
-            $argument = explode(' ', trim($argument));
-            if ($argument[0][0] === '$') {
-                $argumentName = substr($argument[0], 1);
-                $argumentType = new Void();
-            } else {
-                $argumentType = $typeResolver->resolve($argument[0], $context);
-                $argumentName = '';
-                if (isset($argument[1])) {
-                    $argumentName = substr($argument[1], 1);
+        if ('' !== $arguments) {
+            $arguments = explode(',', $arguments);
+            foreach($arguments as &$argument) {
+                $argument = explode(' ', trim($argument));
+                if ($argument[0][0] === '$') {
+                    $argumentName = substr($argument[0], 1);
+                    $argumentType = new Void();
+                } else {
+                    $argumentType = $typeResolver->resolve($argument[0], $context);
+                    $argumentName = '';
+                    if (isset($argument[1])) {
+                        $argumentName = substr($argument[1], 1);
+                    }
                 }
-            }
 
-            $argument = [ 'name' => $argumentName, 'type' => $argumentType];
+                $argument = [ 'name' => $argumentName, 'type' => $argumentType];
+            }
+        } else {
+            $arguments = [];
         }
 
         return new static($methodName, $arguments, $returnType, $static, $description);

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -328,4 +328,37 @@ class MethodTest extends \PHPUnit_Framework_TestCase
     {
         new Method('body', [ [ 'name' => 'myName', 'unknown' => 'nah' ] ]);
     }
+
+    /**
+     * @covers ::create
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Method::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\TypeResolver
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Fqsen
+     * @uses \phpDocumentor\Reflection\Types\Context
+     */
+    public function testCreateMethodParenthesisMissing()
+    {
+        $descriptionFactory = m::mock(DescriptionFactory::class);
+        $resolver           = new TypeResolver();
+        $context            = new Context('');
+
+        $description  = new Description('My Description');
+
+        $descriptionFactory->shouldReceive('create')->with('My Description', $context)->andReturn($description);
+
+        $fixture = Method::create(
+            'static void myMethod My Description',
+            $resolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertSame('static void myMethod() My Description', (string)$fixture);
+        $this->assertSame('myMethod', $fixture->getMethodName());
+        $this->assertEquals([], $fixture->getArguments());
+        $this->assertInstanceOf(Void::class, $fixture->getReturnType());
+        $this->assertSame($description, $fixture->getDescription());
+    }
 }


### PR DESCRIPTION
Fix method name is empty when parenthesis is missing in @method