### PR TITLE
Surround the creation of the tags with a try catch block

### DIFF
--- a/src/DocBlockFactory.php
+++ b/src/DocBlockFactory.php
@@ -228,7 +228,11 @@ final class DocBlockFactory implements DocBlockFactoryInterface
 
         $result = $this->splitTagBlockIntoTagLines($tags);
         foreach ($result as $key => $tagLine) {
-            $result[$key] = $this->tagFactory->create(trim($tagLine), $context);
+            try {
+                $result[$key] = $this->tagFactory->create(trim($tagLine), $context);
+            }
+            catch(\Exception $e) {
+            }
         }
 
         return $result;


### PR DESCRIPTION
Surround the creation of the tags of a try catch block to support php doc with unknown tags such as @JMS\Type("int"), etc