### PR TITLE
Fixes namespace error in ExampleFinder

### DIFF
--- a/src/DocBlock/ExampleFinder.php
+++ b/src/DocBlock/ExampleFinder.php
@@ -10,7 +10,7 @@
  * @link      http://phpdoc.org
  */
 
-namespace phpDocumentor\Reflection;
+namespace phpDocumentor\Reflection\DocBlock;
 
 use phpDocumentor\Reflection\DocBlock\Tags\Example;
 

--- a/tests/unit/DocBlock/ExampleFinderTest.php
+++ b/tests/unit/DocBlock/ExampleFinderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace phpDocumentor\Reflection\DocBlock;
+
+use phpDocumentor\Reflection\DocBlock\Tags\Example;
+
+/**
+ * @coversDefaultClass phpDocumentor\Reflection\DocBlock\ExampleFinder
+ * @covers ::<private>
+ */
+class ExampleFinderTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var ExampleFinder */
+    private $fixture;
+
+    public function setUp()
+    {
+        $this->fixture = new ExampleFinder();
+    }
+
+    /**
+     * @covers ::find
+     * @covers ::getSourceDirectory
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Example
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     */
+    public function testFileNotFound()
+    {
+        $example = new Example('./example.php', false, 1, 0, new Description('Test'));
+        $this->assertSame('** File not found : ./example.php **', $this->fixture->find($example));
+    }
+}


### PR DESCRIPTION
Namespace of ExampleFinder was not correct according to the location of the class.