### PR TITLE
Add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.scrutinizer.yml export-ignore
+/.travis.yml export-ignore
+/composer.lock export-ignore
+/examples/ export-ignore
+/phpmd.xml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/tests/ export-ignore


### PR DESCRIPTION
Used to allow composer to ignore tests and other development files in
distribution of releases.