### PR TITLE
Check tag body has a value before trying to access it as an string array

### DIFF
--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -113,7 +113,7 @@ final class StandardTagFactory implements TagFactory
 
         list($tagName, $tagBody) = $this->extractTagParts($tagLine);
 
-        if ($tagBody[0] === '[') {
+        if ($tagBody !== '' && $tagBody[0] === '[') {
             throw new \InvalidArgumentException(
                 'The tag "' . $tagLine . '" does not seem to be wellformed, please check it for errors'
             );

--- a/tests/integration/DocblocksWithAnnotationsTest.php
+++ b/tests/integration/DocblocksWithAnnotationsTest.php
@@ -23,6 +23,7 @@ final class DocblocksWithAnnotationsTest extends \PHPUnit_Framework_TestCase
             /**
      * @var \DateTime[]
      * @Groups({"a", "b"})
+     * @ORM\Entity
      */
 DOCCOMMENT;
 
@@ -30,6 +31,6 @@ DOCCOMMENT;
         $factory  = DocBlockFactory::createInstance();
         $docblock = $factory->create($docComment);
 
-        $this->assertCount(2, $docblock->getTags());
+        $this->assertCount(3, $docblock->getTags());
     }
 }


### PR DESCRIPTION
Related to issue #111 

Check if the string is not empty before accessing it as an array. After I noticed all the other failures in the tests from the previous MR, I understood what was the intention.