### PR TITLE
Ignore URLs in @see tag, fixes #78

### DIFF
--- a/examples/02-interpreting-tags.php
+++ b/examples/02-interpreting-tags.php
@@ -8,6 +8,7 @@ $docComment = <<<DOCCOMMENT
  * This is an example of a summary.
  *
  * @see \phpDocumentor\Reflection\DocBlock\StandardTagFactory
+ * @see https://example.org
  */
 DOCCOMMENT;
 

--- a/src/DocBlock/Tags/See.php
+++ b/src/DocBlock/Tags/See.php
@@ -56,6 +56,10 @@ class See extends BaseTag implements Factory\StaticMethod
         $parts       = preg_split('/\s+/Su', $body, 2);
         $description = isset($parts[1]) ? $descriptionFactory->create($parts[1], $context) : null;
 
+        if (preg_match('{^https?://}', $parts[0])) {
+            return null;
+        }
+
         return new static($resolver->resolve($parts[0], $context), $description);
     }
 


### PR DESCRIPTION
There are many more false-positives caused by Fqsen being greedily used in a lot of places, but this is an easy start that covers a lot of warnings out there.