### PR TITLE
Check tag body is an array before trying to access it as one

### DIFF
--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -113,7 +113,7 @@ final class StandardTagFactory implements TagFactory
 
         list($tagName, $tagBody) = $this->extractTagParts($tagLine);
 
-        if ($tagBody[0] === '[') {
+        if (is_array($tagBody) && $tagBody[0] === '[') {
             throw new \InvalidArgumentException(
                 'The tag "' . $tagLine . '" does not seem to be wellformed, please check it for errors'
             );

--- a/tests/integration/DocblocksWithAnnotationsTest.php
+++ b/tests/integration/DocblocksWithAnnotationsTest.php
@@ -23,6 +23,7 @@ final class DocblocksWithAnnotationsTest extends \PHPUnit_Framework_TestCase
             /**
      * @var \DateTime[]
      * @Groups({"a", "b"})
+     * @ORM\Entity
      */
 DOCCOMMENT;
 
@@ -30,6 +31,6 @@ DOCCOMMENT;
         $factory  = DocBlockFactory::createInstance();
         $docblock = $factory->create($docComment);
 
-        $this->assertCount(2, $docblock->getTags());
+        $this->assertCount(3, $docblock->getTags());
     }
 }


### PR DESCRIPTION
Related to issue #111 

It seems when the extract tag parts, it can return an empty string instead of an array (seems to be like that for years now). I added a simple check that it is in fact an array before accessing it.