### PR TITLE
Allow typed arrays in @method annotation.

### DIFF
--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -91,7 +91,11 @@ final class Method extends BaseTag implements Factory\StaticMethod
                 )?
                 # Return type
                 (?:
-                    ([\w\|_\\\\]+)
+                    (
+                        (?:[\w\|_\\\\]+)
+                        # array notation           
+                        (?:\[\])*
+                    )?
                     \s+
                 )?
                 # Legacy method name (not captured)


### PR DESCRIPTION
Since the type resolver has support for typed arrays,
I allowed the syntax for the @method annotation.

In effect you can now annotate magic methods like:
    @method Object[] myMethod($arg1, $arg2)
    @method int[] myOtherMethod()