### PR TITLE
Custom tag formatter

### DIFF
--- a/src/DocBlock/Serializer.php
+++ b/src/DocBlock/Serializer.php
@@ -32,6 +32,9 @@ class Serializer
     /** @var int|null The max length of a line. */
     protected $lineLength = null;
 
+    /** @var DocBlock\Tags\Formatter A custom tag formatter. */
+    protected $tagFormatter = null;
+
     /**
      * Create a Serializer instance.
      *
@@ -39,18 +42,21 @@ class Serializer
      * @param string   $indentString    The string to indent the comment with.
      * @param bool     $indentFirstLine Whether to indent the first line.
      * @param int|null $lineLength The max length of a line or NULL to disable line wrapping.
+     * @param DocBlock\Tags\Formatter $tagFormatter A custom tag formatter, defaults to PassthroughFormatter.
      */
-    public function __construct($indent = 0, $indentString = ' ', $indentFirstLine = true, $lineLength = null)
+    public function __construct($indent = 0, $indentString = ' ', $indentFirstLine = true, $lineLength = null, $tagFormatter = null)
     {
         Assert::integer($indent);
         Assert::string($indentString);
         Assert::boolean($indentFirstLine);
         Assert::nullOrInteger($lineLength);
+        Assert::nullOrIsInstanceOf($tagFormatter, 'phpDocumentor\Reflection\DocBlock\Tags\Formatter');
 
         $this->indent = $indent;
         $this->indentString = $indentString;
         $this->isFirstLineIndented = $indentFirstLine;
         $this->lineLength = $lineLength;
+        $this->tagFormatter = $tagFormatter ?: new DocBlock\Tags\Formatter\PassthroughFormatter();
     }
 
     /**
@@ -128,8 +134,7 @@ class Serializer
     private function addTagBlock(DocBlock $docblock, $wrapLength, $indent, $comment)
     {
         foreach ($docblock->getTags() as $tag) {
-            $formatter = new DocBlock\Tags\Formatter\PassthroughFormatter();
-            $tagText   = $formatter->format($tag);
+            $tagText = $this->tagFormatter->format($tag);
             if ($wrapLength !== null) {
                 $tagText = wordwrap($tagText, $wrapLength);
             }

--- a/src/DocBlock/Tags/Formatter/AlignFormatter.php
+++ b/src/DocBlock/Tags/Formatter/AlignFormatter.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2017 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\DocBlock\Tags\Formatter;
+
+use phpDocumentor\Reflection\DocBlock\Tag;
+use phpDocumentor\Reflection\DocBlock\Tags\Formatter;
+
+class AlignFormatter implements Formatter
+{
+    /** @var int The maximum tag name length. */
+    protected $maxLen = 0;
+
+    /**
+     * Constructor.
+     *
+     * @param Tag[] $tags All tags that should later be aligned with the formatter.
+     */
+    public function __construct(array $tags)
+    {
+        foreach ($tags as $tag) {
+            $this->maxLen = max($this->maxLen, strlen($tag->getName()));
+        }
+    }
+
+    /**
+     * Formats the given tag to return a simple plain text version.
+     *
+     * @param Tag $tag
+     *
+     * @return string
+     */
+    public function format(Tag $tag)
+    {
+        return '@' . $tag->getName() . str_repeat(' ', $this->maxLen - strlen($tag->getName()) + 1) . (string)$tag;
+    }
+}

--- a/src/DocBlock/Tags/Formatter/AlignFormatter.php
+++ b/src/DocBlock/Tags/Formatter/AlignFormatter.php
@@ -5,6 +5,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
+ * @author    Jan Schneider <jan@horde.org>
  * @copyright 2017 Mike van Riel<mike@phpdoc.org>
  * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      http://phpdoc.org

--- a/tests/unit/DocBlock/Tags/Formatter/AlignFormatterTest.php
+++ b/tests/unit/DocBlock/Tags/Formatter/AlignFormatterTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @author    Jan Schneider <jan@horde.org>
+ * @copyright 2017 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\DocBlock\Tags\Formatter;
+
+use phpDocumentor\Reflection\DocBlock\Description;
+use phpDocumentor\Reflection\DocBlock\Tags\Link;
+use phpDocumentor\Reflection\DocBlock\Tags\Param;
+use phpDocumentor\Reflection\DocBlock\Tags\Version;
+use phpDocumentor\Reflection\Types\String_;
+
+/**
+ * @coversDefaultClass \phpDocumentor\Reflection\DocBlock\Tags\Formatter\AlignFormatter
+ */
+class PassthroughFormatterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers ::format
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Link
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Param
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Version
+     * @uses \phpDocumentor\Reflection\Types\String_
+     */
+    public function testFormatterCallsToStringAndReturnsAStandardRepresentation()
+    {
+        $tags = array(
+            new Param('foobar', new String_()),
+            new Version('1.2.0'),
+            new Link('http://www.example.com', new Description('Examples'))
+        );
+        $fixture = new AlignFormatter($tags);
+
+        $expected = array(
+            '@param   string $foobar',
+            '@version 1.2.0',
+            '@link    http://www.example.com Examples'
+        );
+
+        foreach ($tags as $key => $tag) {
+            $this->assertSame(
+                $expected[$key],
+                $fixture->format($tag)
+            );
+        }
+    }
+}


### PR DESCRIPTION
This PR adds to the Serializer an option to use a custom tag formatter, other than the default PassthroughFormatter. It also adds an alternative formatter that aligns the tag values.