### PR TITLE
Allow omitting method return type

### DIFF
--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -125,6 +125,11 @@ final class Method extends BaseTag implements Factory\StaticMethod
         list(, $static, $returnType, $methodName, $arguments, $description) = $matches;
 
         $static      = $static === 'static';
+
+        if ($returnType === '') {
+            $returnType = 'void';
+        }
+
         $returnType  = $typeResolver->resolve($returnType, $context);
         $description = $descriptionFactory->create($description, $context);
 
@@ -196,11 +201,11 @@ final class Method extends BaseTag implements Factory\StaticMethod
             $arguments[] = $argument['type'] . ' $' . $argument['name'];
         }
 
-        return ($this->isStatic() ? 'static ' : '')
+        return trim(($this->isStatic() ? 'static ' : '')
             . (string)$this->returnType . ' '
             . $this->methodName
             . '(' . implode(', ', $arguments) . ')'
-            . ($this->description ? ' ' . $this->description->render() : '');
+            . ($this->description ? ' ' . $this->description->render() : ''));
     }
 
     private function filterArguments($arguments)

--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -98,8 +98,8 @@ final class Method extends BaseTag implements Factory\StaticMethod
                             (?:[\w\|_\\\\]+)
                             # array notation           
                             (?:\[\])*
-                        )
-                    )?
+                        )*
+                    )
                     \s+
                 )?
                 # Legacy method name (not captured)

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -305,7 +305,7 @@ class MethodTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertTrue($fixture->isStatic());
-        $this->assertSame('static $this myMethod() ', (string)$fixture);
+        $this->assertSame('static $this myMethod()', (string)$fixture);
         $this->assertSame('myMethod', $fixture->getMethodName());
         $this->assertInstanceOf(This::class, $fixture->getReturnType());
     }
@@ -463,6 +463,30 @@ class MethodTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertSame('static void myMethod() My Description', (string)$fixture);
+        $this->assertSame('myMethod', $fixture->getMethodName());
+        $this->assertEquals([], $fixture->getArguments());
+        $this->assertInstanceOf(Void_::class, $fixture->getReturnType());
+        $this->assertSame($description, $fixture->getDescription());
+    }
+
+    public function testCreateWithoutReturnType()
+    {
+        $descriptionFactory = m::mock(DescriptionFactory::class);
+        $resolver           = new TypeResolver();
+        $context            = new Context('');
+
+        $description  = new Description('');
+
+        $descriptionFactory->shouldReceive('create')->with('', $context)->andReturn($description);
+
+        $fixture = Method::create(
+            'myMethod()',
+            $resolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertSame('void myMethod()', (string)$fixture);
         $this->assertSame('myMethod', $fixture->getMethodName());
         $this->assertEquals([], $fixture->getArguments());
         $this->assertInstanceOf(Void_::class, $fixture->getReturnType());

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Reflection\DocBlock\Tags;
 use Mockery as m;
 use phpDocumentor\Reflection\DocBlock\Description;
 use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
+use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Array_;
 use phpDocumentor\Reflection\Types\Compound;
@@ -469,6 +470,16 @@ class MethodTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($description, $fixture->getDescription());
     }
 
+    /**
+     * @covers ::create
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Method::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\TypeResolver
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Fqsen
+     * @uses \phpDocumentor\Reflection\Types\Context
+     * @uses \phpDocumentor\Reflection\Types\Void_
+     */
     public function testCreateWithoutReturnType()
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -491,5 +502,45 @@ class MethodTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([], $fixture->getArguments());
         $this->assertInstanceOf(Void_::class, $fixture->getReturnType());
         $this->assertSame($description, $fixture->getDescription());
+    }
+
+    /**
+     * @covers ::create
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Method::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\TypeResolver
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Fqsen
+     * @uses \phpDocumentor\Reflection\Types\Context
+     * @uses \phpDocumentor\Reflection\Types\Array_
+     * @uses \phpDocumentor\Reflection\Types\Compound
+     * @uses \phpDocumentor\Reflection\Types\Integer
+     * @uses \phpDocumentor\Reflection\Types\Object_
+     */
+    public function testCreateWithMixedReturnTypes()
+    {
+        $descriptionFactory = m::mock(DescriptionFactory::class);
+        $resolver           = new TypeResolver();
+        $context            = new Context('');
+
+        $descriptionFactory->shouldReceive('create')->andReturn(new Description(''));
+
+        $fixture = Method::create(
+            'MyClass[]|int[] myMethod()',
+            $resolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertSame('\MyClass[]|int[] myMethod()', (string)$fixture);
+        $this->assertSame('myMethod', $fixture->getMethodName());
+        $this->assertEquals([], $fixture->getArguments());
+
+        $this->assertEquals(
+            new Compound([
+                new Array_(new Object_(new Fqsen('\MyClass'))),
+                new Array_(new Integer()),
+            ])
+            , $fixture->getReturnType());
     }
 }


### PR DESCRIPTION
Support for `@method myMethod()` was missing but according to the
docs of phpdocumentor this is possible.

Refs #74