### PR TITLE
Feature/php71 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,13 @@ php:
   - 5.6
   - 7.0
   - hhvm
+  - nightly
 
 matrix:
   allow_failures:
-    - php: hhvm
+    - php:
+        - hhvm
+        - nightly
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.5",
         "phpdocumentor/reflection-common": "^1.0@dev",
-        "phpdocumentor/type-resolver": "^0.1.5",
+        "phpdocumentor/type-resolver": "^0.2.0",
         "webmozart/assert": "^1.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bb0e430e32d40dd98ae89d0744edf864",
-    "content-hash": "a97035b9599fe2a0c23169d91b7b1936",
+    "hash": "9dfabded4193c3fd2ec85874de3b2e3c",
+    "content-hash": "69f6ae6608b8524fa04ddb0264bbf091",
     "packages": [
         {
             "name": "phpdocumentor/reflection-common",
@@ -17,7 +17,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/9969bd1c9661a73fdab104df7dbf132639d5c4d8",
                 "reference": "9969bd1c9661a73fdab104df7dbf132639d5c4d8",
                 "shasum": ""
             },
@@ -63,25 +63,25 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.1.5",
+            "version": "0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "83e31258fb03b9a27884a83b81501cb4cb297a81"
+                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/83e31258fb03b9a27884a83b81501cb4cb297a81",
-                "reference": "83e31258fb03b9a27884a83b81501cb4cb297a81",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0@dev"
+                "phpdocumentor/reflection-common": "^1.0"
             },
             "require-dev": {
                 "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.6"
+                "phpunit/phpunit": "^5.2||^4.8.24"
             },
             "type": "library",
             "extra": {
@@ -106,7 +106,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2015-07-18 13:58:32"
+            "time": "2016-06-10 07:14:17"
         },
         {
             "name": "webmozart/assert",
@@ -294,7 +294,7 @@
             ],
             "authors": [
                 {
-                    "name": "Padraic Brady",
+                    "name": "Pádraic Brady",
                     "email": "padraic.brady@gmail.com",
                     "homepage": "http://blog.astrumfutura.com"
                 },

--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -17,7 +17,7 @@ use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
-use phpDocumentor\Reflection\Types\Void;
+use phpDocumentor\Reflection\Types\Void_;
 use Webmozart\Assert\Assert;
 
 /**
@@ -50,7 +50,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
         Assert::boolean($static);
 
         if ($returnType === null) {
-            $returnType = new Void();
+            $returnType = new Void_();
         }
 
         $this->methodName  = $methodName;
@@ -130,7 +130,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
                 $argument = explode(' ', trim($argument));
                 if ($argument[0][0] === '$') {
                     $argumentName = substr($argument[0], 1);
-                    $argumentType = new Void();
+                    $argumentType = new Void_();
                 } else {
                     $argumentType = $typeResolver->resolve($argument[0], $context);
                     $argumentName = '';
@@ -205,7 +205,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
                 $argument = [ 'name' => $argument ];
             }
             if (! isset($argument['type'])) {
-                $argument['type'] = new Void();
+                $argument['type'] = new Void_();
             }
             $keys = array_keys($argument);
             if ($keys !== [ 'name', 'type' ]) {

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -22,7 +22,7 @@ use phpDocumentor\Reflection\Types\Context;
 use phpDocumentor\Reflection\Types\Integer;
 use phpDocumentor\Reflection\Types\Object_;
 use phpDocumentor\Reflection\Types\String_;
-use phpDocumentor\Reflection\Types\Void;
+use phpDocumentor\Reflection\Types\Void_;
 
 /**
  * @coversDefaultClass \phpDocumentor\Reflection\DocBlock\Tags\Method
@@ -56,7 +56,7 @@ class MethodTest extends \PHPUnit_Framework_TestCase
             ['name' => 'argument1', 'type' => new String_()],
             ['name' => 'argument2', 'type' => new Object_()]
         ];
-        $fixture = new Method('myMethod', $arguments, new Void(), true, new Description('My Description'));
+        $fixture = new Method('myMethod', $arguments, new Void_(), true, new Description('My Description'));
 
         $this->assertSame(
             '@method static void myMethod(string $argument1, object $argument2) My Description',
@@ -115,7 +115,7 @@ class MethodTest extends \PHPUnit_Framework_TestCase
     {
         $arguments = ['argument1'];
         $expected = [
-            [ 'name' => $arguments[0], 'type' => new Void() ]
+            [ 'name' => $arguments[0], 'type' => new Void_() ]
         ];
 
         $fixture = new Method('myMethod', $arguments);
@@ -131,7 +131,7 @@ class MethodTest extends \PHPUnit_Framework_TestCase
     {
         $arguments = [ [ 'name' => 'argument1' ] ];
         $expected = [
-            [ 'name' => $arguments[0]['name'], 'type' => new Void() ]
+            [ 'name' => $arguments[0]['name'], 'type' => new Void_() ]
         ];
 
         $fixture = new Method('myMethod', $arguments);
@@ -160,7 +160,7 @@ class MethodTest extends \PHPUnit_Framework_TestCase
     {
         $fixture = new Method('myMethod', []);
 
-        $this->assertEquals(new Void(), $fixture->getReturnType());
+        $this->assertEquals(new Void_(), $fixture->getReturnType());
     }
 
     /**
@@ -204,7 +204,7 @@ class MethodTest extends \PHPUnit_Framework_TestCase
             ['name' => 'argument1', 'type' => new String_()],
             ['name' => 'argument2', 'type' => new Object_()]
         ];
-        $fixture = new Method('myMethod', $arguments, new Void(), true, new Description('My Description'));
+        $fixture = new Method('myMethod', $arguments, new Void_(), true, new Description('My Description'));
 
         $this->assertSame(
             'static void myMethod(string $argument1, object $argument2) My Description',
@@ -230,7 +230,7 @@ class MethodTest extends \PHPUnit_Framework_TestCase
         $description  = new Description('My Description');
         $expectedArguments = [
             [ 'name' => 'argument1', 'type' => new String_() ],
-            [ 'name' => 'argument2', 'type' => new Void() ]
+            [ 'name' => 'argument2', 'type' => new Void_() ]
         ];
 
         $descriptionFactory->shouldReceive('create')->with('My Description', $context)->andReturn($description);
@@ -245,7 +245,7 @@ class MethodTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('static void myMethod(string $argument1, void $argument2) My Description', (string)$fixture);
         $this->assertSame('myMethod', $fixture->getMethodName());
         $this->assertEquals($expectedArguments, $fixture->getArguments());
-        $this->assertInstanceOf(Void::class, $fixture->getReturnType());
+        $this->assertInstanceOf(Void_::class, $fixture->getReturnType());
         $this->assertSame($description, $fixture->getDescription());
     }
 
@@ -404,7 +404,7 @@ class MethodTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('static void myMethod() My Description', (string)$fixture);
         $this->assertSame('myMethod', $fixture->getMethodName());
         $this->assertEquals([], $fixture->getArguments());
-        $this->assertInstanceOf(Void::class, $fixture->getReturnType());
+        $this->assertInstanceOf(Void_::class, $fixture->getReturnType());
         $this->assertSame($description, $fixture->getDescription());
     }
 }


### PR DESCRIPTION
Renaming Void to Void_ since void is a reserved keyword in PHP7.1.

```
Running the unit tests with php nightly exposed the bug:

Fatal error: Cannot use phpDocumentor\Reflection\Types\Void as Void
because 'Void' is a special class name in
/home/travis/build/hboomsma/ReflectionDocBlock/tests/unit/DocBlock/Tags/MethodTest.php
on line 25
```

This PR is needed after phpDocumentor/TypeResolver#18 gets merged. I'll will update the composer.json
with the right version when needed. The build for this PR will obviously fail until then.