### PR TITLE
Allow `$this` as return type in `@method` annotations

### DIFF
--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -128,7 +128,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
         $returnType  = $typeResolver->resolve($returnType, $context);
         $description = $descriptionFactory->create($description, $context);
 
-        if ('' !== $arguments) {
+        if (is_string($arguments) && strlen($arguments) > 0) {
             $arguments = explode(',', $arguments);
             foreach($arguments as &$argument) {
                 $argument = explode(' ', self::stripRestArg(trim($argument)), 2);

--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -91,10 +91,14 @@ final class Method extends BaseTag implements Factory\StaticMethod
                 )?
                 # Return type
                 (?:
-                    (
-                        (?:[\w\|_\\\\]+)
-                        # array notation           
-                        (?:\[\])*
+                    (   
+                        (?:[\w\|_\\\\]*\$this[\w\|_\\\\]*)
+                        |
+                        (?:
+                            (?:[\w\|_\\\\]+)
+                            # array notation           
+                            (?:\[\])*
+                        )
                     )?
                     \s+
                 )?

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -277,6 +277,13 @@ class MethodTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($description, $fixture->getDescription());
     }
 
+    /**
+     * @covers ::create
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Method::<public>
+     * @uses \phpDocumentor\Reflection\TypeResolver
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\Context
+     */
     public function testReturnTypeThis()
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -22,6 +22,7 @@ use phpDocumentor\Reflection\Types\Context;
 use phpDocumentor\Reflection\Types\Integer;
 use phpDocumentor\Reflection\Types\Object_;
 use phpDocumentor\Reflection\Types\String_;
+use phpDocumentor\Reflection\Types\This;
 use phpDocumentor\Reflection\Types\Void_;
 
 /**
@@ -274,6 +275,29 @@ class MethodTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedArguments, $fixture->getArguments());
         $this->assertInstanceOf(Void_::class, $fixture->getReturnType());
         $this->assertSame($description, $fixture->getDescription());
+    }
+
+    public function testReturnTypeThis()
+    {
+        $descriptionFactory = m::mock(DescriptionFactory::class);
+        $resolver           = new TypeResolver();
+        $context            = new Context('');
+
+        $description  = new Description('');
+
+        $descriptionFactory->shouldReceive('create')->with('', $context)->andReturn($description);
+
+        $fixture = Method::create(
+            'static $this myMethod()',
+            $resolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertTrue($fixture->isStatic());
+        $this->assertSame('static $this myMethod() ', (string)$fixture);
+        $this->assertSame('myMethod', $fixture->getMethodName());
+        $this->assertInstanceOf(This::class, $fixture->getReturnType());
     }
 
     public function collectionReturnTypesProvider()


### PR DESCRIPTION
Fixes #93 

- Modify the RegEx, so that an annotation like `@method $this myMethod()` is parsed correctly
- Write a Unittest for that usecase