### PR TITLE
Add support for rest argument notation

### DIFF
--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -127,7 +127,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
         if ('' !== $arguments) {
             $arguments = explode(',', $arguments);
             foreach($arguments as &$argument) {
-                $argument = explode(' ', trim($argument));
+                $argument = explode(' ', self::stripRestArg(trim($argument)), 2);
                 if ($argument[0][0] === '$') {
                     $argumentName = substr($argument[0], 1);
                     $argumentType = new Void_();
@@ -135,6 +135,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
                     $argumentType = $typeResolver->resolve($argument[0], $context);
                     $argumentName = '';
                     if (isset($argument[1])) {
+                        $argument[1] = self::stripRestArg($argument[1]);
                         $argumentName = substr($argument[1], 1);
                     }
                 }
@@ -216,5 +217,14 @@ final class Method extends BaseTag implements Factory\StaticMethod
         }
 
         return $arguments;
+    }
+
+    private static function stripRestArg($argument)
+    {
+        if (strpos($argument, '...') === 0) {
+            $argument = trim(substr($argument, 3));
+        }
+
+        return $argument;
     }
 }

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -140,6 +140,33 @@ class MethodTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers ::create
+     */
+    public function testRestArgumentIsParsedAsRegularArg()
+    {
+        $expected = [
+            [ 'name' => 'arg1', 'type' => new Void_() ],
+            [ 'name' => 'rest', 'type' => new Void_() ],
+            [ 'name' => 'rest2', 'type' => new Array_() ],
+        ];
+
+        $descriptionFactory = m::mock(DescriptionFactory::class);
+        $resolver           = new TypeResolver();
+        $context            = new Context('');
+        $description  = new Description('');
+        $descriptionFactory->shouldReceive('create')->with('', $context)->andReturn($description);
+
+        $fixture = Method::create(
+            'void myMethod($arg1, ...$rest, array ... $rest2)',
+            $resolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertEquals($expected, $fixture->getArguments());
+    }
+
+    /**
      * @covers ::__construct
      * @covers ::getReturnType
      */


### PR DESCRIPTION
`@method foo(...$arg)` breaks it as it tries to parse `...` as a type, and you end up with `InvalidArgumentException: "\...$arg" is not a valid Fqsen.`

This fixes it by ignoring `...` entirely. I suppose it would be nicer to keep track of it as an additional type or something, but it'd be nice if you can merge this as it fixes an issue already, and then work on improvements as needed.