### PR TITLE
Fix an unexpected behaviour with @deprecated tags

### DIFF
--- a/src/DocBlock/Tags/Deprecated.php
+++ b/src/DocBlock/Tags/Deprecated.php
@@ -63,7 +63,10 @@ final class Deprecated extends BaseTag implements Factory\StaticMethod
 
         $matches = [];
         if (!preg_match('/^(' . self::REGEX_VECTOR . ')\s*(.+)?$/sux', $body, $matches)) {
-            return null;
+            return new static(
+                null,
+                null !== $descriptionFactory ? $descriptionFactory->create($body, $context) : null
+            );
         }
 
         return new static(

--- a/tests/unit/DocBlock/Tags/DeprecatedTest.php
+++ b/tests/unit/DocBlock/Tags/DeprecatedTest.php
@@ -161,6 +161,6 @@ class DeprecatedTest extends \PHPUnit_Framework_TestCase
      */
     public function testFactoryMethodReturnsNullIfBodyDoesNotMatchRegex()
     {
-        $this->assertNull(Deprecated::create('dkhf<'));
+        $this->assertEquals(new Deprecated(), Deprecated::create('dkhf<'));
     }
 }


### PR DESCRIPTION
When a ``@deprecated`` tag is not followed by a version vector, it won't be treated at all. This looks very unexpected as the constructor accepts an empty version.