### PR TITLE
Allow see tag to url

### DIFF
--- a/src/DocBlock/Tags/Reference/Fqsen.php
+++ b/src/DocBlock/Tags/Reference/Fqsen.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
+ *  @license   http://www.opensource.org/licenses/mit-license.php MIT
+ *  @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\DocBlock\Tags\Reference;
+
+use phpDocumentor\Reflection\Fqsen as RealFqsen;
+
+/**
+ * Fqsen reference used by {@see phpDocumentor\Reflection\DocBlock\Tags\See}
+ */
+final class Fqsen implements Reference
+{
+    /**
+     * @var RealFqsen
+     */
+    private $fqsen;
+
+    /**
+     * Fqsen constructor.
+     */
+    public function __construct(RealFqsen $fqsen)
+    {
+        $this->fqsen = $fqsen;
+    }
+
+    /**
+     * @return string string representation of the referenced fqsen
+     */
+    public function __toString()
+    {
+        return (string)$this->fqsen;
+    }
+}

--- a/src/DocBlock/Tags/Reference/Reference.php
+++ b/src/DocBlock/Tags/Reference/Reference.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
+ *  @license   http://www.opensource.org/licenses/mit-license.php MIT
+ *  @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\DocBlock\Tags\Reference;
+
+/**
+ * Interface for references in {@see phpDocumentor\Reflection\DocBlock\Tags\See}
+ */
+interface Reference
+{
+   public function __toString();
+}

--- a/src/DocBlock/Tags/Reference/Url.php
+++ b/src/DocBlock/Tags/Reference/Url.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
+ *  @license   http://www.opensource.org/licenses/mit-license.php MIT
+ *  @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\DocBlock\Tags\Reference;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * Url reference used by {@see phpDocumentor\Reflection\DocBlock\Tags\See}
+ */
+final class Url implements Reference
+{
+    /**
+     * @var string
+     */
+    private $uri;
+
+    /**
+     * Url constructor.
+     */
+    public function __construct($uri)
+    {
+        Assert::stringNotEmpty($uri);
+        $this->uri = $uri;
+    }
+
+    public function __toString()
+    {
+        return $this->uri;
+    }
+}

--- a/src/DocBlock/Tags/See.php
+++ b/src/DocBlock/Tags/See.php
@@ -13,6 +13,9 @@
 namespace phpDocumentor\Reflection\DocBlock\Tags;
 
 use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
+use phpDocumentor\Reflection\DocBlock\Tags\Reference\Fqsen as FqsenRef;
+use phpDocumentor\Reflection\DocBlock\Tags\Reference\Reference;
+use phpDocumentor\Reflection\DocBlock\Tags\Reference\Url;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
@@ -26,16 +29,16 @@ class See extends BaseTag implements Factory\StaticMethod
 {
     protected $name = 'see';
 
-    /** @var Fqsen */
+    /** @var Reference */
     protected $refers = null;
 
     /**
      * Initializes this tag.
      *
-     * @param Fqsen $refers
+     * @param Reference $refers
      * @param Description $description
      */
-    public function __construct(Fqsen $refers, Description $description = null)
+    public function __construct(Reference $refers, Description $description = null)
     {
         $this->refers = $refers;
         $this->description = $description;
@@ -56,13 +59,18 @@ class See extends BaseTag implements Factory\StaticMethod
         $parts       = preg_split('/\s+/Su', $body, 2);
         $description = isset($parts[1]) ? $descriptionFactory->create($parts[1], $context) : null;
 
-        return new static($resolver->resolve($parts[0], $context), $description);
+        // https://tools.ietf.org/html/rfc2396#section-3
+        if (preg_match('/\w:\/\/\w/i', $parts[0])) {
+            return new static(new Url($parts[0]), $description);
+        }
+
+        return new static(new FqsenRef($resolver->resolve($parts[0], $context)), $description);
     }
 
     /**
-     * Returns the structural element this tag refers to.
+     * Returns the ref of this tag.
      *
-     * @return Fqsen
+     * @return Reference
      */
     public function getReference()
     {


### PR DESCRIPTION
The see tag allows Fqsen and uri's. But in the current implementation
only Fqsen where allowed. This wrapps the uri and Fqsen in an uniform class
to be able address them in the same way.

Fixes #78
Replaces #88 and #92 