### PR TITLE
Restores future support for annotations

### DIFF
--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -113,6 +113,12 @@ final class StandardTagFactory implements TagFactory
 
         list($tagName, $tagBody) = $this->extractTagParts($tagLine);
 
+        if ($tagBody[0] === '[') {
+            throw new \InvalidArgumentException(
+                'The tag "' . $tagLine . '" does not seem to be wellformed, please check it for errors'
+            );
+        }
+
         return $this->createTag($tagBody, $tagName, $context);
     }
 
@@ -161,7 +167,7 @@ final class StandardTagFactory implements TagFactory
     private function extractTagParts($tagLine)
     {
         $matches = array();
-        if (! preg_match('/^@(' . self::REGEX_TAGNAME . ')(?:\s+([^\s].*)|$)/us', $tagLine, $matches)) {
+        if (! preg_match('/^@(' . self::REGEX_TAGNAME . ')(?:\s*([^\s].*)|$)/us', $tagLine, $matches)) {
             throw new \InvalidArgumentException(
                 'The tag "' . $tagLine . '" does not seem to be wellformed, please check it for errors'
             );

--- a/tests/integration/DocblocksWithAnnotationsTest.php
+++ b/tests/integration/DocblocksWithAnnotationsTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
+ *  @license   http://www.opensource.org/licenses/mit-license.php MIT
+ *  @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection;
+
+/**
+ * @coversNothing
+ */
+final class DocblocksWithAnnotationsTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDocblockWithAnnotations()
+    {
+        $docComment = <<<DOCCOMMENT
+            /**
+     * @var \DateTime[]
+     * @Groups({"a", "b"})
+     */
+DOCCOMMENT;
+
+
+        $factory  = DocBlockFactory::createInstance();
+        $docblock = $factory->create($docComment);
+
+        $this->assertCount(2, $docblock->getTags());
+    }
+}


### PR DESCRIPTION
In #89 the regex to parse tags was to strict. The first character after a tag
had to be a single string. Annotations typically start with a parentheses. Only character not
allowed after a tag is a [.

Fixes #108