### PR TITLE
Fix missing Example::__toString method

### DIFF
--- a/src/DocBlock/Tags/Example.php
+++ b/src/DocBlock/Tags/Example.php
@@ -135,6 +135,16 @@ final class Example extends BaseTag
     }
 
     /**
+     * Returns a string representation for this tag.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->filePath . ($this->description ? ' ' . $this->description->render() : '');
+    }
+
+    /**
      * Returns true if the provided URI is relative or contains a complete scheme (and thus is absolute).
      *
      * @param string $uri


### PR DESCRIPTION
This method is required by the Tag interface.

Closes #76.

IMO, a new patch tag should be pushed ASAP to get PHPUnit working.

cc @sebastianbergmann