### PR TITLE
Fix regex for tag name extraction and restore disabled test

### DIFF
--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -161,7 +161,7 @@ final class StandardTagFactory implements TagFactory
     private function extractTagParts($tagLine)
     {
         $matches = array();
-        if (! preg_match('/^@(' . self::REGEX_TAGNAME . ')(?:\s*([^\s].*)|$)?/us', $tagLine, $matches)) {
+        if (! preg_match('/^@(' . self::REGEX_TAGNAME . ')(?:\s+([^\s].*)|$)/us', $tagLine, $matches)) {
             throw new \InvalidArgumentException(
                 'The tag "' . $tagLine . '" does not seem to be wellformed, please check it for errors'
             );

--- a/tests/unit/DocBlock/StandardTagFactoryTest.php
+++ b/tests/unit/DocBlock/StandardTagFactoryTest.php
@@ -136,14 +136,10 @@ class StandardTagFactoryTest extends \PHPUnit_Framework_TestCase
      * @uses                     phpDocumentor\Reflection\DocBlock\StandardTagFactory::__construct
      * @uses                     phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The tag "@user/myuser" does not seem to be wellformed, please check it for errors
+     * @expectedExceptionMessage The tag "@user[myuser" does not seem to be wellformed, please check it for errors
      */
     public function testExceptionIsThrownIfProvidedTagIsNotWellformed()
     {
-        $this->markTestIncomplete(
-            'For some reason this test fails; once I have access to a RegEx analyzer I will have to test the regex'
-        )
-        ;
         $tagFactory = new StandardTagFactory(m::mock(FqsenResolver::class));
         $tagFactory->create('@user[myuser');
     }


### PR DESCRIPTION
As far as I can tell, the goal of the regex is to extract `@<tag name>` followed by either whitespace and more stuff, or nothing at all (end of string). The new regex does that, and tests pass so I hope it's fine.