### PR TITLE
Unit tests fixed

### DIFF
--- a/tests/unit/DocBlock/Tags/DeprecatedTest.php
+++ b/tests/unit/DocBlock/Tags/DeprecatedTest.php
@@ -158,6 +158,7 @@ class DeprecatedTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers ::create
+     * @uses   \phpDocumentor\Reflection\DocBlock\Tags\Deprecated::__construct
      */
     public function testFactoryMethodReturnsNullIfBodyDoesNotMatchRegex()
     {

--- a/tests/unit/DocBlock/Tags/Formatter/AlignFormatterTest.php
+++ b/tests/unit/DocBlock/Tags/Formatter/AlignFormatterTest.php
@@ -22,10 +22,11 @@ use phpDocumentor\Reflection\Types\String_;
 /**
  * @coversDefaultClass \phpDocumentor\Reflection\DocBlock\Tags\Formatter\AlignFormatter
  */
-class PassthroughFormatterTest extends \PHPUnit_Framework_TestCase
+class AlignFormatterTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @covers ::format
+     * @covers \phpDocumentor\Reflection\DocBlock\Tags\Formatter\AlignFormatter::__construct
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Link

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -142,6 +142,9 @@ class MethodTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers ::create
+     * @uses   \phpDocumentor\Reflection\DocBlock\Tags\Method::__construct
+     * @uses   \phpDocumentor\Reflection\DocBlock\Tags\Method::getArguments
+     * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
     public function testRestArgumentIsParsedAsRegularArg()
     {


### PR DESCRIPTION
## Motivation

Master is broken. 

## Changes

1. `AlignFormatterTest` class name fixed. Build is going to be green.
2. All necessary `@covers` and `@uses` tags added. No more risky tests.