### PR TITLE
Fix author tag generation

### DIFF
--- a/src/DocBlock/Tags/Author.php
+++ b/src/DocBlock/Tags/Author.php
@@ -73,7 +73,7 @@ final class Author extends BaseTag implements Factory\StaticMethod
      */
     public function __toString()
     {
-        return $this->authorName . '<' . $this->authorEmail . '>';
+        return $this->authorName . (strlen($this->authorEmail) ? ' <' . $this->authorEmail . '>' : '');
     }
 
     /**

--- a/tests/unit/DocBlock/Tags/AuthorTest.php
+++ b/tests/unit/DocBlock/Tags/AuthorTest.php
@@ -121,7 +121,7 @@ class AuthorTest extends \PHPUnit_Framework_TestCase
     {
         $fixture = new Author('Mike van Riel', 'mike@phpdoc.org');
 
-        $this->assertSame('Mike van Riel<mike@phpdoc.org>', (string)$fixture);
+        $this->assertSame('Mike van Riel <mike@phpdoc.org>', (string)$fixture);
     }
 
     /**
@@ -132,7 +132,7 @@ class AuthorTest extends \PHPUnit_Framework_TestCase
     {
         $fixture = Author::create('Mike van Riel <mike@phpdoc.org>');
 
-        $this->assertSame('Mike van Riel<mike@phpdoc.org>', (string)$fixture);
+        $this->assertSame('Mike van Riel <mike@phpdoc.org>', (string)$fixture);
         $this->assertSame('Mike van Riel', $fixture->getAuthorName());
         $this->assertSame('mike@phpdoc.org', $fixture->getEmail());
     }

--- a/tests/unit/DocBlock/Tags/AuthorTest.php
+++ b/tests/unit/DocBlock/Tags/AuthorTest.php
@@ -125,6 +125,17 @@ class AuthorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function testStringRepresentationWithEmtpyEmail()
+    {
+        $fixture = new Author('Mike van Riel', '');
+
+        $this->assertSame('Mike van Riel', (string)$fixture);
+    }
+
+    /**
      * @covers ::create
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Author::<public>
      */

--- a/tests/unit/DocBlock/Tags/AuthorTest.php
+++ b/tests/unit/DocBlock/Tags/AuthorTest.php
@@ -42,7 +42,7 @@ class AuthorTest extends \PHPUnit_Framework_TestCase
     {
         $fixture = new Author('Mike van Riel', 'mike@phpdoc.org');
 
-        $this->assertSame('@author Mike van Riel<mike@phpdoc.org>', $fixture->render());
+        $this->assertSame('@author Mike van Riel <mike@phpdoc.org>', $fixture->render());
     }
 
     /**


### PR DESCRIPTION
When generating author tags, the author name and author email run into each other. If the email is empty, empty arrow brackets are generated. Both is fixed with this PR.