### PR TITLE
Bump to PHP 7.1, add typehtins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name":    "phpdocumentor/reflection-docblock",
+    "name": "phpdocumentor/reflection-docblock",
     "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
     "type":    "library",
     "license": "MIT",
@@ -10,21 +10,25 @@
         }
     ],
     "require": {
-        "php": "^7.0",
-        "phpdocumentor/reflection-common": "^1.0.0",
-        "phpdocumentor/type-resolver": "^0.4.0",
+        "php": "^7.1",
+        "phpdocumentor/reflection-common": "^1.0",
+        "phpdocumentor/type-resolver": "^0.4",
         "webmozart/assert": "^1.0"
     },
     "autoload": {
-        "psr-4": {"phpDocumentor\\Reflection\\": ["src/"]}
+        "psr-4": {
+            "phpDocumentor\\Reflection\\": "src"
+        }
     },
     "autoload-dev": {
-        "psr-4": {"phpDocumentor\\Reflection\\": ["tests/unit"]}
+        "psr-4": {
+            "phpDocumentor\\Reflection\\": "tests/unit"
+        }
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^6.4",
-        "doctrine/instantiator": "~1.0.5"
+        "doctrine/instantiator": "^1.0"
     },
     "extra": {
         "branch-alias": {

--- a/composer.lock
+++ b/composer.lock
@@ -475,16 +475,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.2",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6"
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
                 "shasum": ""
             },
             "require": {
@@ -496,7 +496,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
             "type": "library",
             "extra": {
@@ -534,7 +534,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-09-04T11:05:03+00:00"
+            "time": "2017-11-24T13:59:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -602,16 +602,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "8ebba84e5bd74fc5fdeb916b38749016c7232f93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/8ebba84e5bd74fc5fdeb916b38749016c7232f93",
+                "reference": "8ebba84e5bd74fc5fdeb916b38749016c7232f93",
                 "shasum": ""
             },
             "require": {
@@ -645,7 +645,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-24T15:00:59+00:00"
         },
         {
             "name": "phpunit/php-text-template",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f69122debe760b39f6a8eb6eb737b30a",
+    "content-hash": "2a242eca1a53d53cacb1e5bb03e62846",
     "packages": [
         {
             "name": "phpdocumentor/reflection-common",
@@ -161,32 +161,32 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
                 "athletic/athletic": "~0.1.8",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -211,7 +211,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2017-07-22T11:58:36+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -1535,7 +1535,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.0"
+        "php": "^7.1"
     },
     "platform-dev": []
 }

--- a/examples/04-adding-your-own-tag.php
+++ b/examples/04-adding-your-own-tag.php
@@ -86,7 +86,6 @@ final class MyTag extends BaseTag implements StaticMethod
      */
     public static function create(string $body, DescriptionFactory $descriptionFactory = null, Context $context = null): MyTag
     {
-        Assert::string($body);
         Assert::notNull($descriptionFactory);
 
         return new static($descriptionFactory->create($body, $context));

--- a/examples/04-adding-your-own-tag.php
+++ b/examples/04-adding-your-own-tag.php
@@ -83,10 +83,8 @@ final class MyTag extends BaseTag implements StaticMethod
      *
      * @see Tag for the interface declaration of the `create` method.
      * @see Tag::create() for more information on this method's workings.
-     *
-     * @return MyTag
      */
-    public static function create($body, DescriptionFactory $descriptionFactory = null, Context $context = null)
+    public static function create(string $body, DescriptionFactory $descriptionFactory = null, Context $context = null): MyTag
     {
         Assert::string($body);
         Assert::notNull($descriptionFactory);
@@ -99,10 +97,8 @@ final class MyTag extends BaseTag implements StaticMethod
      *
      * This method is used to reconstitute a DocBlock into its original form by the {@see Serializer}. It should
      * feature all parts of the tag so that the serializer can put it back together.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return (string)$this->description;
     }

--- a/src/DocBlock.php
+++ b/src/DocBlock.php
@@ -56,9 +56,6 @@ final class DocBlock
         bool $isTemplateStart = false,
         bool $isTemplateEnd = false
     ) {
-        Assert::string($summary);
-        Assert::boolean($isTemplateStart);
-        Assert::boolean($isTemplateEnd);
         Assert::allIsInstanceOf($tags, Tag::class);
 
         $this->summary = $summary;
@@ -166,8 +163,6 @@ final class DocBlock
      */
     public function getTagsByName(string $name)
     {
-        Assert::string($name);
-
         $result = [];
 
         /** @var Tag $tag */
@@ -191,8 +186,6 @@ final class DocBlock
      */
     public function hasTag(string $name): bool
     {
-        Assert::string($name);
-
         /** @var Tag $tag */
         foreach ($this->getTags() as $tag) {
             if ($tag->getName() === $name) {

--- a/src/DocBlock.php
+++ b/src/DocBlock.php
@@ -73,9 +73,6 @@ final class DocBlock
         return $this->summary;
     }
 
-    /**
-     * @return DocBlock\Description
-     */
     public function getDescription(): DocBlock\Description
     {
         return $this->description;

--- a/src/DocBlock.php
+++ b/src/DocBlock.php
@@ -46,10 +46,10 @@ final class DocBlock
      */
     public function __construct(
         string $summary = '',
-        DocBlock\Description $description = null,
+        ?DocBlock\Description $description = null,
         array $tags = [],
-        Types\Context $context = null,
-        Location $location = null,
+        ?Types\Context $context = null,
+        ?Location $location = null,
         bool $isTemplateStart = false,
         bool $isTemplateEnd = false
     ) {
@@ -84,7 +84,6 @@ final class DocBlock
     /**
      * Returns the current context.
      *
-     * @return Types\Context
      */
     public function getContext(): Types\Context
     {
@@ -118,7 +117,6 @@ final class DocBlock
      *
      * @see self::isTemplateEnd() for the check whether a closing marker was provided.
      *
-     * @return boolean
      */
     public function isTemplateStart(): bool
     {
@@ -130,7 +128,6 @@ final class DocBlock
      *
      * @see self::isTemplateStart() for a more complete description of the Docblock Template functionality.
      *
-     * @return boolean
      */
     public function isTemplateEnd(): bool
     {
@@ -193,7 +190,7 @@ final class DocBlock
      *
      * @param Tag $tag The tag to remove.
      */
-    public function removeTag(Tag $tagToRemove)
+    public function removeTag(Tag $tagToRemove): void
     {
         foreach ($this->tags as $key => $tag) {
             if ($tag === $tagToRemove) {
@@ -208,7 +205,7 @@ final class DocBlock
      *
      * @param Tag $tag The tag to add.
      */
-    private function addTag(Tag $tag)
+    private function addTag(Tag $tag): void
     {
         $this->tags[] = $tag;
     }

--- a/src/DocBlock.php
+++ b/src/DocBlock.php
@@ -40,12 +40,9 @@ final class DocBlock
     private $isTemplateEnd = false;
 
     /**
-     * @param string $summary
      * @param DocBlock\Tag[] $tags
      * @param Types\Context $context The context in which the DocBlock occurs.
      * @param Location $location The location within the file that this DocBlock occurs in.
-     * @param bool $isTemplateStart
-     * @param bool $isTemplateEnd
      */
     public function __construct(
         string $summary = '',
@@ -71,9 +68,6 @@ final class DocBlock
         $this->isTemplateStart = $isTemplateStart;
     }
 
-    /**
-     * @return string
-     */
     public function getSummary(): string
     {
         return $this->summary;
@@ -181,8 +175,6 @@ final class DocBlock
      * Checks if a tag of a certain type is present in this DocBlock.
      *
      * @param string $name Tag name to check for.
-     *
-     * @return bool
      */
     public function hasTag(string $name): bool
     {
@@ -200,7 +192,6 @@ final class DocBlock
      * Remove a tag from this DocBlock.
      *
      * @param Tag $tag The tag to remove.
-     *
      */
     public function removeTag(Tag $tagToRemove)
     {
@@ -216,7 +207,6 @@ final class DocBlock
      * Adds a tag to this DocBlock.
      *
      * @param Tag $tag The tag to add.
-     *
      */
     private function addTag(Tag $tag)
     {

--- a/src/DocBlock.php
+++ b/src/DocBlock.php
@@ -83,7 +83,6 @@ final class DocBlock
 
     /**
      * Returns the current context.
-     *
      */
     public function getContext(): Types\Context
     {
@@ -116,7 +115,6 @@ final class DocBlock
      * elements that follow until another DocBlock is found that contains the closing marker (`#@-`).
      *
      * @see self::isTemplateEnd() for the check whether a closing marker was provided.
-     *
      */
     public function isTemplateStart(): bool
     {
@@ -127,7 +125,6 @@ final class DocBlock
      * Returns whether this DocBlock is the end of a Template section.
      *
      * @see self::isTemplateStart() for a more complete description of the Docblock Template functionality.
-     *
      */
     public function isTemplateEnd(): bool
     {

--- a/src/DocBlock.php
+++ b/src/DocBlock.php
@@ -102,10 +102,8 @@ final class DocBlock
 
     /**
      * Returns the current location.
-     *
-     * @return Location
      */
-    public function getLocation(): Location
+    public function getLocation(): ?Location
     {
         return $this->location;
     }

--- a/src/DocBlock.php
+++ b/src/DocBlock.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -40,7 +41,6 @@ final class DocBlock
 
     /**
      * @param string $summary
-     * @param DocBlock\Description $description
      * @param DocBlock\Tag[] $tags
      * @param Types\Context $context The context in which the DocBlock occurs.
      * @param Location $location The location within the file that this DocBlock occurs in.
@@ -48,13 +48,13 @@ final class DocBlock
      * @param bool $isTemplateEnd
      */
     public function __construct(
-        $summary = '',
+        string $summary = '',
         DocBlock\Description $description = null,
         array $tags = [],
         Types\Context $context = null,
         Location $location = null,
-        $isTemplateStart = false,
-        $isTemplateEnd = false
+        bool $isTemplateStart = false,
+        bool $isTemplateEnd = false
     ) {
         Assert::string($summary);
         Assert::boolean($isTemplateStart);
@@ -77,7 +77,7 @@ final class DocBlock
     /**
      * @return string
      */
-    public function getSummary()
+    public function getSummary(): string
     {
         return $this->summary;
     }
@@ -85,7 +85,7 @@ final class DocBlock
     /**
      * @return DocBlock\Description
      */
-    public function getDescription()
+    public function getDescription(): DocBlock\Description
     {
         return $this->description;
     }
@@ -95,7 +95,7 @@ final class DocBlock
      *
      * @return Types\Context
      */
-    public function getContext()
+    public function getContext(): Types\Context
     {
         return $this->context;
     }
@@ -105,7 +105,7 @@ final class DocBlock
      *
      * @return Location
      */
-    public function getLocation()
+    public function getLocation(): Location
     {
         return $this->location;
     }
@@ -131,7 +131,7 @@ final class DocBlock
      *
      * @return boolean
      */
-    public function isTemplateStart()
+    public function isTemplateStart(): bool
     {
         return $this->isTemplateStart;
     }
@@ -143,7 +143,7 @@ final class DocBlock
      *
      * @return boolean
      */
-    public function isTemplateEnd()
+    public function isTemplateEnd(): bool
     {
         return $this->isTemplateEnd;
     }
@@ -166,7 +166,7 @@ final class DocBlock
      *
      * @return Tag[]
      */
-    public function getTagsByName($name)
+    public function getTagsByName(string $name)
     {
         Assert::string($name);
 
@@ -191,7 +191,7 @@ final class DocBlock
      *
      * @return bool
      */
-    public function hasTag($name)
+    public function hasTag(string $name): bool
     {
         Assert::string($name);
 
@@ -210,7 +210,6 @@ final class DocBlock
      *
      * @param Tag $tag The tag to remove.
      *
-     * @return void
      */
     public function removeTag(Tag $tagToRemove)
     {
@@ -227,7 +226,6 @@ final class DocBlock
      *
      * @param Tag $tag The tag to add.
      *
-     * @return void
      */
     private function addTag(Tag $tag)
     {

--- a/src/DocBlock/Description.php
+++ b/src/DocBlock/Description.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -62,10 +63,8 @@ class Description
      * @param string $bodyTemplate
      * @param Tag[] $tags
      */
-    public function __construct($bodyTemplate, array $tags = [])
+    public function __construct(string $bodyTemplate, array $tags = [])
     {
-        Assert::string($bodyTemplate);
-
         $this->bodyTemplate = $bodyTemplate;
         $this->tags = $tags;
     }
@@ -84,11 +83,10 @@ class Description
      * Renders this description as a string where the provided formatter will format the tags in the expected string
      * format.
      *
-     * @param Formatter|null $formatter
      *
      * @return string
      */
-    public function render(Formatter $formatter = null)
+    public function render(Formatter $formatter = null): string
     {
         if ($formatter === null) {
             $formatter = new PassthroughFormatter();
@@ -107,7 +105,7 @@ class Description
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->render();
     }

--- a/src/DocBlock/Description.php
+++ b/src/DocBlock/Description.php
@@ -59,7 +59,6 @@ class Description
     /**
      * Initializes a Description with its body (template) and a listing of the tags used in the body template.
      *
-     * @param string $bodyTemplate
      * @param Tag[] $tags
      */
     public function __construct(string $bodyTemplate, array $tags = [])
@@ -81,9 +80,6 @@ class Description
     /**
      * Renders this description as a string where the provided formatter will format the tags in the expected string
      * format.
-     *
-     *
-     * @return string
      */
     public function render(Formatter $formatter = null): string
     {
@@ -101,8 +97,6 @@ class Description
 
     /**
      * Returns a plain string representation of this description.
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/src/DocBlock/Description.php
+++ b/src/DocBlock/Description.php
@@ -15,7 +15,6 @@ namespace phpDocumentor\Reflection\DocBlock;
 
 use phpDocumentor\Reflection\DocBlock\Tags\Formatter;
 use phpDocumentor\Reflection\DocBlock\Tags\Formatter\PassthroughFormatter;
-use Webmozart\Assert\Assert;
 
 /**
  * Object representing to description for a DocBlock.

--- a/src/DocBlock/Description.php
+++ b/src/DocBlock/Description.php
@@ -81,7 +81,7 @@ class Description
      * Renders this description as a string where the provided formatter will format the tags in the expected string
      * format.
      */
-    public function render(Formatter $formatter = null): string
+    public function render(?Formatter $formatter = null): string
     {
         if ($formatter === null) {
             $formatter = new PassthroughFormatter();

--- a/src/DocBlock/DescriptionFactory.php
+++ b/src/DocBlock/DescriptionFactory.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -39,7 +40,6 @@ class DescriptionFactory
     /**
      * Initializes this factory with the means to construct (inline) tags.
      *
-     * @param TagFactory $tagFactory
      */
     public function __construct(TagFactory $tagFactory)
     {
@@ -50,11 +50,10 @@ class DescriptionFactory
      * Returns the parsed text of this description.
      *
      * @param string $contents
-     * @param TypeContext $context
      *
      * @return Description
      */
-    public function create($contents, TypeContext $context = null)
+    public function create(string $contents, TypeContext $context = null): Description
     {
         list($text, $tags) = $this->parse($this->lex($contents), $context);
 
@@ -68,7 +67,7 @@ class DescriptionFactory
      *
      * @return string[] A series of tokens of which the description text is composed.
      */
-    private function lex($contents)
+    private function lex(string $contents)
     {
         $contents = $this->removeSuperfluousStartingWhitespace($contents);
 
@@ -103,7 +102,7 @@ class DescriptionFactory
                 )
             \}/Sux',
             $contents,
-            null,
+            0,
             PREG_SPLIT_DELIM_CAPTURE
         );
     }
@@ -112,7 +111,6 @@ class DescriptionFactory
      * Parses the stream of tokens in to a new set of tokens containing Tags.
      *
      * @param string[] $tokens
-     * @param TypeContext $context
      *
      * @return string[]|Tag[]
      */
@@ -156,7 +154,7 @@ class DescriptionFactory
      *
      * @return string
      */
-    private function removeSuperfluousStartingWhitespace($contents)
+    private function removeSuperfluousStartingWhitespace(string $contents): string
     {
         $lines = explode("\n", $contents);
 

--- a/src/DocBlock/DescriptionFactory.php
+++ b/src/DocBlock/DescriptionFactory.php
@@ -39,7 +39,6 @@ class DescriptionFactory
 
     /**
      * Initializes this factory with the means to construct (inline) tags.
-     *
      */
     public function __construct(TagFactory $tagFactory)
     {
@@ -49,7 +48,6 @@ class DescriptionFactory
     /**
      * Returns the parsed text of this description.
      *
-     * @param string $contents
      *
      * @return Description
      */
@@ -63,7 +61,6 @@ class DescriptionFactory
     /**
      * Strips the contents from superfluous whitespace and splits the description into a series of tokens.
      *
-     * @param string $contents
      *
      * @return string[] A series of tokens of which the description text is composed.
      */
@@ -149,10 +146,6 @@ class DescriptionFactory
      *
      * If we do not normalize the indentation then we have superfluous whitespace on the second and subsequent
      * lines and this may cause rendering issues when, for example, using a Markdown converter.
-     *
-     * @param string $contents
-     *
-     * @return string
      */
     private function removeSuperfluousStartingWhitespace(string $contents): string
     {

--- a/src/DocBlock/DescriptionFactory.php
+++ b/src/DocBlock/DescriptionFactory.php
@@ -49,11 +49,10 @@ class DescriptionFactory
      * Returns the parsed text of this description.
      *
      *
-     * @return Description
      */
-    public function create(string $contents, TypeContext $context = null): Description
+    public function create(string $contents, ?TypeContext $context = null): Description
     {
-        list($text, $tags) = $this->parse($this->lex($contents), $context);
+        [$text, $tags] = $this->parse($this->lex($contents), $context);
 
         return new Description($text, $tags);
     }

--- a/src/DocBlock/DescriptionFactory.php
+++ b/src/DocBlock/DescriptionFactory.php
@@ -47,8 +47,6 @@ class DescriptionFactory
 
     /**
      * Returns the parsed text of this description.
-     *
-     *
      */
     public function create(string $contents, ?TypeContext $context = null): Description
     {

--- a/src/DocBlock/ExampleFinder.php
+++ b/src/DocBlock/ExampleFinder.php
@@ -44,7 +44,7 @@ class ExampleFinder
     /**
      * Registers the project's root directory where an 'examples' folder can be expected.
      */
-    public function setSourceDirectory(string $directory = '')
+    public function setSourceDirectory(string $directory = ''): void
     {
         $this->sourceDirectory = $directory;
     }
@@ -62,7 +62,7 @@ class ExampleFinder
      *
      * @param string[] $directories
      */
-    public function setExampleDirectories(array $directories)
+    public function setExampleDirectories(array $directories): void
     {
         $this->exampleDirectories = $directories;
     }
@@ -89,9 +89,8 @@ class ExampleFinder
      * 4. Checks the path relative to the current working directory for the given filename
      *
      *
-     * @return string|null
      */
-    private function getExampleFileContents(string $filename)
+    private function getExampleFileContents(string $filename): ?string
     {
         $normalizedPath = null;
 

--- a/src/DocBlock/ExampleFinder.php
+++ b/src/DocBlock/ExampleFinder.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -28,11 +29,10 @@ class ExampleFinder
     /**
      * Attempts to find the example contents for the given descriptor.
      *
-     * @param Example $example
      *
      * @return string
      */
-    public function find(Example $example)
+    public function find(Example $example): string
     {
         $filename = $example->getFilePath();
 
@@ -49,9 +49,8 @@ class ExampleFinder
      *
      * @param string $directory
      *
-     * @return void
      */
-    public function setSourceDirectory($directory = '')
+    public function setSourceDirectory(string $directory = '')
     {
         $this->sourceDirectory = $directory;
     }
@@ -61,7 +60,7 @@ class ExampleFinder
      *
      * @return string
      */
-    public function getSourceDirectory()
+    public function getSourceDirectory(): string
     {
         return $this->sourceDirectory;
     }
@@ -101,7 +100,7 @@ class ExampleFinder
      *
      * @return string|null
      */
-    private function getExampleFileContents($filename)
+    private function getExampleFileContents(string $filename)
     {
         $normalizedPath = null;
 
@@ -133,7 +132,7 @@ class ExampleFinder
      *
      * @return string
      */
-    private function getExamplePathFromExampleDirectory($file)
+    private function getExamplePathFromExampleDirectory(string $file): string
     {
         return getcwd() . DIRECTORY_SEPARATOR . 'examples' . DIRECTORY_SEPARATOR . $file;
     }
@@ -146,7 +145,7 @@ class ExampleFinder
      *
      * @return string
      */
-    private function constructExamplePath($directory, $file)
+    private function constructExamplePath(string $directory, string $file): string
     {
         return rtrim($directory, '\\/') . DIRECTORY_SEPARATOR . $file;
     }
@@ -158,7 +157,7 @@ class ExampleFinder
      *
      * @return string
      */
-    private function getExamplePathFromSource($file)
+    private function getExamplePathFromSource(string $file): string
     {
         return sprintf(
             '%s%s%s',

--- a/src/DocBlock/ExampleFinder.php
+++ b/src/DocBlock/ExampleFinder.php
@@ -28,9 +28,6 @@ class ExampleFinder
 
     /**
      * Attempts to find the example contents for the given descriptor.
-     *
-     *
-     * @return string
      */
     public function find(Example $example): string
     {
@@ -46,9 +43,6 @@ class ExampleFinder
 
     /**
      * Registers the project's root directory where an 'examples' folder can be expected.
-     *
-     * @param string $directory
-     *
      */
     public function setSourceDirectory(string $directory = '')
     {
@@ -57,8 +51,6 @@ class ExampleFinder
 
     /**
      * Returns the project's root directory where an 'examples' folder can be expected.
-     *
-     * @return string
      */
     public function getSourceDirectory(): string
     {
@@ -96,7 +88,6 @@ class ExampleFinder
      * 3. Checks the 'examples' folder in the current working directory for examples
      * 4. Checks the path relative to the current working directory for the given filename
      *
-     * @param string $filename
      *
      * @return string|null
      */
@@ -127,10 +118,6 @@ class ExampleFinder
 
     /**
      * Get example filepath based on the example directory inside your project.
-     *
-     * @param string $file
-     *
-     * @return string
      */
     private function getExamplePathFromExampleDirectory(string $file): string
     {
@@ -139,11 +126,6 @@ class ExampleFinder
 
     /**
      * Returns a path to the example file in the given directory..
-     *
-     * @param string $directory
-     * @param string $file
-     *
-     * @return string
      */
     private function constructExamplePath(string $directory, string $file): string
     {
@@ -152,10 +134,6 @@ class ExampleFinder
 
     /**
      * Get example filepath based on sourcecode.
-     *
-     * @param string $file
-     *
-     * @return string
      */
     private function getExamplePathFromSource(string $file): string
     {

--- a/src/DocBlock/ExampleFinder.php
+++ b/src/DocBlock/ExampleFinder.php
@@ -87,8 +87,6 @@ class ExampleFinder
      * 2. Checks the source folder for the given filename
      * 3. Checks the 'examples' folder in the current working directory for examples
      * 4. Checks the path relative to the current working directory for the given filename
-     *
-     *
      */
     private function getExampleFileContents(string $filename): ?string
     {

--- a/src/DocBlock/Serializer.php
+++ b/src/DocBlock/Serializer.php
@@ -14,7 +14,6 @@
 namespace phpDocumentor\Reflection\DocBlock;
 
 use phpDocumentor\Reflection\DocBlock;
-use Webmozart\Assert\Assert;
 
 /**
  * Converts a DocBlock back from an object to a complete DocComment including Asterisks.

--- a/src/DocBlock/Serializer.php
+++ b/src/DocBlock/Serializer.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -44,7 +45,7 @@ class Serializer
      * @param int|null $lineLength The max length of a line or NULL to disable line wrapping.
      * @param DocBlock\Tags\Formatter $tagFormatter A custom tag formatter, defaults to PassthroughFormatter.
      */
-    public function __construct($indent = 0, $indentString = ' ', $indentFirstLine = true, $lineLength = null, $tagFormatter = null)
+    public function __construct(int $indent = 0, string $indentString = ' ', bool $indentFirstLine = true, int $lineLength = null, DocBlock\Tags\Formatter $tagFormatter = null)
     {
         Assert::integer($indent);
         Assert::string($indentString);
@@ -66,7 +67,7 @@ class Serializer
      *
      * @return string The serialized doc block.
      */
-    public function getDocComment(DocBlock $docblock)
+    public function getDocComment(DocBlock $docblock): string
     {
         $indent = str_repeat($this->indentString, $this->indent);
         $firstIndent = $this->isFirstLineIndented ? $indent : '';
@@ -114,11 +115,10 @@ class Serializer
     }
 
     /**
-     * @param DocBlock $docblock
      * @param $wrapLength
      * @return string
      */
-    private function getSummaryAndDescriptionTextBlock(DocBlock $docblock, $wrapLength)
+    private function getSummaryAndDescriptionTextBlock(DocBlock $docblock, $wrapLength): string
     {
         $text = $docblock->getSummary() . ((string)$docblock->getDescription() ? "\n\n" . $docblock->getDescription()
                 : '');
@@ -131,13 +131,12 @@ class Serializer
     }
 
     /**
-     * @param DocBlock $docblock
      * @param $wrapLength
      * @param $indent
      * @param $comment
      * @return string
      */
-    private function addTagBlock(DocBlock $docblock, $wrapLength, $indent, $comment)
+    private function addTagBlock(DocBlock $docblock, $wrapLength, $indent, $comment): string
     {
         foreach ($docblock->getTags() as $tag) {
             $tagText = $this->tagFormatter->format($tag);

--- a/src/DocBlock/Serializer.php
+++ b/src/DocBlock/Serializer.php
@@ -45,14 +45,8 @@ class Serializer
      * @param int|null $lineLength The max length of a line or NULL to disable line wrapping.
      * @param DocBlock\Tags\Formatter $tagFormatter A custom tag formatter, defaults to PassthroughFormatter.
      */
-    public function __construct(int $indent = 0, string $indentString = ' ', bool $indentFirstLine = true, int $lineLength = null, DocBlock\Tags\Formatter $tagFormatter = null)
+    public function __construct(int $indent = 0, string $indentString = ' ', bool $indentFirstLine = true, ?int $lineLength = null, ?DocBlock\Tags\Formatter $tagFormatter = null)
     {
-        Assert::integer($indent);
-        Assert::string($indentString);
-        Assert::boolean($indentFirstLine);
-        Assert::nullOrInteger($lineLength);
-        Assert::nullOrIsInstanceOf($tagFormatter, 'phpDocumentor\Reflection\DocBlock\Tags\Formatter');
-
         $this->indent = $indent;
         $this->indentString = $indentString;
         $this->isFirstLineIndented = $indentFirstLine;

--- a/src/DocBlock/Serializer.php
+++ b/src/DocBlock/Serializer.php
@@ -88,8 +88,6 @@ class Serializer
     }
 
     /**
-     * @param $indent
-     * @param $text
      * @return mixed
      */
     private function removeTrailingSpaces($indent, $text)
@@ -98,8 +96,6 @@ class Serializer
     }
 
     /**
-     * @param $indent
-     * @param $text
      * @return mixed
      */
     private function addAsterisksForEachLine($indent, $text)
@@ -107,10 +103,6 @@ class Serializer
         return str_replace("\n", "\n{$indent} * ", $text);
     }
 
-    /**
-     * @param $wrapLength
-     * @return string
-     */
     private function getSummaryAndDescriptionTextBlock(DocBlock $docblock, $wrapLength): string
     {
         $text = $docblock->getSummary() . ((string)$docblock->getDescription() ? "\n\n" . $docblock->getDescription()
@@ -123,12 +115,6 @@ class Serializer
         return $text;
     }
 
-    /**
-     * @param $wrapLength
-     * @param $indent
-     * @param $comment
-     * @return string
-     */
     private function addTagBlock(DocBlock $docblock, $wrapLength, $indent, $comment): string
     {
         foreach ($docblock->getTags() as $tag) {

--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -87,7 +88,6 @@ final class StandardTagFactory implements TagFactory
      * If no tag handlers are provided than the default list in the {@see self::$tagHandlerMappings} property
      * is used.
      *
-     * @param FqsenResolver $fqsenResolver
      * @param string[]      $tagHandlers
      *
      * @see self::registerTagHandler() to add a new tag handler to the existing default list.
@@ -105,7 +105,7 @@ final class StandardTagFactory implements TagFactory
     /**
      * {@inheritDoc}
      */
-    public function create($tagLine, TypeContext $context = null)
+    public function create(string $tagLine, TypeContext $context = null): Tag
     {
         if (! $context) {
             $context = new TypeContext('');
@@ -125,7 +125,7 @@ final class StandardTagFactory implements TagFactory
     /**
      * {@inheritDoc}
      */
-    public function addParameter($name, $value)
+    public function addParameter(string $name, $value)
     {
         $this->serviceLocator[$name] = $value;
     }
@@ -141,7 +141,7 @@ final class StandardTagFactory implements TagFactory
     /**
      * {@inheritDoc}
      */
-    public function registerTagHandler($tagName, $handler)
+    public function registerTagHandler(string $tagName, string $handler)
     {
         Assert::stringNotEmpty($tagName);
         Assert::stringNotEmpty($handler);
@@ -164,7 +164,7 @@ final class StandardTagFactory implements TagFactory
      *
      * @return string[]
      */
-    private function extractTagParts($tagLine)
+    private function extractTagParts(string $tagLine)
     {
         $matches = [];
         if (! preg_match('/^@(' . self::REGEX_TAGNAME . ')(?:\s*([^\s].*)|$)/us', $tagLine, $matches)) {
@@ -186,11 +186,10 @@ final class StandardTagFactory implements TagFactory
      *
      * @param string  $body
      * @param string  $name
-     * @param TypeContext $context
      *
      * @return Tag|null
      */
-    private function createTag($body, $name, TypeContext $context)
+    private function createTag(string $body, string $name, TypeContext $context)
     {
         $handlerClassName = $this->findHandlerClassName($name, $context);
         $arguments        = $this->getArgumentsForParametersFromWiring(
@@ -205,11 +204,10 @@ final class StandardTagFactory implements TagFactory
      * Determines the Fully Qualified Class Name of the Factory or Tag (containing a Factory Method `create`).
      *
      * @param string  $tagName
-     * @param TypeContext $context
      *
      * @return string
      */
-    private function findHandlerClassName($tagName, TypeContext $context)
+    private function findHandlerClassName(string $tagName, TypeContext $context): string
     {
         $handlerClassName = Generic::class;
         if (isset($this->tagHandlerMappings[$tagName])) {
@@ -264,7 +262,7 @@ final class StandardTagFactory implements TagFactory
      *
      * @return \ReflectionParameter[]
      */
-    private function fetchParametersForHandlerFactoryMethod($handlerClassName)
+    private function fetchParametersForHandlerFactoryMethod(string $handlerClassName)
     {
         if (! isset($this->tagHandlerParameterCache[$handlerClassName])) {
             $methodReflection                                  = new \ReflectionMethod($handlerClassName, 'create');
@@ -284,7 +282,7 @@ final class StandardTagFactory implements TagFactory
      *
      * @return mixed[]
      */
-    private function getServiceLocatorWithDynamicParameters(TypeContext $context, $tagName, $tagBody)
+    private function getServiceLocatorWithDynamicParameters(TypeContext $context, string $tagName, string $tagBody)
     {
         $locator = array_merge(
             $this->serviceLocator,
@@ -307,7 +305,7 @@ final class StandardTagFactory implements TagFactory
      *
      * @return bool
      */
-    private function isAnnotation($tagContent)
+    private function isAnnotation(string $tagContent): bool
     {
         // 1. Contains a namespace separator
         // 2. Contains parenthesis

--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -160,7 +160,6 @@ final class StandardTagFactory implements TagFactory
     /**
      * Extracts all components for a tag.
      *
-     * @param string $tagLine
      *
      * @return string[]
      */
@@ -184,8 +183,6 @@ final class StandardTagFactory implements TagFactory
      * Creates a new tag object with the given name and body or returns null if the tag name was recognized but the
      * body was invalid.
      *
-     * @param string  $body
-     * @param string  $name
      *
      * @return Tag|null
      */
@@ -202,10 +199,6 @@ final class StandardTagFactory implements TagFactory
 
     /**
      * Determines the Fully Qualified Class Name of the Factory or Tag (containing a Factory Method `create`).
-     *
-     * @param string  $tagName
-     *
-     * @return string
      */
     private function findHandlerClassName(string $tagName, TypeContext $context): string
     {
@@ -258,7 +251,6 @@ final class StandardTagFactory implements TagFactory
      * Retrieves a series of ReflectionParameter objects for the static 'create' method of the given
      * tag handler class name.
      *
-     * @param string $handlerClassName
      *
      * @return \ReflectionParameter[]
      */
@@ -299,11 +291,8 @@ final class StandardTagFactory implements TagFactory
     /**
      * Returns whether the given tag belongs to an annotation.
      *
-     * @param string $tagContent
      *
      * @todo this method should be populated once we implement Annotation notation support.
-     *
-     * @return bool
      */
     private function isAnnotation(string $tagContent): bool
     {

--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -39,7 +39,7 @@ use Webmozart\Assert\Assert;
 final class StandardTagFactory implements TagFactory
 {
     /** PCRE regular expression matching a tag name. */
-    const REGEX_TAGNAME = '[\w\-\_\\\\]+';
+    public const REGEX_TAGNAME = '[\w\-\_\\\\]+';
 
     /**
      * @var string[] An array with a tag as a key, and an FQCN to a class that handles it as an array value.
@@ -92,7 +92,7 @@ final class StandardTagFactory implements TagFactory
      *
      * @see self::registerTagHandler() to add a new tag handler to the existing default list.
      */
-    public function __construct(FqsenResolver $fqsenResolver, array $tagHandlers = null)
+    public function __construct(FqsenResolver $fqsenResolver, ?array $tagHandlers = null)
     {
         $this->fqsenResolver = $fqsenResolver;
         if ($tagHandlers !== null) {
@@ -105,13 +105,13 @@ final class StandardTagFactory implements TagFactory
     /**
      * {@inheritDoc}
      */
-    public function create(string $tagLine, TypeContext $context = null): Tag
+    public function create(string $tagLine, ?TypeContext $context = null): Tag
     {
         if (! $context) {
             $context = new TypeContext('');
         }
 
-        list($tagName, $tagBody) = $this->extractTagParts($tagLine);
+        [$tagName, $tagBody] = $this->extractTagParts($tagLine);
 
         if ($tagBody !== '' && $tagBody[0] === '[') {
             throw new \InvalidArgumentException(
@@ -125,7 +125,7 @@ final class StandardTagFactory implements TagFactory
     /**
      * {@inheritDoc}
      */
-    public function addParameter(string $name, $value)
+    public function addParameter(string $name, $value): void
     {
         $this->serviceLocator[$name] = $value;
     }
@@ -133,7 +133,7 @@ final class StandardTagFactory implements TagFactory
     /**
      * {@inheritDoc}
      */
-    public function addService($service, $alias = null)
+    public function addService($service, $alias = null): void
     {
         $this->serviceLocator[$alias ?: get_class($service)] = $service;
     }
@@ -141,7 +141,7 @@ final class StandardTagFactory implements TagFactory
     /**
      * {@inheritDoc}
      */
-    public function registerTagHandler(string $tagName, string $handler)
+    public function registerTagHandler(string $tagName, string $handler): void
     {
         Assert::stringNotEmpty($tagName);
         Assert::stringNotEmpty($handler);
@@ -184,9 +184,8 @@ final class StandardTagFactory implements TagFactory
      * body was invalid.
      *
      *
-     * @return Tag|null
      */
-    private function createTag(string $body, string $name, TypeContext $context)
+    private function createTag(string $body, string $name, TypeContext $context): ?Tag
     {
         $handlerClassName = $this->findHandlerClassName($name, $context);
         $arguments        = $this->getArgumentsForParametersFromWiring(

--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -182,8 +182,6 @@ final class StandardTagFactory implements TagFactory
     /**
      * Creates a new tag object with the given name and body or returns null if the tag name was recognized but the
      * body was invalid.
-     *
-     *
      */
     private function createTag(string $body, string $name, TypeContext $context): ?Tag
     {

--- a/src/DocBlock/Tag.php
+++ b/src/DocBlock/Tag.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -18,7 +19,7 @@ interface Tag
 {
     public function getName();
 
-    public static function create($body);
+    public static function create(string $body);
 
     public function render(Formatter $formatter = null);
 

--- a/src/DocBlock/Tag.php
+++ b/src/DocBlock/Tag.php
@@ -17,11 +17,14 @@ use phpDocumentor\Reflection\DocBlock\Tags\Formatter;
 
 interface Tag
 {
-    public function getName();
+    public function getName(): string;
 
+    /**
+     * @return Tag Class that implements Tag
+     */
     public static function create(string $body);
 
-    public function render(Formatter $formatter = null);
+    public function render(?Formatter $formatter = null): string;
 
-    public function __toString();
+    public function __toString(): string;
 }

--- a/src/DocBlock/Tag.php
+++ b/src/DocBlock/Tag.php
@@ -20,7 +20,7 @@ interface Tag
     public function getName(): string;
 
     /**
-     * @return Tag Class that implements Tag
+     * @return Tag|mixed Class that implements Tag
      */
     public static function create(string $body);
 

--- a/src/DocBlock/TagFactory.php
+++ b/src/DocBlock/TagFactory.php
@@ -67,7 +67,7 @@ interface TagFactory
      *
      * @return Tag A new tag object.
      */
-    public function create(string $tagLine, TypeContext $context = null): Tag;
+    public function create(string $tagLine, TypeContext $context = null): ?Tag;
 
     /**
      * Registers a handler for tags.

--- a/src/DocBlock/TagFactory.php
+++ b/src/DocBlock/TagFactory.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -39,7 +40,7 @@ interface TagFactory
      *
      * @return void
      */
-    public function addParameter($name, $value);
+    public function addParameter(string $name, $value);
 
     /**
      * Registers a service with the Service Locator using the FQCN of the class or the alias, if provided.
@@ -61,13 +62,12 @@ interface TagFactory
      * Factory method responsible for instantiating the correct sub type.
      *
      * @param string $tagLine The text for this tag, including description.
-     * @param TypeContext $context
      *
      * @throws \InvalidArgumentException if an invalid tag line was presented.
      *
      * @return Tag A new tag object.
      */
-    public function create($tagLine, TypeContext $context = null);
+    public function create(string $tagLine, TypeContext $context = null): Tag;
 
     /**
      * Registers a handler for tags.
@@ -89,5 +89,5 @@ interface TagFactory
      *
      * @return void
      */
-    public function registerTagHandler($tagName, $handler);
+    public function registerTagHandler(string $tagName, string $handler);
 }

--- a/src/DocBlock/TagFactory.php
+++ b/src/DocBlock/TagFactory.php
@@ -37,8 +37,6 @@ interface TagFactory
      *
      * @param string $name
      * @param mixed  $value
-     *
-     * @return void
      */
     public function addParameter(string $name, $value);
 
@@ -52,9 +50,6 @@ interface TagFactory
      * interface is passed as alias then every time that interface is requested the provided service will be returned.
      *
      * @param object $service
-     * @param string $alias
-     *
-     * @return void
      */
     public function addService($service);
 
@@ -86,8 +81,6 @@ interface TagFactory
      * @throws \InvalidArgumentException if the handler is not a string
      * @throws \InvalidArgumentException if the handler is not an existing class
      * @throws \InvalidArgumentException if the handler does not implement the {@see Tag} interface
-     *
-     * @return void
      */
     public function registerTagHandler(string $tagName, string $handler);
 }

--- a/src/DocBlock/TagFactory.php
+++ b/src/DocBlock/TagFactory.php
@@ -35,10 +35,9 @@ interface TagFactory
      *
      * These parameters are injected at the last moment and will override any existing parameter with those names.
      *
-     * @param string $name
      * @param mixed  $value
      */
-    public function addParameter(string $name, $value);
+    public function addParameter(string $name, $value): void;
 
     /**
      * Registers a service with the Service Locator using the FQCN of the class or the alias, if provided.
@@ -51,7 +50,7 @@ interface TagFactory
      *
      * @param object $service
      */
-    public function addService($service);
+    public function addService($service): void;
 
     /**
      * Factory method responsible for instantiating the correct sub type.
@@ -62,7 +61,7 @@ interface TagFactory
      *
      * @return Tag A new tag object.
      */
-    public function create(string $tagLine, TypeContext $context = null): ?Tag;
+    public function create(string $tagLine, ?TypeContext $context = null): ?Tag;
 
     /**
      * Registers a handler for tags.
@@ -82,5 +81,5 @@ interface TagFactory
      * @throws \InvalidArgumentException if the handler is not an existing class
      * @throws \InvalidArgumentException if the handler does not implement the {@see Tag} interface
      */
-    public function registerTagHandler(string $tagName, string $handler);
+    public function registerTagHandler(string $tagName, string $handler): void;
 }

--- a/src/DocBlock/Tags/Author.php
+++ b/src/DocBlock/Tags/Author.php
@@ -30,9 +30,6 @@ final class Author extends BaseTag implements Factory\StaticMethod
 
     /**
      * Initializes this tag with the author name and e-mail.
-     *
-     * @param string $authorName
-     * @param string $authorEmail
      */
     public function __construct(string $authorName, string $authorEmail)
     {
@@ -66,8 +63,6 @@ final class Author extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns this tag in string form.
-     *
-     * @return string
      */
     public function __toString(): string
     {
@@ -77,7 +72,6 @@ final class Author extends BaseTag implements Factory\StaticMethod
     /**
      * Attempts to create a new Author object based on †he tag body.
      *
-     * @param string $body
      *
      * @return static
      */

--- a/src/DocBlock/Tags/Author.php
+++ b/src/DocBlock/Tags/Author.php
@@ -84,8 +84,6 @@ final class Author extends BaseTag implements Factory\StaticMethod
      */
     public static function create(string $body)
     {
-        Assert::string($body);
-
         $splitTagContent = preg_match('/^([^\<]*)(?:\<([^\>]*)\>)?$/u', $body, $matches);
         if (!$splitTagContent) {
             return null;

--- a/src/DocBlock/Tags/Author.php
+++ b/src/DocBlock/Tags/Author.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -34,7 +35,7 @@ final class Author extends BaseTag implements Factory\StaticMethod
      * @param string $authorName
      * @param string $authorEmail
      */
-    public function __construct($authorName, $authorEmail)
+    public function __construct(string $authorName, string $authorEmail)
     {
         Assert::string($authorName);
         Assert::string($authorEmail);
@@ -51,7 +52,7 @@ final class Author extends BaseTag implements Factory\StaticMethod
      *
      * @return string The author's name.
      */
-    public function getAuthorName()
+    public function getAuthorName(): string
     {
         return $this->authorName;
     }
@@ -61,7 +62,7 @@ final class Author extends BaseTag implements Factory\StaticMethod
      *
      * @return string The author's email.
      */
-    public function getEmail()
+    public function getEmail(): string
     {
         return $this->authorEmail;
     }
@@ -71,7 +72,7 @@ final class Author extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->authorName . (strlen($this->authorEmail) ? ' <' . $this->authorEmail . '>' : '');
     }
@@ -83,7 +84,7 @@ final class Author extends BaseTag implements Factory\StaticMethod
      *
      * @return static
      */
-    public static function create($body)
+    public static function create(string $body)
     {
         Assert::string($body);
 

--- a/src/DocBlock/Tags/Author.php
+++ b/src/DocBlock/Tags/Author.php
@@ -37,8 +37,6 @@ final class Author extends BaseTag implements Factory\StaticMethod
      */
     public function __construct(string $authorName, string $authorEmail)
     {
-        Assert::string($authorName);
-        Assert::string($authorEmail);
         if ($authorEmail && !filter_var($authorEmail, FILTER_VALIDATE_EMAIL)) {
             throw new \InvalidArgumentException('The author tag does not have a valid e-mail address');
         }

--- a/src/DocBlock/Tags/Author.php
+++ b/src/DocBlock/Tags/Author.php
@@ -13,7 +13,6 @@
 
 namespace phpDocumentor\Reflection\DocBlock\Tags;
 
-
 /**
  * Reflection class for an {@}author tag in a Docblock.
  */

--- a/src/DocBlock/Tags/Author.php
+++ b/src/DocBlock/Tags/Author.php
@@ -13,7 +13,6 @@
 
 namespace phpDocumentor\Reflection\DocBlock\Tags;
 
-use Webmozart\Assert\Assert;
 
 /**
  * Reflection class for an {@}author tag in a Docblock.

--- a/src/DocBlock/Tags/BaseTag.php
+++ b/src/DocBlock/Tags/BaseTag.php
@@ -24,7 +24,7 @@ abstract class BaseTag implements DocBlock\Tag
     /** @var string Name of the tag */
     protected $name = '';
 
-    /** @var Description|null Description of the tag. */
+    /** @var Description|string|null Description of the tag. */
     protected $description;
 
     /**

--- a/src/DocBlock/Tags/BaseTag.php
+++ b/src/DocBlock/Tags/BaseTag.php
@@ -42,7 +42,7 @@ abstract class BaseTag implements DocBlock\Tag
         return $this->description;
     }
 
-    public function render(Formatter $formatter = null)
+    public function render(?Formatter $formatter = null): string
     {
         if ($formatter === null) {
             $formatter = new Formatter\PassthroughFormatter();

--- a/src/DocBlock/Tags/BaseTag.php
+++ b/src/DocBlock/Tags/BaseTag.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -31,7 +32,7 @@ abstract class BaseTag implements DocBlock\Tag
      *
      * @return string The name of this tag.
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/src/DocBlock/Tags/Covers.php
+++ b/src/DocBlock/Tags/Covers.php
@@ -33,7 +33,7 @@ final class Covers extends BaseTag implements Factory\StaticMethod
     /**
      * Initializes this tag.
      */
-    public function __construct(Fqsen $refers, Description $description = null)
+    public function __construct(Fqsen $refers, ?Description $description = null)
     {
         $this->refers = $refers;
         $this->description = $description;
@@ -44,9 +44,9 @@ final class Covers extends BaseTag implements Factory\StaticMethod
      */
     public static function create(
         string $body,
-        DescriptionFactory $descriptionFactory = null,
-        FqsenResolver $resolver = null,
-        TypeContext $context = null
+        ?DescriptionFactory $descriptionFactory = null,
+        ?FqsenResolver $resolver = null,
+        ?TypeContext $context = null
     ) {
         Assert::notEmpty($body);
 
@@ -61,7 +61,6 @@ final class Covers extends BaseTag implements Factory\StaticMethod
     /**
      * Returns the structural element this tag refers to.
      *
-     * @return Fqsen
      */
     public function getReference(): Fqsen
     {

--- a/src/DocBlock/Tags/Covers.php
+++ b/src/DocBlock/Tags/Covers.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -32,7 +33,6 @@ final class Covers extends BaseTag implements Factory\StaticMethod
     /**
      * Initializes this tag.
      *
-     * @param Fqsen $refers
      * @param Description $description
      */
     public function __construct(Fqsen $refers, Description $description = null)
@@ -45,7 +45,7 @@ final class Covers extends BaseTag implements Factory\StaticMethod
      * {@inheritdoc}
      */
     public static function create(
-        $body,
+        string $body,
         DescriptionFactory $descriptionFactory = null,
         FqsenResolver $resolver = null,
         TypeContext $context = null
@@ -57,7 +57,7 @@ final class Covers extends BaseTag implements Factory\StaticMethod
 
         return new static(
             $resolver->resolve($parts[0], $context),
-            $descriptionFactory->create(isset($parts[1]) ? $parts[1] : '', $context)
+            $descriptionFactory->create($parts[1] ?? '', $context)
         );
     }
 
@@ -66,7 +66,7 @@ final class Covers extends BaseTag implements Factory\StaticMethod
      *
      * @return Fqsen
      */
-    public function getReference()
+    public function getReference(): Fqsen
     {
         return $this->refers;
     }
@@ -76,7 +76,7 @@ final class Covers extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->refers . ($this->description ? ' ' . $this->description->render() : '');
     }

--- a/src/DocBlock/Tags/Covers.php
+++ b/src/DocBlock/Tags/Covers.php
@@ -50,7 +50,6 @@ final class Covers extends BaseTag implements Factory\StaticMethod
         FqsenResolver $resolver = null,
         TypeContext $context = null
     ) {
-        Assert::string($body);
         Assert::notEmpty($body);
 
         $parts = preg_split('/\s+/Su', $body, 2);

--- a/src/DocBlock/Tags/Covers.php
+++ b/src/DocBlock/Tags/Covers.php
@@ -60,7 +60,6 @@ final class Covers extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns the structural element this tag refers to.
-     *
      */
     public function getReference(): Fqsen
     {

--- a/src/DocBlock/Tags/Covers.php
+++ b/src/DocBlock/Tags/Covers.php
@@ -32,8 +32,6 @@ final class Covers extends BaseTag implements Factory\StaticMethod
 
     /**
      * Initializes this tag.
-     *
-     * @param Description $description
      */
     public function __construct(Fqsen $refers, Description $description = null)
     {
@@ -72,8 +70,6 @@ final class Covers extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns a string representation of this tag.
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/src/DocBlock/Tags/Deprecated.php
+++ b/src/DocBlock/Tags/Deprecated.php
@@ -29,7 +29,7 @@ final class Deprecated extends BaseTag implements Factory\StaticMethod
      * PCRE regular expression matching a version vector.
      * Assumes the "x" modifier.
      */
-    const REGEX_VECTOR = '(?:
+    public const REGEX_VECTOR = '(?:
         # Normal release vectors.
         \d\S*
         |
@@ -44,7 +44,7 @@ final class Deprecated extends BaseTag implements Factory\StaticMethod
     /** @var string The version vector. */
     private $version = '';
 
-    public function __construct($version = null, Description $description = null)
+    public function __construct($version = null, ?Description $description = null)
     {
         Assert::nullOrStringNotEmpty($version);
 
@@ -57,8 +57,8 @@ final class Deprecated extends BaseTag implements Factory\StaticMethod
      */
     public static function create(
         ?string $body,
-        DescriptionFactory $descriptionFactory = null,
-        TypeContext $context = null
+        ?DescriptionFactory $descriptionFactory = null,
+        ?TypeContext $context = null
     ) {
         if (empty($body)) {
             return new static();
@@ -81,9 +81,8 @@ final class Deprecated extends BaseTag implements Factory\StaticMethod
     /**
      * Gets the version section of the tag.
      *
-     * @return string|null
      */
-    public function getVersion()
+    public function getVersion(): ?string
     {
         return $this->version;
     }

--- a/src/DocBlock/Tags/Deprecated.php
+++ b/src/DocBlock/Tags/Deprecated.php
@@ -80,7 +80,6 @@ final class Deprecated extends BaseTag implements Factory\StaticMethod
 
     /**
      * Gets the version section of the tag.
-     *
      */
     public function getVersion(): ?string
     {

--- a/src/DocBlock/Tags/Deprecated.php
+++ b/src/DocBlock/Tags/Deprecated.php
@@ -56,11 +56,10 @@ final class Deprecated extends BaseTag implements Factory\StaticMethod
      * @return static
      */
     public static function create(
-        string $body,
+        ?string $body,
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
     ) {
-        Assert::nullOrString($body);
         if (empty($body)) {
             return new static();
         }
@@ -82,17 +81,15 @@ final class Deprecated extends BaseTag implements Factory\StaticMethod
     /**
      * Gets the version section of the tag.
      *
-     * @return string
+     * @return string|null
      */
-    public function getVersion(): string
+    public function getVersion()
     {
         return $this->version;
     }
 
     /**
      * Returns a string representation for this tag.
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/src/DocBlock/Tags/Deprecated.php
+++ b/src/DocBlock/Tags/Deprecated.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -54,8 +55,11 @@ final class Deprecated extends BaseTag implements Factory\StaticMethod
     /**
      * @return static
      */
-    public static function create($body, DescriptionFactory $descriptionFactory = null, TypeContext $context = null)
-    {
+    public static function create(
+        string $body,
+        DescriptionFactory $descriptionFactory = null,
+        TypeContext $context = null
+    ) {
         Assert::nullOrString($body);
         if (empty($body)) {
             return new static();
@@ -71,7 +75,7 @@ final class Deprecated extends BaseTag implements Factory\StaticMethod
 
         return new static(
             $matches[1],
-            $descriptionFactory->create(isset($matches[2]) ? $matches[2] : '', $context)
+            $descriptionFactory->create($matches[2] ?? '', $context)
         );
     }
 
@@ -80,7 +84,7 @@ final class Deprecated extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function getVersion()
+    public function getVersion(): string
     {
         return $this->version;
     }
@@ -90,7 +94,7 @@ final class Deprecated extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->version . ($this->description ? ' ' . $this->description->render() : '');
     }

--- a/src/DocBlock/Tags/Example.php
+++ b/src/DocBlock/Tags/Example.php
@@ -138,8 +138,6 @@ final class Example extends BaseTag
 
     /**
      * Returns a string representation for this tag.
-     *
-     * @return string
      */
     public function __toString(): string
     {
@@ -148,27 +146,17 @@ final class Example extends BaseTag
 
     /**
      * Returns true if the provided URI is relative or contains a complete scheme (and thus is absolute).
-     *
-     * @param string $uri
-     *
-     * @return bool
      */
     private function isUriRelative(string $uri): bool
     {
         return false === strpos($uri, ':');
     }
 
-    /**
-     * @return int
-     */
     public function getStartingLine(): int
     {
         return $this->startingLine;
     }
 
-    /**
-     * @return int
-     */
     public function getLineCount(): int
     {
         return $this->lineCount;

--- a/src/DocBlock/Tags/Example.php
+++ b/src/DocBlock/Tags/Example.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -42,10 +43,9 @@ final class Example extends BaseTag
      */
     private $lineCount;
 
-    public function __construct($filePath, $isURI, $startingLine, $lineCount, $description)
+    public function __construct(string $filePath, bool $isURI, int $startingLine, $lineCount, $description)
     {
         Assert::notEmpty($filePath);
-        Assert::integer($startingLine);
         Assert::greaterThanEq($startingLine, 0);
 
         $this->filePath = $filePath;
@@ -53,7 +53,7 @@ final class Example extends BaseTag
         $this->lineCount = $lineCount;
         $this->name = 'example';
         if ($description !== null) {
-            $this->description = trim($description);
+            $this->description = trim((string) $description);
         }
 
         $this->isURI = $isURI;
@@ -81,7 +81,7 @@ final class Example extends BaseTag
     /**
      * {@inheritdoc}
      */
-    public static function create($body)
+    public static function create(string $body)
     {
         // File component: File path in quotes or File URI / Source information
         if (! preg_match('/^(?:\"([^\"]+)\"|(\S+))(?:\s+(.*))?$/sux', $body, $matches)) {
@@ -131,7 +131,7 @@ final class Example extends BaseTag
      * @return string Path to a file to use as an example.
      *     May also be an absolute URI.
      */
-    public function getFilePath()
+    public function getFilePath(): string
     {
         return $this->filePath;
     }
@@ -141,7 +141,7 @@ final class Example extends BaseTag
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->filePath . ($this->description ? ' ' . $this->description : '');
     }
@@ -153,7 +153,7 @@ final class Example extends BaseTag
      *
      * @return bool
      */
-    private function isUriRelative($uri)
+    private function isUriRelative(string $uri): bool
     {
         return false === strpos($uri, ':');
     }
@@ -161,7 +161,7 @@ final class Example extends BaseTag
     /**
      * @return int
      */
-    public function getStartingLine()
+    public function getStartingLine(): int
     {
         return $this->startingLine;
     }
@@ -169,7 +169,7 @@ final class Example extends BaseTag
     /**
      * @return int
      */
-    public function getLineCount()
+    public function getLineCount(): int
     {
         return $this->lineCount;
     }

--- a/src/DocBlock/Tags/Factory/StaticMethod.php
+++ b/src/DocBlock/Tags/Factory/StaticMethod.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -14,5 +15,5 @@ namespace phpDocumentor\Reflection\DocBlock\Tags\Factory;
 
 interface StaticMethod
 {
-    public static function create($body);
+    public static function create(string $body);
 }

--- a/src/DocBlock/Tags/Factory/StaticMethod.php
+++ b/src/DocBlock/Tags/Factory/StaticMethod.php
@@ -15,5 +15,8 @@ namespace phpDocumentor\Reflection\DocBlock\Tags\Factory;
 
 interface StaticMethod
 {
+    /**
+     * @return mixed
+     */
     public static function create(string $body);
 }

--- a/src/DocBlock/Tags/Factory/Strategy.php
+++ b/src/DocBlock/Tags/Factory/Strategy.php
@@ -15,5 +15,5 @@ namespace phpDocumentor\Reflection\DocBlock\Tags\Factory;
 
 interface Strategy
 {
-    public function create($body);
+    public function create($body): void;
 }

--- a/src/DocBlock/Tags/Factory/Strategy.php
+++ b/src/DocBlock/Tags/Factory/Strategy.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/src/DocBlock/Tags/Formatter.php
+++ b/src/DocBlock/Tags/Formatter.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -19,9 +20,8 @@ interface Formatter
     /**
      * Formats a tag into a string representation according to a specific format, such as Markdown.
      *
-     * @param Tag $tag
      *
      * @return string
      */
-    public function format(Tag $tag);
+    public function format(Tag $tag): string;
 }

--- a/src/DocBlock/Tags/Formatter.php
+++ b/src/DocBlock/Tags/Formatter.php
@@ -21,7 +21,6 @@ interface Formatter
      * Formats a tag into a string representation according to a specific format, such as Markdown.
      *
      *
-     * @return string
      */
     public function format(Tag $tag): string;
 }

--- a/src/DocBlock/Tags/Formatter.php
+++ b/src/DocBlock/Tags/Formatter.php
@@ -19,8 +19,6 @@ interface Formatter
 {
     /**
      * Formats a tag into a string representation according to a specific format, such as Markdown.
-     *
-     *
      */
     public function format(Tag $tag): string;
 }

--- a/src/DocBlock/Tags/Formatter/AlignFormatter.php
+++ b/src/DocBlock/Tags/Formatter/AlignFormatter.php
@@ -36,9 +36,6 @@ class AlignFormatter implements Formatter
 
     /**
      * Formats the given tag to return a simple plain text version.
-     *
-     *
-     * @return string
      */
     public function format(Tag $tag): string
     {

--- a/src/DocBlock/Tags/Formatter/AlignFormatter.php
+++ b/src/DocBlock/Tags/Formatter/AlignFormatter.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -36,11 +37,10 @@ class AlignFormatter implements Formatter
     /**
      * Formats the given tag to return a simple plain text version.
      *
-     * @param Tag $tag
      *
      * @return string
      */
-    public function format(Tag $tag)
+    public function format(Tag $tag): string
     {
         return '@' . $tag->getName() . str_repeat(' ', $this->maxLen - strlen($tag->getName()) + 1) . (string)$tag;
     }

--- a/src/DocBlock/Tags/Formatter/PassthroughFormatter.php
+++ b/src/DocBlock/Tags/Formatter/PassthroughFormatter.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -20,11 +21,10 @@ class PassthroughFormatter implements Formatter
     /**
      * Formats the given tag to return a simple plain text version.
      *
-     * @param Tag $tag
      *
      * @return string
      */
-    public function format(Tag $tag)
+    public function format(Tag $tag): string
     {
         return trim('@' . $tag->getName() . ' ' . (string)$tag);
     }

--- a/src/DocBlock/Tags/Formatter/PassthroughFormatter.php
+++ b/src/DocBlock/Tags/Formatter/PassthroughFormatter.php
@@ -20,9 +20,6 @@ class PassthroughFormatter implements Formatter
 {
     /**
      * Formats the given tag to return a simple plain text version.
-     *
-     *
-     * @return string
      */
     public function format(Tag $tag): string
     {

--- a/src/DocBlock/Tags/Generic.php
+++ b/src/DocBlock/Tags/Generic.php
@@ -53,7 +53,6 @@ class Generic extends BaseTag implements Factory\StaticMethod
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
     ) {
-        Assert::string($body);
         Assert::stringNotEmpty($name);
         Assert::notNull($descriptionFactory);
 

--- a/src/DocBlock/Tags/Generic.php
+++ b/src/DocBlock/Tags/Generic.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -29,7 +30,7 @@ class Generic extends BaseTag implements Factory\StaticMethod
      * @param string $name Name of the tag.
      * @param Description $description The contents of the given tag.
      */
-    public function __construct($name, Description $description = null)
+    public function __construct(string $name, Description $description = null)
     {
         $this->validateTagName($name);
 
@@ -42,14 +43,13 @@ class Generic extends BaseTag implements Factory\StaticMethod
      *
      * @param string             $body
      * @param string             $name
-     * @param DescriptionFactory $descriptionFactory
      * @param TypeContext        $context
      *
      * @return static
      */
     public static function create(
-        $body,
-        $name = '',
+        string $body,
+        string $name = '',
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
     ) {
@@ -67,7 +67,7 @@ class Generic extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return ($this->description ? $this->description->render() : '');
     }
@@ -77,9 +77,8 @@ class Generic extends BaseTag implements Factory\StaticMethod
      *
      * @param string $name
      *
-     * @return void
      */
-    private function validateTagName($name)
+    private function validateTagName(string $name)
     {
         if (! preg_match('/^' . StandardTagFactory::REGEX_TAGNAME . '$/u', $name)) {
             throw new \InvalidArgumentException(

--- a/src/DocBlock/Tags/Generic.php
+++ b/src/DocBlock/Tags/Generic.php
@@ -68,7 +68,7 @@ class Generic extends BaseTag implements Factory\StaticMethod
      */
     public function __toString(): string
     {
-        return ($this->description ? $this->description->render() : '');
+        return $this->description ? $this->description->render() : '';
     }
 
     /**

--- a/src/DocBlock/Tags/Generic.php
+++ b/src/DocBlock/Tags/Generic.php
@@ -30,7 +30,7 @@ class Generic extends BaseTag implements Factory\StaticMethod
      * @param string $name Name of the tag.
      * @param Description $description The contents of the given tag.
      */
-    public function __construct(string $name, Description $description = null)
+    public function __construct(string $name, ?Description $description = null)
     {
         $this->validateTagName($name);
 
@@ -47,8 +47,8 @@ class Generic extends BaseTag implements Factory\StaticMethod
     public static function create(
         string $body,
         string $name = '',
-        DescriptionFactory $descriptionFactory = null,
-        TypeContext $context = null
+        ?DescriptionFactory $descriptionFactory = null,
+        ?TypeContext $context = null
     ) {
         Assert::stringNotEmpty($name);
         Assert::notNull($descriptionFactory);
@@ -69,7 +69,7 @@ class Generic extends BaseTag implements Factory\StaticMethod
     /**
      * Validates if the tag name matches the expected format, otherwise throws an exception.
      */
-    private function validateTagName(string $name)
+    private function validateTagName(string $name): void
     {
         if (! preg_match('/^' . StandardTagFactory::REGEX_TAGNAME . '$/u', $name)) {
             throw new \InvalidArgumentException(

--- a/src/DocBlock/Tags/Generic.php
+++ b/src/DocBlock/Tags/Generic.php
@@ -41,9 +41,6 @@ class Generic extends BaseTag implements Factory\StaticMethod
     /**
      * Creates a new tag that represents any unknown tag type.
      *
-     * @param string             $body
-     * @param string             $name
-     * @param TypeContext        $context
      *
      * @return static
      */
@@ -63,8 +60,6 @@ class Generic extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns the tag as a serialized string
-     *
-     * @return string
      */
     public function __toString(): string
     {
@@ -73,9 +68,6 @@ class Generic extends BaseTag implements Factory\StaticMethod
 
     /**
      * Validates if the tag name matches the expected format, otherwise throws an exception.
-     *
-     * @param string $name
-     *
      */
     private function validateTagName(string $name)
     {

--- a/src/DocBlock/Tags/Link.php
+++ b/src/DocBlock/Tags/Link.php
@@ -30,8 +30,6 @@ final class Link extends BaseTag implements Factory\StaticMethod
 
     /**
      * Initializes a link to a URL.
-     *
-     * @param string      $link
      */
     public function __construct(string $link, Description $description = null)
     {
@@ -53,10 +51,8 @@ final class Link extends BaseTag implements Factory\StaticMethod
     }
 
     /**
-    * Gets the link
-    *
-    * @return string
-    */
+     * Gets the link
+     */
     public function getLink(): string
     {
         return $this->link;
@@ -64,8 +60,6 @@ final class Link extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns a string representation for this tag.
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/src/DocBlock/Tags/Link.php
+++ b/src/DocBlock/Tags/Link.php
@@ -31,7 +31,7 @@ final class Link extends BaseTag implements Factory\StaticMethod
     /**
      * Initializes a link to a URL.
      */
-    public function __construct(string $link, Description $description = null)
+    public function __construct(string $link, ?Description $description = null)
     {
         $this->link = $link;
         $this->description = $description;
@@ -40,7 +40,7 @@ final class Link extends BaseTag implements Factory\StaticMethod
     /**
      * {@inheritdoc}
      */
-    public static function create(string $body, DescriptionFactory $descriptionFactory = null, TypeContext $context = null)
+    public static function create(string $body, ?DescriptionFactory $descriptionFactory = null, ?TypeContext $context = null): Link
     {
         Assert::notNull($descriptionFactory);
 

--- a/src/DocBlock/Tags/Link.php
+++ b/src/DocBlock/Tags/Link.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * phpDocumentor
  *
@@ -31,9 +32,8 @@ final class Link extends BaseTag implements Factory\StaticMethod
      * Initializes a link to a URL.
      *
      * @param string      $link
-     * @param Description $description
      */
-    public function __construct($link, Description $description = null)
+    public function __construct(string $link, Description $description = null)
     {
         Assert::string($link);
 
@@ -44,7 +44,7 @@ final class Link extends BaseTag implements Factory\StaticMethod
     /**
      * {@inheritdoc}
      */
-    public static function create($body, DescriptionFactory $descriptionFactory = null, TypeContext $context = null)
+    public static function create(string $body, DescriptionFactory $descriptionFactory = null, TypeContext $context = null)
     {
         Assert::string($body);
         Assert::notNull($descriptionFactory);
@@ -60,7 +60,7 @@ final class Link extends BaseTag implements Factory\StaticMethod
     *
     * @return string
     */
-    public function getLink()
+    public function getLink(): string
     {
         return $this->link;
     }
@@ -70,7 +70,7 @@ final class Link extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->link . ($this->description ? ' ' . $this->description->render() : '');
     }

--- a/src/DocBlock/Tags/Link.php
+++ b/src/DocBlock/Tags/Link.php
@@ -46,7 +46,6 @@ final class Link extends BaseTag implements Factory\StaticMethod
      */
     public static function create(string $body, DescriptionFactory $descriptionFactory = null, TypeContext $context = null)
     {
-        Assert::string($body);
         Assert::notNull($descriptionFactory);
 
         $parts = preg_split('/\s+/Su', $body, 2);

--- a/src/DocBlock/Tags/Link.php
+++ b/src/DocBlock/Tags/Link.php
@@ -35,8 +35,6 @@ final class Link extends BaseTag implements Factory\StaticMethod
      */
     public function __construct(string $link, Description $description = null)
     {
-        Assert::string($link);
-
         $this->link = $link;
         $this->description = $description;
     }

--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -43,9 +43,9 @@ final class Method extends BaseTag implements Factory\StaticMethod
     public function __construct(
         $methodName,
         array $arguments = [],
-        Type $returnType = null,
+        ?Type $returnType = null,
         $static = false,
-        Description $description = null
+        ?Description $description = null
     ) {
         Assert::stringNotEmpty($methodName);
         Assert::boolean($static);
@@ -66,10 +66,10 @@ final class Method extends BaseTag implements Factory\StaticMethod
      */
     public static function create(
         string $body,
-        TypeResolver $typeResolver = null,
-        DescriptionFactory $descriptionFactory = null,
-        TypeContext $context = null
-    ) {
+        ?TypeResolver $typeResolver = null,
+        ?DescriptionFactory $descriptionFactory = null,
+        ?TypeContext $context = null
+    ): Method {
         Assert::stringNotEmpty($body);
         Assert::allNotNull([ $typeResolver, $descriptionFactory ]);
 
@@ -123,7 +123,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
             return null;
         }
 
-        list(, $static, $returnType, $methodName, $arguments, $description) = $matches;
+        [, $static, $returnType, $methodName, $arguments, $description] = $matches;
 
         $static      = $static === 'static';
 
@@ -193,7 +193,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
         return $this->returnType;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         $arguments = [];
         foreach ($this->arguments as $argument) {

--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -161,8 +161,6 @@ final class Method extends BaseTag implements Factory\StaticMethod
 
     /**
      * Retrieves the method name.
-     *
-     * @return string
      */
     public function getMethodName(): string
     {

--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -185,9 +185,6 @@ final class Method extends BaseTag implements Factory\StaticMethod
         return $this->isStatic;
     }
 
-    /**
-     * @return Type
-     */
     public function getReturnType(): Type
     {
         return $this->returnType;

--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -64,7 +65,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
      * {@inheritdoc}
      */
     public static function create(
-        $body,
+        string $body,
         TypeResolver $typeResolver = null,
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
@@ -163,7 +164,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function getMethodName()
+    public function getMethodName(): string
     {
         return $this->methodName;
     }
@@ -181,7 +182,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
      *
      * @return bool TRUE if the method declaration is for a static method, FALSE otherwise.
      */
-    public function isStatic()
+    public function isStatic(): bool
     {
         return $this->isStatic;
     }
@@ -189,7 +190,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
     /**
      * @return Type
      */
-    public function getReturnType()
+    public function getReturnType(): Type
     {
         return $this->returnType;
     }

--- a/src/DocBlock/Tags/Param.php
+++ b/src/DocBlock/Tags/Param.php
@@ -98,7 +98,6 @@ final class Param extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns the variable's type or null if unknown.
-     *
      */
     public function getType(): ?Type
     {
@@ -107,7 +106,6 @@ final class Param extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns whether this tag is variadic.
-     *
      */
     public function isVariadic(): bool
     {

--- a/src/DocBlock/Tags/Param.php
+++ b/src/DocBlock/Tags/Param.php
@@ -37,7 +37,7 @@ final class Param extends BaseTag implements Factory\StaticMethod
     /** @var bool determines whether this is a variadic argument */
     private $isVariadic = false;
 
-    public function __construct(string $variableName, Type $type = null, bool $isVariadic = false, Description $description = null)
+    public function __construct(string $variableName, ?Type $type = null, bool $isVariadic = false, ?Description $description = null)
     {
         $this->variableName = $variableName;
         $this->type = $type;
@@ -50,9 +50,9 @@ final class Param extends BaseTag implements Factory\StaticMethod
      */
     public static function create(
         string $body,
-        TypeResolver $typeResolver = null,
-        DescriptionFactory $descriptionFactory = null,
-        TypeContext $context = null
+        ?TypeResolver $typeResolver = null,
+        ?DescriptionFactory $descriptionFactory = null,
+        ?TypeContext $context = null
     ) {
         Assert::stringNotEmpty($body);
         Assert::allNotNull([$typeResolver, $descriptionFactory]);
@@ -99,9 +99,8 @@ final class Param extends BaseTag implements Factory\StaticMethod
     /**
      * Returns the variable's type or null if unknown.
      *
-     * @return Type|null
      */
-    public function getType()
+    public function getType(): ?Type
     {
         return $this->type;
     }
@@ -109,7 +108,6 @@ final class Param extends BaseTag implements Factory\StaticMethod
     /**
      * Returns whether this tag is variadic.
      *
-     * @return boolean
      */
     public function isVariadic(): bool
     {

--- a/src/DocBlock/Tags/Param.php
+++ b/src/DocBlock/Tags/Param.php
@@ -44,9 +44,6 @@ final class Param extends BaseTag implements Factory\StaticMethod
      */
     public function __construct(string $variableName, Type $type = null, bool $isVariadic = false, Description $description = null)
     {
-        Assert::string($variableName);
-        Assert::boolean($isVariadic);
-
         $this->variableName = $variableName;
         $this->type = $type;
         $this->isVariadic = $isVariadic;

--- a/src/DocBlock/Tags/Param.php
+++ b/src/DocBlock/Tags/Param.php
@@ -37,11 +37,6 @@ final class Param extends BaseTag implements Factory\StaticMethod
     /** @var bool determines whether this is a variadic argument */
     private $isVariadic = false;
 
-    /**
-     * @param string $variableName
-     * @param bool $isVariadic
-     * @param Description $description
-     */
     public function __construct(string $variableName, Type $type = null, bool $isVariadic = false, Description $description = null)
     {
         $this->variableName = $variableName;
@@ -95,8 +90,6 @@ final class Param extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns the variable's name.
-     *
-     * @return string
      */
     public function getVariableName(): string
     {
@@ -125,8 +118,6 @@ final class Param extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns a string representation for this tag.
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/src/DocBlock/Tags/Param.php
+++ b/src/DocBlock/Tags/Param.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -38,11 +39,10 @@ final class Param extends BaseTag implements Factory\StaticMethod
 
     /**
      * @param string $variableName
-     * @param Type $type
      * @param bool $isVariadic
      * @param Description $description
      */
-    public function __construct($variableName, Type $type = null, $isVariadic = false, Description $description = null)
+    public function __construct(string $variableName, Type $type = null, bool $isVariadic = false, Description $description = null)
     {
         Assert::string($variableName);
         Assert::boolean($isVariadic);
@@ -57,7 +57,7 @@ final class Param extends BaseTag implements Factory\StaticMethod
      * {@inheritdoc}
      */
     public static function create(
-        $body,
+        string $body,
         TypeResolver $typeResolver = null,
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
@@ -101,7 +101,7 @@ final class Param extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function getVariableName()
+    public function getVariableName(): string
     {
         return $this->variableName;
     }
@@ -121,7 +121,7 @@ final class Param extends BaseTag implements Factory\StaticMethod
      *
      * @return boolean
      */
-    public function isVariadic()
+    public function isVariadic(): bool
     {
         return $this->isVariadic;
     }
@@ -131,7 +131,7 @@ final class Param extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return ($this->type ? $this->type . ' ' : '')
         . ($this->isVariadic() ? '...' : '')

--- a/src/DocBlock/Tags/Property.php
+++ b/src/DocBlock/Tags/Property.php
@@ -88,7 +88,6 @@ class Property extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns the variable's type or null if unknown.
-     *
      */
     public function getType(): ?Type
     {

--- a/src/DocBlock/Tags/Property.php
+++ b/src/DocBlock/Tags/Property.php
@@ -40,8 +40,6 @@ class Property extends BaseTag implements Factory\StaticMethod
      */
     public function __construct(string $variableName, Type $type = null, Description $description = null)
     {
-        Assert::string($variableName);
-
         $this->variableName = $variableName;
         $this->type = $type;
         $this->description = $description;

--- a/src/DocBlock/Tags/Property.php
+++ b/src/DocBlock/Tags/Property.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -36,9 +37,8 @@ class Property extends BaseTag implements Factory\StaticMethod
     /**
      * @param string      $variableName
      * @param Type        $type
-     * @param Description $description
      */
-    public function __construct($variableName, Type $type = null, Description $description = null)
+    public function __construct(string $variableName, Type $type = null, Description $description = null)
     {
         Assert::string($variableName);
 
@@ -51,7 +51,7 @@ class Property extends BaseTag implements Factory\StaticMethod
      * {@inheritdoc}
      */
     public static function create(
-        $body,
+        string $body,
         TypeResolver $typeResolver = null,
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
@@ -89,7 +89,7 @@ class Property extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function getVariableName()
+    public function getVariableName(): string
     {
         return $this->variableName;
     }
@@ -109,7 +109,7 @@ class Property extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return ($this->type ? $this->type . ' ' : '')
         . '$' . $this->variableName

--- a/src/DocBlock/Tags/Property.php
+++ b/src/DocBlock/Tags/Property.php
@@ -34,10 +34,6 @@ class Property extends BaseTag implements Factory\StaticMethod
     /** @var string */
     protected $variableName = '';
 
-    /**
-     * @param string      $variableName
-     * @param Type        $type
-     */
     public function __construct(string $variableName, Type $type = null, Description $description = null)
     {
         $this->variableName = $variableName;
@@ -84,8 +80,6 @@ class Property extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns the variable's name.
-     *
-     * @return string
      */
     public function getVariableName(): string
     {
@@ -104,8 +98,6 @@ class Property extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns a string representation for this tag.
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/src/DocBlock/Tags/Property.php
+++ b/src/DocBlock/Tags/Property.php
@@ -34,7 +34,7 @@ class Property extends BaseTag implements Factory\StaticMethod
     /** @var string */
     protected $variableName = '';
 
-    public function __construct(string $variableName, Type $type = null, Description $description = null)
+    public function __construct(string $variableName, ?Type $type = null, ?Description $description = null)
     {
         $this->variableName = $variableName;
         $this->type = $type;
@@ -46,9 +46,9 @@ class Property extends BaseTag implements Factory\StaticMethod
      */
     public static function create(
         string $body,
-        TypeResolver $typeResolver = null,
-        DescriptionFactory $descriptionFactory = null,
-        TypeContext $context = null
+        ?TypeResolver $typeResolver = null,
+        ?DescriptionFactory $descriptionFactory = null,
+        ?TypeContext $context = null
     ) {
         Assert::stringNotEmpty($body);
         Assert::allNotNull([$typeResolver, $descriptionFactory]);
@@ -89,9 +89,8 @@ class Property extends BaseTag implements Factory\StaticMethod
     /**
      * Returns the variable's type or null if unknown.
      *
-     * @return Type|null
      */
-    public function getType()
+    public function getType(): ?Type
     {
         return $this->type;
     }

--- a/src/DocBlock/Tags/PropertyRead.php
+++ b/src/DocBlock/Tags/PropertyRead.php
@@ -88,7 +88,6 @@ class PropertyRead extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns the variable's type or null if unknown.
-     *
      */
     public function getType(): ?Type
     {

--- a/src/DocBlock/Tags/PropertyRead.php
+++ b/src/DocBlock/Tags/PropertyRead.php
@@ -40,8 +40,6 @@ class PropertyRead extends BaseTag implements Factory\StaticMethod
      */
     public function __construct(string $variableName, Type $type = null, Description $description = null)
     {
-        Assert::string($variableName);
-
         $this->variableName = $variableName;
         $this->type = $type;
         $this->description = $description;

--- a/src/DocBlock/Tags/PropertyRead.php
+++ b/src/DocBlock/Tags/PropertyRead.php
@@ -34,10 +34,6 @@ class PropertyRead extends BaseTag implements Factory\StaticMethod
     /** @var string */
     protected $variableName = '';
 
-    /**
-     * @param string      $variableName
-     * @param Type        $type
-     */
     public function __construct(string $variableName, Type $type = null, Description $description = null)
     {
         $this->variableName = $variableName;
@@ -84,8 +80,6 @@ class PropertyRead extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns the variable's name.
-     *
-     * @return string
      */
     public function getVariableName(): string
     {
@@ -104,8 +98,6 @@ class PropertyRead extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns a string representation for this tag.
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/src/DocBlock/Tags/PropertyRead.php
+++ b/src/DocBlock/Tags/PropertyRead.php
@@ -34,7 +34,7 @@ class PropertyRead extends BaseTag implements Factory\StaticMethod
     /** @var string */
     protected $variableName = '';
 
-    public function __construct(string $variableName, Type $type = null, Description $description = null)
+    public function __construct(string $variableName, ?Type $type = null, ?Description $description = null)
     {
         $this->variableName = $variableName;
         $this->type = $type;
@@ -46,9 +46,9 @@ class PropertyRead extends BaseTag implements Factory\StaticMethod
      */
     public static function create(
         string $body,
-        TypeResolver $typeResolver = null,
-        DescriptionFactory $descriptionFactory = null,
-        TypeContext $context = null
+        ?TypeResolver $typeResolver = null,
+        ?DescriptionFactory $descriptionFactory = null,
+        ?TypeContext $context = null
     ) {
         Assert::stringNotEmpty($body);
         Assert::allNotNull([$typeResolver, $descriptionFactory]);
@@ -89,9 +89,8 @@ class PropertyRead extends BaseTag implements Factory\StaticMethod
     /**
      * Returns the variable's type or null if unknown.
      *
-     * @return Type|null
      */
-    public function getType()
+    public function getType(): ?Type
     {
         return $this->type;
     }

--- a/src/DocBlock/Tags/PropertyRead.php
+++ b/src/DocBlock/Tags/PropertyRead.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -36,9 +37,8 @@ class PropertyRead extends BaseTag implements Factory\StaticMethod
     /**
      * @param string      $variableName
      * @param Type        $type
-     * @param Description $description
      */
-    public function __construct($variableName, Type $type = null, Description $description = null)
+    public function __construct(string $variableName, Type $type = null, Description $description = null)
     {
         Assert::string($variableName);
 
@@ -51,7 +51,7 @@ class PropertyRead extends BaseTag implements Factory\StaticMethod
      * {@inheritdoc}
      */
     public static function create(
-        $body,
+        string $body,
         TypeResolver $typeResolver = null,
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
@@ -89,7 +89,7 @@ class PropertyRead extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function getVariableName()
+    public function getVariableName(): string
     {
         return $this->variableName;
     }
@@ -109,7 +109,7 @@ class PropertyRead extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return ($this->type ? $this->type . ' ' : '')
         . '$' . $this->variableName

--- a/src/DocBlock/Tags/PropertyWrite.php
+++ b/src/DocBlock/Tags/PropertyWrite.php
@@ -88,7 +88,6 @@ class PropertyWrite extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns the variable's type or null if unknown.
-     *
      */
     public function getType(): ?Type
     {

--- a/src/DocBlock/Tags/PropertyWrite.php
+++ b/src/DocBlock/Tags/PropertyWrite.php
@@ -34,7 +34,7 @@ class PropertyWrite extends BaseTag implements Factory\StaticMethod
     /** @var string */
     protected $variableName = '';
 
-    public function __construct(string $variableName, Type $type = null, Description $description = null)
+    public function __construct(string $variableName, ?Type $type = null, ?Description $description = null)
     {
         $this->variableName = $variableName;
         $this->type = $type;
@@ -46,9 +46,9 @@ class PropertyWrite extends BaseTag implements Factory\StaticMethod
      */
     public static function create(
         string $body,
-        TypeResolver $typeResolver = null,
-        DescriptionFactory $descriptionFactory = null,
-        TypeContext $context = null
+        ?TypeResolver $typeResolver = null,
+        ?DescriptionFactory $descriptionFactory = null,
+        ?TypeContext $context = null
     ) {
         Assert::stringNotEmpty($body);
         Assert::allNotNull([$typeResolver, $descriptionFactory]);
@@ -89,9 +89,8 @@ class PropertyWrite extends BaseTag implements Factory\StaticMethod
     /**
      * Returns the variable's type or null if unknown.
      *
-     * @return Type|null
      */
-    public function getType()
+    public function getType(): ?Type
     {
         return $this->type;
     }

--- a/src/DocBlock/Tags/PropertyWrite.php
+++ b/src/DocBlock/Tags/PropertyWrite.php
@@ -40,8 +40,6 @@ class PropertyWrite extends BaseTag implements Factory\StaticMethod
      */
     public function __construct(string $variableName, Type $type = null, Description $description = null)
     {
-        Assert::string($variableName);
-
         $this->variableName = $variableName;
         $this->type = $type;
         $this->description = $description;

--- a/src/DocBlock/Tags/PropertyWrite.php
+++ b/src/DocBlock/Tags/PropertyWrite.php
@@ -34,10 +34,6 @@ class PropertyWrite extends BaseTag implements Factory\StaticMethod
     /** @var string */
     protected $variableName = '';
 
-    /**
-     * @param string      $variableName
-     * @param Type        $type
-     */
     public function __construct(string $variableName, Type $type = null, Description $description = null)
     {
         $this->variableName = $variableName;
@@ -84,8 +80,6 @@ class PropertyWrite extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns the variable's name.
-     *
-     * @return string
      */
     public function getVariableName(): string
     {
@@ -104,8 +98,6 @@ class PropertyWrite extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns a string representation for this tag.
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/src/DocBlock/Tags/PropertyWrite.php
+++ b/src/DocBlock/Tags/PropertyWrite.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -36,9 +37,8 @@ class PropertyWrite extends BaseTag implements Factory\StaticMethod
     /**
      * @param string      $variableName
      * @param Type        $type
-     * @param Description $description
      */
-    public function __construct($variableName, Type $type = null, Description $description = null)
+    public function __construct(string $variableName, Type $type = null, Description $description = null)
     {
         Assert::string($variableName);
 
@@ -51,7 +51,7 @@ class PropertyWrite extends BaseTag implements Factory\StaticMethod
      * {@inheritdoc}
      */
     public static function create(
-        $body,
+        string $body,
         TypeResolver $typeResolver = null,
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
@@ -89,7 +89,7 @@ class PropertyWrite extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function getVariableName()
+    public function getVariableName(): string
     {
         return $this->variableName;
     }
@@ -109,7 +109,7 @@ class PropertyWrite extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return ($this->type ? $this->type . ' ' : '')
         . '$' . $this->variableName

--- a/src/DocBlock/Tags/Reference/Fqsen.php
+++ b/src/DocBlock/Tags/Reference/Fqsen.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -35,7 +36,7 @@ final class Fqsen implements Reference
     /**
      * @return string string representation of the referenced fqsen
      */
-    public function __toString()
+    public function __toString(): string
     {
         return (string)$this->fqsen;
     }

--- a/src/DocBlock/Tags/Reference/Reference.php
+++ b/src/DocBlock/Tags/Reference/Reference.php
@@ -18,5 +18,5 @@ namespace phpDocumentor\Reflection\DocBlock\Tags\Reference;
  */
 interface Reference
 {
-    public function __toString();
+    public function __toString(): string;
 }

--- a/src/DocBlock/Tags/Reference/Reference.php
+++ b/src/DocBlock/Tags/Reference/Reference.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/src/DocBlock/Tags/Reference/Url.php
+++ b/src/DocBlock/Tags/Reference/Url.php
@@ -34,7 +34,7 @@ final class Url implements Reference
         $this->uri = $uri;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->uri;
     }

--- a/src/DocBlock/Tags/Reference/Url.php
+++ b/src/DocBlock/Tags/Reference/Url.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/src/DocBlock/Tags/Return_.php
+++ b/src/DocBlock/Tags/Return_.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -39,7 +40,7 @@ final class Return_ extends BaseTag implements Factory\StaticMethod
      * {@inheritdoc}
      */
     public static function create(
-        $body,
+        string $body,
         TypeResolver $typeResolver = null,
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
@@ -49,8 +50,8 @@ final class Return_ extends BaseTag implements Factory\StaticMethod
 
         $parts = preg_split('/\s+/Su', $body, 2);
 
-        $type = $typeResolver->resolve(isset($parts[0]) ? $parts[0] : '', $context);
-        $description = $descriptionFactory->create(isset($parts[1]) ? $parts[1] : '', $context);
+        $type = $typeResolver->resolve($parts[0] ?? '', $context);
+        $description = $descriptionFactory->create($parts[1] ?? '', $context);
 
         return new static($type, $description);
     }
@@ -60,7 +61,7 @@ final class Return_ extends BaseTag implements Factory\StaticMethod
      *
      * @return Type
      */
-    public function getType()
+    public function getType(): Type
     {
         return $this->type;
     }

--- a/src/DocBlock/Tags/Return_.php
+++ b/src/DocBlock/Tags/Return_.php
@@ -30,7 +30,7 @@ final class Return_ extends BaseTag implements Factory\StaticMethod
     /** @var Type */
     private $type;
 
-    public function __construct(Type $type, Description $description = null)
+    public function __construct(Type $type, ?Description $description = null)
     {
         $this->type = $type;
         $this->description = $description;
@@ -41,9 +41,9 @@ final class Return_ extends BaseTag implements Factory\StaticMethod
      */
     public static function create(
         string $body,
-        TypeResolver $typeResolver = null,
-        DescriptionFactory $descriptionFactory = null,
-        TypeContext $context = null
+        ?TypeResolver $typeResolver = null,
+        ?DescriptionFactory $descriptionFactory = null,
+        ?TypeContext $context = null
     ) {
         Assert::allNotNull([$typeResolver, $descriptionFactory]);
 
@@ -57,15 +57,13 @@ final class Return_ extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns the type section of the variable.
-     *
-     * @return Type
      */
     public function getType(): Type
     {
         return $this->type;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->type . ' ' . $this->description;
     }

--- a/src/DocBlock/Tags/Return_.php
+++ b/src/DocBlock/Tags/Return_.php
@@ -45,7 +45,6 @@ final class Return_ extends BaseTag implements Factory\StaticMethod
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
     ) {
-        Assert::string($body);
         Assert::allNotNull([$typeResolver, $descriptionFactory]);
 
         $parts = preg_split('/\s+/Su', $body, 2);

--- a/src/DocBlock/Tags/See.php
+++ b/src/DocBlock/Tags/See.php
@@ -52,7 +52,6 @@ class See extends BaseTag implements Factory\StaticMethod
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
     ) {
-        Assert::string($body);
         Assert::allNotNull([$resolver, $descriptionFactory]);
 
         $parts       = preg_split('/\s+/Su', $body, 2);

--- a/src/DocBlock/Tags/See.php
+++ b/src/DocBlock/Tags/See.php
@@ -65,7 +65,6 @@ class See extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns the ref of this tag.
-     *
      */
     public function getReference(): Reference
     {

--- a/src/DocBlock/Tags/See.php
+++ b/src/DocBlock/Tags/See.php
@@ -35,7 +35,7 @@ class See extends BaseTag implements Factory\StaticMethod
     /**
      * Initializes this tag.
      */
-    public function __construct(Reference $refers, Description $description = null)
+    public function __construct(Reference $refers, ?Description $description = null)
     {
         $this->refers = $refers;
         $this->description = $description;
@@ -46,9 +46,9 @@ class See extends BaseTag implements Factory\StaticMethod
      */
     public static function create(
         string $body,
-        FqsenResolver $resolver = null,
-        DescriptionFactory $descriptionFactory = null,
-        TypeContext $context = null
+        ?FqsenResolver $resolver = null,
+        ?DescriptionFactory $descriptionFactory = null,
+        ?TypeContext $context = null
     ) {
         Assert::allNotNull([$resolver, $descriptionFactory]);
 
@@ -66,7 +66,6 @@ class See extends BaseTag implements Factory\StaticMethod
     /**
      * Returns the ref of this tag.
      *
-     * @return Reference
      */
     public function getReference(): Reference
     {

--- a/src/DocBlock/Tags/See.php
+++ b/src/DocBlock/Tags/See.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -34,7 +35,6 @@ class See extends BaseTag implements Factory\StaticMethod
     /**
      * Initializes this tag.
      *
-     * @param Reference $refers
      * @param Description $description
      */
     public function __construct(Reference $refers, Description $description = null)
@@ -47,7 +47,7 @@ class See extends BaseTag implements Factory\StaticMethod
      * {@inheritdoc}
      */
     public static function create(
-        $body,
+        string $body,
         FqsenResolver $resolver = null,
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
@@ -71,7 +71,7 @@ class See extends BaseTag implements Factory\StaticMethod
      *
      * @return Reference
      */
-    public function getReference()
+    public function getReference(): Reference
     {
         return $this->refers;
     }
@@ -81,7 +81,7 @@ class See extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->refers . ($this->description ? ' ' . $this->description->render() : '');
     }

--- a/src/DocBlock/Tags/See.php
+++ b/src/DocBlock/Tags/See.php
@@ -34,8 +34,6 @@ class See extends BaseTag implements Factory\StaticMethod
 
     /**
      * Initializes this tag.
-     *
-     * @param Description $description
      */
     public function __construct(Reference $refers, Description $description = null)
     {
@@ -77,8 +75,6 @@ class See extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns a string representation of this tag.
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/src/DocBlock/Tags/Since.php
+++ b/src/DocBlock/Tags/Since.php
@@ -85,8 +85,6 @@ final class Since extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns a string representation for this tag.
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/src/DocBlock/Tags/Since.php
+++ b/src/DocBlock/Tags/Since.php
@@ -56,7 +56,7 @@ final class Since extends BaseTag implements Factory\StaticMethod
      * @return static
      */
     public static function create(
-        string $body,
+        ?string $body,
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
     ) {
@@ -78,10 +78,8 @@ final class Since extends BaseTag implements Factory\StaticMethod
 
     /**
      * Gets the version section of the tag.
-     *
-     * @return string
      */
-    public function getVersion(): string
+    public function getVersion(): ?string
     {
         return $this->version;
     }

--- a/src/DocBlock/Tags/Since.php
+++ b/src/DocBlock/Tags/Since.php
@@ -29,7 +29,7 @@ final class Since extends BaseTag implements Factory\StaticMethod
      * PCRE regular expression matching a version vector.
      * Assumes the "x" modifier.
      */
-    const REGEX_VECTOR = '(?:
+    public const REGEX_VECTOR = '(?:
         # Normal release vectors.
         \d\S*
         |
@@ -44,7 +44,7 @@ final class Since extends BaseTag implements Factory\StaticMethod
     /** @var string The version vector. */
     private $version = '';
 
-    public function __construct($version = null, Description $description = null)
+    public function __construct($version = null, ?Description $description = null)
     {
         Assert::nullOrStringNotEmpty($version);
 
@@ -57,8 +57,8 @@ final class Since extends BaseTag implements Factory\StaticMethod
      */
     public static function create(
         ?string $body,
-        DescriptionFactory $descriptionFactory = null,
-        TypeContext $context = null
+        ?DescriptionFactory $descriptionFactory = null,
+        ?TypeContext $context = null
     ) {
         if (empty($body)) {
             return new static();

--- a/src/DocBlock/Tags/Since.php
+++ b/src/DocBlock/Tags/Since.php
@@ -60,7 +60,6 @@ final class Since extends BaseTag implements Factory\StaticMethod
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
     ) {
-        Assert::nullOrString($body);
         if (empty($body)) {
             return new static();
         }

--- a/src/DocBlock/Tags/Since.php
+++ b/src/DocBlock/Tags/Since.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -54,8 +55,11 @@ final class Since extends BaseTag implements Factory\StaticMethod
     /**
      * @return static
      */
-    public static function create($body, DescriptionFactory $descriptionFactory = null, TypeContext $context = null)
-    {
+    public static function create(
+        string $body,
+        DescriptionFactory $descriptionFactory = null,
+        TypeContext $context = null
+    ) {
         Assert::nullOrString($body);
         if (empty($body)) {
             return new static();
@@ -68,7 +72,7 @@ final class Since extends BaseTag implements Factory\StaticMethod
 
         return new static(
             $matches[1],
-            $descriptionFactory->create(isset($matches[2]) ? $matches[2] : '', $context)
+            $descriptionFactory->create($matches[2] ?? '', $context)
         );
     }
 
@@ -77,7 +81,7 @@ final class Since extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function getVersion()
+    public function getVersion(): string
     {
         return $this->version;
     }
@@ -87,7 +91,7 @@ final class Since extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->version . ($this->description ? ' ' . $this->description->render() : '');
     }

--- a/src/DocBlock/Tags/Source.php
+++ b/src/DocBlock/Tags/Source.php
@@ -32,7 +32,7 @@ final class Source extends BaseTag implements Factory\StaticMethod
     /** @var int|null The number of lines, relative to the starting line. NULL means "to the end". */
     private $lineCount = null;
 
-    public function __construct($startingLine, $lineCount = null, Description $description = null)
+    public function __construct($startingLine, $lineCount = null, ?Description $description = null)
     {
         Assert::integerish($startingLine);
         Assert::nullOrIntegerish($lineCount);
@@ -47,8 +47,8 @@ final class Source extends BaseTag implements Factory\StaticMethod
      */
     public static function create(
         string $body,
-        DescriptionFactory $descriptionFactory = null,
-        TypeContext $context = null
+        ?DescriptionFactory $descriptionFactory = null,
+        ?TypeContext $context = null
     ) {
         Assert::stringNotEmpty($body);
         Assert::notNull($descriptionFactory);
@@ -87,12 +87,12 @@ final class Source extends BaseTag implements Factory\StaticMethod
      * @return int|null The number of lines, relative to the starting line. NULL
      *     means "to the end".
      */
-    public function getLineCount()
+    public function getLineCount(): ?int
     {
         return $this->lineCount;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->startingLine
         . ($this->lineCount !== null ? ' ' . $this->lineCount : '')

--- a/src/DocBlock/Tags/Source.php
+++ b/src/DocBlock/Tags/Source.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -44,8 +45,11 @@ final class Source extends BaseTag implements Factory\StaticMethod
     /**
      * {@inheritdoc}
      */
-    public static function create($body, DescriptionFactory $descriptionFactory = null, TypeContext $context = null)
-    {
+    public static function create(
+        string $body,
+        DescriptionFactory $descriptionFactory = null,
+        TypeContext $context = null
+    ) {
         Assert::stringNotEmpty($body);
         Assert::notNull($descriptionFactory);
 
@@ -72,7 +76,7 @@ final class Source extends BaseTag implements Factory\StaticMethod
      * @return int The starting line, relative to the structural element's
      *     location.
      */
-    public function getStartingLine()
+    public function getStartingLine(): int
     {
         return $this->startingLine;
     }

--- a/src/DocBlock/Tags/Throws.php
+++ b/src/DocBlock/Tags/Throws.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -39,7 +40,7 @@ final class Throws extends BaseTag implements Factory\StaticMethod
      * {@inheritdoc}
      */
     public static function create(
-        $body,
+        string $body,
         TypeResolver $typeResolver = null,
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
@@ -49,8 +50,8 @@ final class Throws extends BaseTag implements Factory\StaticMethod
 
         $parts = preg_split('/\s+/Su', $body, 2);
 
-        $type        = $typeResolver->resolve(isset($parts[0]) ? $parts[0] : '', $context);
-        $description = $descriptionFactory->create(isset($parts[1]) ? $parts[1] : '', $context);
+        $type        = $typeResolver->resolve($parts[0] ?? '', $context);
+        $description = $descriptionFactory->create($parts[1] ?? '', $context);
 
         return new static($type, $description);
     }
@@ -60,7 +61,7 @@ final class Throws extends BaseTag implements Factory\StaticMethod
      *
      * @return Type
      */
-    public function getType()
+    public function getType(): Type
     {
         return $this->type;
     }

--- a/src/DocBlock/Tags/Throws.php
+++ b/src/DocBlock/Tags/Throws.php
@@ -30,7 +30,7 @@ final class Throws extends BaseTag implements Factory\StaticMethod
     /** @var Type */
     private $type;
 
-    public function __construct(Type $type, Description $description = null)
+    public function __construct(Type $type, ?Description $description = null)
     {
         $this->type        = $type;
         $this->description = $description;
@@ -41,9 +41,9 @@ final class Throws extends BaseTag implements Factory\StaticMethod
      */
     public static function create(
         string $body,
-        TypeResolver $typeResolver = null,
-        DescriptionFactory $descriptionFactory = null,
-        TypeContext $context = null
+        ?TypeResolver $typeResolver = null,
+        ?DescriptionFactory $descriptionFactory = null,
+        ?TypeContext $context = null
     ) {
         Assert::allNotNull([$typeResolver, $descriptionFactory]);
 
@@ -58,14 +58,13 @@ final class Throws extends BaseTag implements Factory\StaticMethod
     /**
      * Returns the type section of the variable.
      *
-     * @return Type
      */
     public function getType(): Type
     {
         return $this->type;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->type . ' ' . $this->description;
     }

--- a/src/DocBlock/Tags/Throws.php
+++ b/src/DocBlock/Tags/Throws.php
@@ -45,7 +45,6 @@ final class Throws extends BaseTag implements Factory\StaticMethod
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
     ) {
-        Assert::string($body);
         Assert::allNotNull([$typeResolver, $descriptionFactory]);
 
         $parts = preg_split('/\s+/Su', $body, 2);

--- a/src/DocBlock/Tags/Throws.php
+++ b/src/DocBlock/Tags/Throws.php
@@ -57,7 +57,6 @@ final class Throws extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns the type section of the variable.
-     *
      */
     public function getType(): Type
     {

--- a/src/DocBlock/Tags/Uses.php
+++ b/src/DocBlock/Tags/Uses.php
@@ -33,7 +33,7 @@ final class Uses extends BaseTag implements Factory\StaticMethod
     /**
      * Initializes this tag.
      */
-    public function __construct(Fqsen $refers, Description $description = null)
+    public function __construct(Fqsen $refers, ?Description $description = null)
     {
         $this->refers      = $refers;
         $this->description = $description;
@@ -44,9 +44,9 @@ final class Uses extends BaseTag implements Factory\StaticMethod
      */
     public static function create(
         string $body,
-        FqsenResolver $resolver = null,
-        DescriptionFactory $descriptionFactory = null,
-        TypeContext $context = null
+        ?FqsenResolver $resolver = null,
+        ?DescriptionFactory $descriptionFactory = null,
+        ?TypeContext $context = null
     ) {
         Assert::allNotNull([$resolver, $descriptionFactory]);
 
@@ -61,7 +61,6 @@ final class Uses extends BaseTag implements Factory\StaticMethod
     /**
      * Returns the structural element this tag refers to.
      *
-     * @return Fqsen
      */
     public function getReference(): Fqsen
     {

--- a/src/DocBlock/Tags/Uses.php
+++ b/src/DocBlock/Tags/Uses.php
@@ -60,7 +60,6 @@ final class Uses extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns the structural element this tag refers to.
-     *
      */
     public function getReference(): Fqsen
     {

--- a/src/DocBlock/Tags/Uses.php
+++ b/src/DocBlock/Tags/Uses.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -33,7 +34,6 @@ final class Uses extends BaseTag implements Factory\StaticMethod
      * Initializes this tag.
      *
      * @param Fqsen       $refers
-     * @param Description $description
      */
     public function __construct(Fqsen $refers, Description $description = null)
     {
@@ -45,7 +45,7 @@ final class Uses extends BaseTag implements Factory\StaticMethod
      * {@inheritdoc}
      */
     public static function create(
-        $body,
+        string $body,
         FqsenResolver $resolver = null,
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
@@ -57,7 +57,7 @@ final class Uses extends BaseTag implements Factory\StaticMethod
 
         return new static(
             $resolver->resolve($parts[0], $context),
-            $descriptionFactory->create(isset($parts[1]) ? $parts[1] : '', $context)
+            $descriptionFactory->create($parts[1] ?? '', $context)
         );
     }
 
@@ -66,7 +66,7 @@ final class Uses extends BaseTag implements Factory\StaticMethod
      *
      * @return Fqsen
      */
-    public function getReference()
+    public function getReference(): Fqsen
     {
         return $this->refers;
     }
@@ -76,7 +76,7 @@ final class Uses extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->refers . ' ' . $this->description->render();
     }

--- a/src/DocBlock/Tags/Uses.php
+++ b/src/DocBlock/Tags/Uses.php
@@ -32,8 +32,6 @@ final class Uses extends BaseTag implements Factory\StaticMethod
 
     /**
      * Initializes this tag.
-     *
-     * @param Fqsen       $refers
      */
     public function __construct(Fqsen $refers, Description $description = null)
     {
@@ -72,8 +70,6 @@ final class Uses extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns a string representation of this tag.
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/src/DocBlock/Tags/Uses.php
+++ b/src/DocBlock/Tags/Uses.php
@@ -50,7 +50,6 @@ final class Uses extends BaseTag implements Factory\StaticMethod
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
     ) {
-        Assert::string($body);
         Assert::allNotNull([$resolver, $descriptionFactory]);
 
         $parts = preg_split('/\s+/Su', $body, 2);

--- a/src/DocBlock/Tags/Var_.php
+++ b/src/DocBlock/Tags/Var_.php
@@ -88,7 +88,6 @@ class Var_ extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns the variable's type or null if unknown.
-     *
      */
     public function getType(): ?Type
     {

--- a/src/DocBlock/Tags/Var_.php
+++ b/src/DocBlock/Tags/Var_.php
@@ -40,8 +40,6 @@ class Var_ extends BaseTag implements Factory\StaticMethod
      */
     public function __construct(string $variableName, Type $type = null, Description $description = null)
     {
-        Assert::string($variableName);
-
         $this->variableName = $variableName;
         $this->type         = $type;
         $this->description  = $description;

--- a/src/DocBlock/Tags/Var_.php
+++ b/src/DocBlock/Tags/Var_.php
@@ -34,7 +34,7 @@ class Var_ extends BaseTag implements Factory\StaticMethod
     /** @var string */
     protected $variableName = '';
 
-    public function __construct(string $variableName, Type $type = null, Description $description = null)
+    public function __construct(string $variableName, ?Type $type = null, ?Description $description = null)
     {
         $this->variableName = $variableName;
         $this->type         = $type;
@@ -46,9 +46,9 @@ class Var_ extends BaseTag implements Factory\StaticMethod
      */
     public static function create(
         string $body,
-        TypeResolver $typeResolver = null,
-        DescriptionFactory $descriptionFactory = null,
-        TypeContext $context = null
+        ?TypeResolver $typeResolver = null,
+        ?DescriptionFactory $descriptionFactory = null,
+        ?TypeContext $context = null
     ) {
         Assert::stringNotEmpty($body);
         Assert::allNotNull([$typeResolver, $descriptionFactory]);
@@ -89,9 +89,8 @@ class Var_ extends BaseTag implements Factory\StaticMethod
     /**
      * Returns the variable's type or null if unknown.
      *
-     * @return Type|null
      */
-    public function getType()
+    public function getType(): ?Type
     {
         return $this->type;
     }

--- a/src/DocBlock/Tags/Var_.php
+++ b/src/DocBlock/Tags/Var_.php
@@ -34,10 +34,6 @@ class Var_ extends BaseTag implements Factory\StaticMethod
     /** @var string */
     protected $variableName = '';
 
-    /**
-     * @param string      $variableName
-     * @param Type        $type
-     */
     public function __construct(string $variableName, Type $type = null, Description $description = null)
     {
         $this->variableName = $variableName;
@@ -84,8 +80,6 @@ class Var_ extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns the variable's name.
-     *
-     * @return string
      */
     public function getVariableName(): string
     {
@@ -104,8 +98,6 @@ class Var_ extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns a string representation for this tag.
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/src/DocBlock/Tags/Var_.php
+++ b/src/DocBlock/Tags/Var_.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -36,9 +37,8 @@ class Var_ extends BaseTag implements Factory\StaticMethod
     /**
      * @param string      $variableName
      * @param Type        $type
-     * @param Description $description
      */
-    public function __construct($variableName, Type $type = null, Description $description = null)
+    public function __construct(string $variableName, Type $type = null, Description $description = null)
     {
         Assert::string($variableName);
 
@@ -51,7 +51,7 @@ class Var_ extends BaseTag implements Factory\StaticMethod
      * {@inheritdoc}
      */
     public static function create(
-        $body,
+        string $body,
         TypeResolver $typeResolver = null,
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
@@ -89,7 +89,7 @@ class Var_ extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function getVariableName()
+    public function getVariableName(): string
     {
         return $this->variableName;
     }
@@ -109,7 +109,7 @@ class Var_ extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return ($this->type ? $this->type . ' ' : '')
             . (empty($this->variableName) ? null : ('$' . $this->variableName))

--- a/src/DocBlock/Tags/Version.php
+++ b/src/DocBlock/Tags/Version.php
@@ -85,8 +85,6 @@ final class Version extends BaseTag implements Factory\StaticMethod
 
     /**
      * Returns a string representation for this tag.
-     *
-     * @return string
      */
     public function __toString(): string
     {

--- a/src/DocBlock/Tags/Version.php
+++ b/src/DocBlock/Tags/Version.php
@@ -29,7 +29,7 @@ final class Version extends BaseTag implements Factory\StaticMethod
      * PCRE regular expression matching a version vector.
      * Assumes the "x" modifier.
      */
-    const REGEX_VECTOR = '(?:
+    public const REGEX_VECTOR = '(?:
         # Normal release vectors.
         \d\S*
         |
@@ -44,7 +44,7 @@ final class Version extends BaseTag implements Factory\StaticMethod
     /** @var string The version vector. */
     private $version = '';
 
-    public function __construct($version = null, Description $description = null)
+    public function __construct($version = null, ?Description $description = null)
     {
         Assert::nullOrStringNotEmpty($version);
 
@@ -57,8 +57,8 @@ final class Version extends BaseTag implements Factory\StaticMethod
      */
     public static function create(
         ?string $body,
-        DescriptionFactory $descriptionFactory = null,
-        TypeContext $context = null
+        ?DescriptionFactory $descriptionFactory = null,
+        ?TypeContext $context = null
     ) {
         if (empty($body)) {
             return new static();

--- a/src/DocBlock/Tags/Version.php
+++ b/src/DocBlock/Tags/Version.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * phpDocumentor
  *
@@ -54,8 +55,11 @@ final class Version extends BaseTag implements Factory\StaticMethod
     /**
      * @return static
      */
-    public static function create($body, DescriptionFactory $descriptionFactory = null, TypeContext $context = null)
-    {
+    public static function create(
+        string $body,
+        DescriptionFactory $descriptionFactory = null,
+        TypeContext $context = null
+    ) {
         Assert::nullOrString($body);
         if (empty($body)) {
             return new static();
@@ -68,7 +72,7 @@ final class Version extends BaseTag implements Factory\StaticMethod
 
         return new static(
             $matches[1],
-            $descriptionFactory->create(isset($matches[2]) ? $matches[2] : '', $context)
+            $descriptionFactory->create($matches[2] ?? '', $context)
         );
     }
 
@@ -77,7 +81,7 @@ final class Version extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function getVersion()
+    public function getVersion(): string
     {
         return $this->version;
     }
@@ -87,7 +91,7 @@ final class Version extends BaseTag implements Factory\StaticMethod
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->version . ($this->description ? ' ' . $this->description->render() : '');
     }

--- a/src/DocBlock/Tags/Version.php
+++ b/src/DocBlock/Tags/Version.php
@@ -56,11 +56,10 @@ final class Version extends BaseTag implements Factory\StaticMethod
      * @return static
      */
     public static function create(
-        string $body,
+        ?string $body,
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null
     ) {
-        Assert::nullOrString($body);
         if (empty($body)) {
             return new static();
         }
@@ -78,10 +77,8 @@ final class Version extends BaseTag implements Factory\StaticMethod
 
     /**
      * Gets the version section of the tag.
-     *
-     * @return string
      */
-    public function getVersion(): string
+    public function getVersion(): ?string
     {
         return $this->version;
     }

--- a/src/DocBlockFactory.php
+++ b/src/DocBlockFactory.php
@@ -40,7 +40,6 @@ final class DocBlockFactory implements DocBlockFactoryInterface
      * Factory method for easy instantiation.
      *
      * @param string[] $additionalTags
-     *
      */
     public static function createInstance(array $additionalTags = []): DocBlockFactory
     {
@@ -62,7 +61,6 @@ final class DocBlockFactory implements DocBlockFactoryInterface
     /**
      * @param object|string $docblock A string containing the DocBlock to parse or an object supporting the
      *                                getDocComment method (such as a ReflectionClass object).
-     *
      */
     public function create($docblock, ?Types\Context $context = null, ?Location $location = null): DocBlock
     {

--- a/src/DocBlockFactory.php
+++ b/src/DocBlockFactory.php
@@ -87,7 +87,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
         }
 
         $parts = $this->splitDocBlock($this->stripDocComment($docblock));
-        list($templateMarker, $summary, $description, $tags) = $parts;
+        [$templateMarker, $summary, $description, $tags] = $parts;
 
         return new DocBlock(
             $summary,
@@ -218,7 +218,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
      *
      * @return DocBlock\Tag[]
      */
-    private function parseTagBlock(string $tags, Types\Context $context)
+    private function parseTagBlock(string $tags, Types\Context $context): array
     {
         $tags = $this->filterTagBlock($tags);
         if (!$tags) {
@@ -252,11 +252,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
         return $result;
     }
 
-    /**
-     * @param $tags
-     * @return string
-     */
-    private function filterTagBlock($tags): string
+    private function filterTagBlock($tags): ?string
     {
         $tags = trim($tags);
         if (!$tags) {

--- a/src/DocBlockFactory.php
+++ b/src/DocBlockFactory.php
@@ -41,7 +41,6 @@ final class DocBlockFactory implements DocBlockFactoryInterface
      *
      * @param string[] $additionalTags
      *
-     * @return DocBlockFactory
      */
     public static function createInstance(array $additionalTags = []): DocBlockFactory
     {
@@ -64,9 +63,8 @@ final class DocBlockFactory implements DocBlockFactoryInterface
      * @param object|string $docblock A string containing the DocBlock to parse or an object supporting the
      *                                getDocComment method (such as a ReflectionClass object).
      *
-     * @return DocBlock
      */
-    public function create($docblock, Types\Context $context = null, Location $location = null): DocBlock
+    public function create($docblock, ?Types\Context $context = null, ?Location $location = null): DocBlock
     {
         if (is_object($docblock)) {
             if (!method_exists($docblock, 'getDocComment')) {
@@ -99,7 +97,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
         );
     }
 
-    public function registerTagHandler($tagName, $handler)
+    public function registerTagHandler($tagName, $handler): void
     {
         $this->tagFactory->registerTagHandler($tagName, $handler);
     }

--- a/src/DocBlockFactory.php
+++ b/src/DocBlockFactory.php
@@ -29,8 +29,6 @@ final class DocBlockFactory implements DocBlockFactoryInterface
 
     /**
      * Initializes this factory with the required subcontractors.
-     *
-     * @param TagFactory         $tagFactory
      */
     public function __construct(DescriptionFactory $descriptionFactory, TagFactory $tagFactory)
     {
@@ -65,7 +63,6 @@ final class DocBlockFactory implements DocBlockFactoryInterface
     /**
      * @param object|string $docblock A string containing the DocBlock to parse or an object supporting the
      *                                getDocComment method (such as a ReflectionClass object).
-     * @param Location      $location
      *
      * @return DocBlock
      */
@@ -111,8 +108,6 @@ final class DocBlockFactory implements DocBlockFactoryInterface
      * Strips the asterisks from the DocBlock comment.
      *
      * @param string $comment String containing the comment text.
-     *
-     * @return string
      */
     private function stripDocComment(string $comment): string
     {
@@ -234,8 +229,6 @@ final class DocBlockFactory implements DocBlockFactoryInterface
     }
 
     /**
-     * @param string $tags
-     *
      * @return string[]
      */
     private function splitTagBlockIntoTagLines(string $tags)

--- a/src/DocBlockFactory.php
+++ b/src/DocBlockFactory.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -29,7 +30,6 @@ final class DocBlockFactory implements DocBlockFactoryInterface
     /**
      * Initializes this factory with the required subcontractors.
      *
-     * @param DescriptionFactory $descriptionFactory
      * @param TagFactory         $tagFactory
      */
     public function __construct(DescriptionFactory $descriptionFactory, TagFactory $tagFactory)
@@ -45,7 +45,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
      *
      * @return DocBlockFactory
      */
-    public static function createInstance(array $additionalTags = [])
+    public static function createInstance(array $additionalTags = []): DocBlockFactory
     {
         $fqsenResolver = new FqsenResolver();
         $tagFactory = new StandardTagFactory($fqsenResolver);
@@ -65,12 +65,11 @@ final class DocBlockFactory implements DocBlockFactoryInterface
     /**
      * @param object|string $docblock A string containing the DocBlock to parse or an object supporting the
      *                                getDocComment method (such as a ReflectionClass object).
-     * @param Types\Context $context
      * @param Location      $location
      *
      * @return DocBlock
      */
-    public function create($docblock, Types\Context $context = null, Location $location = null)
+    public function create($docblock, Types\Context $context = null, Location $location = null): DocBlock
     {
         if (is_object($docblock)) {
             if (!method_exists($docblock, 'getDocComment')) {
@@ -115,7 +114,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
      *
      * @return string
      */
-    private function stripDocComment($comment)
+    private function stripDocComment(string $comment): string
     {
         $comment = trim(preg_replace('#[ \t]*(?:\/\*\*|\*\/|\*)?[ \t]{0,1}(.*)?#u', '$1', $comment));
 
@@ -137,7 +136,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
      *
      * @return string[] containing the template marker (if any), summary, description and a string containing the tags.
      */
-    private function splitDocBlock($comment)
+    private function splitDocBlock(string $comment)
     {
         // Performance improvement cheat: if the first character is an @ then only tags are in this DocBlock. This
         // method does not split tags so we return this verbatim as the fourth result (tags). This saves us the
@@ -219,7 +218,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
      *
      * @return DocBlock\Tag[]
      */
-    private function parseTagBlock($tags, Types\Context $context)
+    private function parseTagBlock(string $tags, Types\Context $context)
     {
         $tags = $this->filterTagBlock($tags);
         if (!$tags) {
@@ -239,7 +238,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
      *
      * @return string[]
      */
-    private function splitTagBlockIntoTagLines($tags)
+    private function splitTagBlockIntoTagLines(string $tags)
     {
         $result = [];
         foreach (explode("\n", $tags) as $tag_line) {
@@ -257,7 +256,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
      * @param $tags
      * @return string
      */
-    private function filterTagBlock($tags)
+    private function filterTagBlock($tags): string
     {
         $tags = trim($tags);
         if (!$tags) {

--- a/src/DocBlockFactoryInterface.php
+++ b/src/DocBlockFactoryInterface.php
@@ -9,15 +9,12 @@ interface DocBlockFactoryInterface
      *
      * @param string[] $additionalTags
      *
-     * @return DocBlockFactory
      */
     public static function createInstance(array $additionalTags = []): DocBlockFactory;
 
     /**
      * @param string|object $docblock
-     * @param Location $location
      *
-     * @return DocBlock
      */
-    public function create($docblock, Types\Context $context = null, Location $location = null): DocBlock;
+    public function create($docblock, ?Types\Context $context = null, ?Location $location = null): DocBlock;
 }

--- a/src/DocBlockFactoryInterface.php
+++ b/src/DocBlockFactoryInterface.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace phpDocumentor\Reflection;
 
 interface DocBlockFactoryInterface
@@ -10,14 +11,13 @@ interface DocBlockFactoryInterface
      *
      * @return DocBlockFactory
      */
-    public static function createInstance(array $additionalTags = []);
+    public static function createInstance(array $additionalTags = []): DocBlockFactory;
 
     /**
-     * @param string $docblock
-     * @param Types\Context $context
+     * @param string|object $docblock
      * @param Location $location
      *
      * @return DocBlock
      */
-    public function create($docblock, Types\Context $context = null, Location $location = null);
+    public function create($docblock, Types\Context $context = null, Location $location = null): DocBlock;
 }

--- a/src/DocBlockFactoryInterface.php
+++ b/src/DocBlockFactoryInterface.php
@@ -8,13 +8,11 @@ interface DocBlockFactoryInterface
      * Factory method for easy instantiation.
      *
      * @param string[] $additionalTags
-     *
      */
     public static function createInstance(array $additionalTags = []): DocBlockFactory;
 
     /**
      * @param string|object $docblock
-     *
      */
     public function create($docblock, ?Types\Context $context = null, ?Location $location = null): DocBlock;
 }

--- a/tests/integration/DocblocksWithAnnotationsTest.php
+++ b/tests/integration/DocblocksWithAnnotationsTest.php
@@ -24,12 +24,12 @@ final class DocblocksWithAnnotationsTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testDocblockWithAnnotations()
+    public function testDocblockWithAnnotations(): void
     {
         $docComment = <<<DOCCOMMENT
             /**

--- a/tests/integration/DocblocksWithAnnotationsTest.php
+++ b/tests/integration/DocblocksWithAnnotationsTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/integration/InterpretingDocBlocksTest.php
+++ b/tests/integration/InterpretingDocBlocksTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/integration/InterpretingDocBlocksTest.php
+++ b/tests/integration/InterpretingDocBlocksTest.php
@@ -28,12 +28,12 @@ class InterpretingDocBlocksTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testInterpretingASimpleDocBlock()
+    public function testInterpretingASimpleDocBlock(): void
     {
         /**
          * @var DocBlock    $docblock
@@ -56,7 +56,7 @@ DESCRIPTION;
         $this->assertEmpty($docblock->getTags());
     }
 
-    public function testInterpretingTags()
+    public function testInterpretingTags(): void
     {
         /**
          * @var DocBlock $docblock
@@ -78,7 +78,7 @@ DESCRIPTION;
         $this->assertSame('', (string)$seeTag->getDescription());
     }
 
-    public function testDescriptionsCanEscapeAtSignsAndClosingBraces()
+    public function testDescriptionsCanEscapeAtSignsAndClosingBraces(): void
     {
         /**
          * @var string      $docComment

--- a/tests/integration/ReconstitutingADocBlockTest.php
+++ b/tests/integration/ReconstitutingADocBlockTest.php
@@ -24,12 +24,12 @@ class ReconstitutingADocBlockTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testReconstituteADocBlock()
+    public function testReconstituteADocBlock(): void
     {
         /**
          * @var string $docComment

--- a/tests/integration/ReconstitutingADocBlockTest.php
+++ b/tests/integration/ReconstitutingADocBlockTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/integration/UsingTagsTest.php
+++ b/tests/integration/UsingTagsTest.php
@@ -26,12 +26,12 @@ class UsingTagsTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function testAddingYourOwnTagUsingAStaticMethodAsFactory()
+    public function testAddingYourOwnTagUsingAStaticMethodAsFactory(): void
     {
         /**
          * @var object[] $customTagObjects

--- a/tests/integration/UsingTagsTest.php
+++ b/tests/integration/UsingTagsTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/DescriptionFactoryTest.php
+++ b/tests/unit/DocBlock/DescriptionFactoryTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/DescriptionFactoryTest.php
+++ b/tests/unit/DocBlock/DescriptionFactoryTest.php
@@ -27,7 +27,7 @@ class DescriptionFactoryTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -38,7 +38,7 @@ class DescriptionFactoryTest extends TestCase
      * @uses         phpDocumentor\Reflection\DocBlock\Description
      * @dataProvider provideSimpleExampleDescriptions
      */
-    public function testDescriptionCanParseASimpleString($contents)
+    public function testDescriptionCanParseASimpleString($contents): void
     {
         $tagFactory = m::mock(TagFactory::class);
         $tagFactory->shouldReceive('create')->never();
@@ -55,7 +55,7 @@ class DescriptionFactoryTest extends TestCase
      * @uses         phpDocumentor\Reflection\DocBlock\Description
      * @dataProvider provideEscapeSequences
      */
-    public function testEscapeSequences($contents, $expected)
+    public function testEscapeSequences($contents, $expected): void
     {
         $tagFactory = m::mock(TagFactory::class);
         $tagFactory->shouldReceive('create')->never();
@@ -75,7 +75,7 @@ class DescriptionFactoryTest extends TestCase
      * @uses   phpDocumentor\Reflection\DocBlock\Tags\Formatter\PassthroughFormatter
      * @uses   phpDocumentor\Reflection\Types\Context
      */
-    public function testDescriptionCanParseAStringWithInlineTag()
+    public function testDescriptionCanParseAStringWithInlineTag(): void
     {
         $contents   = 'This is text for a {@link http://phpdoc.org/ description} that uses an inline tag.';
         $context    = new Context('');
@@ -100,7 +100,7 @@ class DescriptionFactoryTest extends TestCase
      * @uses   phpDocumentor\Reflection\DocBlock\Tags\Formatter\PassthroughFormatter
      * @uses   phpDocumentor\Reflection\Types\Context
      */
-    public function testDescriptionCanParseAStringStartingWithInlineTag()
+    public function testDescriptionCanParseAStringStartingWithInlineTag(): void
     {
         $contents   = '{@link http://phpdoc.org/ This} is text for a description that starts with an inline tag.';
         $context    = new Context('');
@@ -121,7 +121,7 @@ class DescriptionFactoryTest extends TestCase
      * @covers ::create
      * @uses   phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testIfSuperfluousStartingSpacesAreRemoved()
+    public function testIfSuperfluousStartingSpacesAreRemoved(): void
     {
         $factory         = new DescriptionFactory(m::mock(TagFactory::class));
         $descriptionText = <<<DESCRIPTION

--- a/tests/unit/DocBlock/DescriptionTest.php
+++ b/tests/unit/DocBlock/DescriptionTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -123,14 +124,5 @@ class DescriptionTest extends TestCase
         $fixture = new Description($body, $tags);
         $expected = '@JoinTable(name="table", joinColumns={@JoinColumn (name="column_id", referencedColumnName="id")}, inverseJoinColumns={@JoinColumn (name="column_id_2", referencedColumnName="id")})';
         $this->assertSame($expected, (string)$fixture);
-    }
-
-    /**
-     * @covers ::__construct
-     * @expectedException \InvalidArgumentException
-     */
-    public function testBodyTemplateMustBeAString()
-    {
-        new Description([]);
     }
 }

--- a/tests/unit/DocBlock/DescriptionTest.php
+++ b/tests/unit/DocBlock/DescriptionTest.php
@@ -26,7 +26,7 @@ class DescriptionTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -38,7 +38,7 @@ class DescriptionTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Formatter\PassthroughFormatter
      */
-    public function testDescriptionCanRenderUsingABodyWithPlaceholdersAndTags()
+    public function testDescriptionCanRenderUsingABodyWithPlaceholdersAndTags(): void
     {
         $body = 'This is a %1$s body.';
         $expected = 'This is a {@internal significant} body.';
@@ -63,7 +63,7 @@ class DescriptionTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Formatter\PassthroughFormatter
      */
-    public function testDescriptionCanBeCastToString()
+    public function testDescriptionCanBeCastToString(): void
     {
         $body = 'This is a %1$s body.';
         $expected = 'This is a {@internal significant} body.';
@@ -79,7 +79,7 @@ class DescriptionTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Generic
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      */
-    public function testDescriptionTagsGetter()
+    public function testDescriptionTagsGetter(): void
     {
         $body = '@JoinTable(name="table", joinColumns=%1$s, inverseJoinColumns=%2$s)';
 
@@ -109,7 +109,7 @@ class DescriptionTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Formatter\PassthroughFormatter
      */
-    public function testDescriptionMultipleTagsCanBeCastToString()
+    public function testDescriptionMultipleTagsCanBeCastToString(): void
     {
         $body = '@JoinTable(name="table", joinColumns=%1$s, inverseJoinColumns=%2$s)';
 

--- a/tests/unit/DocBlock/ExampleFinderTest.php
+++ b/tests/unit/DocBlock/ExampleFinderTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace phpDocumentor\Reflection\DocBlock;
 

--- a/tests/unit/DocBlock/ExampleFinderTest.php
+++ b/tests/unit/DocBlock/ExampleFinderTest.php
@@ -18,12 +18,12 @@ class ExampleFinderTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->fixture = new ExampleFinder();
     }
@@ -34,7 +34,7 @@ class ExampleFinderTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Example
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testFileNotFound()
+    public function testFileNotFound(): void
     {
         $example = new Example('./example.php', false, 1, 0, new Description('Test'));
         $this->assertSame('** File not found : ./example.php **', $this->fixture->find($example));

--- a/tests/unit/DocBlock/SerializerTest.php
+++ b/tests/unit/DocBlock/SerializerTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -197,41 +198,5 @@ DOCCOMMENT_AFTER_REMOVE;
 
         $docBlock->removeTag($genericTag);
         $this->assertSame($expectedAfterRemove, $fixture->getDocComment($docBlock));
-    }
-
-    /**
-     * @covers ::__construct
-     * @expectedException \InvalidArgumentException
-     */
-    public function testInitializationFailsIfIndentIsNotAnInteger()
-    {
-        new Serializer([]);
-    }
-
-    /**
-     * @covers ::__construct
-     * @expectedException \InvalidArgumentException
-     */
-    public function testInitializationFailsIfIndentStringIsNotAString()
-    {
-        new Serializer(0, []);
-    }
-
-    /**
-     * @covers ::__construct
-     * @expectedException \InvalidArgumentException
-     */
-    public function testInitializationFailsIfIndentFirstLineIsNotABoolean()
-    {
-        new Serializer(0, '', []);
-    }
-
-    /**
-     * @covers ::__construct
-     * @expectedException \InvalidArgumentException
-     */
-    public function testInitializationFailsIfLineLengthIsNotNullNorAnInteger()
-    {
-        new Serializer(0, '', false, []);
     }
 }

--- a/tests/unit/DocBlock/SerializerTest.php
+++ b/tests/unit/DocBlock/SerializerTest.php
@@ -26,7 +26,7 @@ class SerializerTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -40,7 +40,7 @@ class SerializerTest extends TestCase
      * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      * @uses phpDocumentor\Reflection\DocBlock\Tags\Generic
      */
-    public function testReconstructsADocCommentFromADocBlock()
+    public function testReconstructsADocCommentFromADocBlock(): void
     {
         $expected = <<<'DOCCOMMENT'
 /**
@@ -74,7 +74,7 @@ DOCCOMMENT;
      * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      * @uses phpDocumentor\Reflection\DocBlock\Tags\Generic
      */
-    public function testAddPrefixToDocBlock()
+    public function testAddPrefixToDocBlock(): void
     {
         $expected = <<<'DOCCOMMENT'
 aa/**
@@ -108,7 +108,7 @@ DOCCOMMENT;
      * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      * @uses phpDocumentor\Reflection\DocBlock\Tags\Generic
      */
-    public function testAddPrefixToDocBlockExceptFirstLine()
+    public function testAddPrefixToDocBlockExceptFirstLine(): void
     {
         $expected = <<<'DOCCOMMENT'
 /**
@@ -142,7 +142,7 @@ DOCCOMMENT;
      * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      * @uses phpDocumentor\Reflection\DocBlock\Tags\Generic
      */
-    public function testWordwrapsAroundTheGivenAmountOfCharacters()
+    public function testWordwrapsAroundTheGivenAmountOfCharacters(): void
     {
         $expected = <<<'DOCCOMMENT'
 /**

--- a/tests/unit/DocBlock/StandardTagFactoryTest.php
+++ b/tests/unit/DocBlock/StandardTagFactoryTest.php
@@ -241,7 +241,7 @@ class StandardTagFactoryTest extends TestCase
         $this->expectException('InvalidArgumentException');
         $resolver   = m::mock(FqsenResolver::class);
         $tagFactory = new StandardTagFactory($resolver);
-        $tagFactory->registerTagHandler('Name\Spaced\Tag', Author::class);
+        $tagFactory->registerTagHandler(\Name\Spaced\Tag::class, Author::class);
     }
 
     /**

--- a/tests/unit/DocBlock/StandardTagFactoryTest.php
+++ b/tests/unit/DocBlock/StandardTagFactoryTest.php
@@ -237,54 +237,12 @@ class StandardTagFactoryTest extends TestCase
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
      * @expectedException \InvalidArgumentException
      */
-    public function testHandlerRegistrationFailsIfProvidedTagNameIsNotAString()
-    {
-        $resolver   = m::mock(FqsenResolver::class);
-        $tagFactory = new StandardTagFactory($resolver);
-
-        $tagFactory->registerTagHandler([], Author::class);
-    }
-
-    /**
-     * @covers ::registerTagHandler
-     * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::__construct
-     * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
-     * @expectedException \InvalidArgumentException
-     */
-    public function testHandlerRegistrationFailsIfProvidedTagNameIsEmpty()
-    {
-        $resolver   = m::mock(FqsenResolver::class);
-        $tagFactory = new StandardTagFactory($resolver);
-
-        $tagFactory->registerTagHandler('', Author::class);
-    }
-
-    /**
-     * @covers ::registerTagHandler
-     * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::__construct
-     * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
-     * @expectedException \InvalidArgumentException
-     */
     public function testHandlerRegistrationFailsIfProvidedTagNameIsNamespaceButNotFullyQualified()
     {
         $resolver   = m::mock(FqsenResolver::class);
         $tagFactory = new StandardTagFactory($resolver);
 
         $tagFactory->registerTagHandler('Name\Spaced\Tag', Author::class);
-    }
-
-    /**
-     * @covers ::registerTagHandler
-     * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::__construct
-     * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
-     * @expectedException \InvalidArgumentException
-     */
-    public function testHandlerRegistrationFailsIfProvidedHandlerIsNotAString()
-    {
-        $resolver   = m::mock(FqsenResolver::class);
-        $tagFactory = new StandardTagFactory($resolver);
-
-        $tagFactory->registerTagHandler('my-tag', []);
     }
 
     /**

--- a/tests/unit/DocBlock/StandardTagFactoryTest.php
+++ b/tests/unit/DocBlock/StandardTagFactoryTest.php
@@ -36,7 +36,7 @@ class StandardTagFactoryTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -49,7 +49,7 @@ class StandardTagFactoryTest extends TestCase
      * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      * @uses phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testCreatingAGenericTag()
+    public function testCreatingAGenericTag(): void
     {
         $expectedTagName         = 'unknown-tag';
         $expectedDescriptionText = 'This is a description';
@@ -81,7 +81,7 @@ class StandardTagFactoryTest extends TestCase
      * @uses phpDocumentor\Reflection\DocBlock\Tags\Author
      * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      */
-    public function testCreatingASpecificTag()
+    public function testCreatingASpecificTag(): void
     {
         $context    = new Context('');
         $tagFactory = new StandardTagFactory(m::mock(FqsenResolver::class));
@@ -102,7 +102,7 @@ class StandardTagFactoryTest extends TestCase
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Reference\Fqsen
      */
-    public function testAnEmptyContextIsCreatedIfNoneIsProvided()
+    public function testAnEmptyContextIsCreatedIfNoneIsProvided(): void
     {
         $fqsen              = '\Tag';
         $resolver           = m::mock(FqsenResolver::class)
@@ -130,7 +130,7 @@ class StandardTagFactoryTest extends TestCase
      * @uses phpDocumentor\Reflection\DocBlock\Tags\Author
      * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      */
-    public function testPassingYourOwnSetOfTagHandlers()
+    public function testPassingYourOwnSetOfTagHandlers(): void
     {
         $context    = new Context('');
         $tagFactory = new StandardTagFactory(m::mock(FqsenResolver::class), ['user' => Author::class]);
@@ -149,7 +149,7 @@ class StandardTagFactoryTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The tag "@user[myuser" does not seem to be wellformed, please check it for errors
      */
-    public function testExceptionIsThrownIfProvidedTagIsNotWellformed()
+    public function testExceptionIsThrownIfProvidedTagIsNotWellformed(): void
     {
         $tagFactory = new StandardTagFactory(m::mock(FqsenResolver::class));
         $tagFactory->create('@user[myuser');
@@ -160,7 +160,7 @@ class StandardTagFactoryTest extends TestCase
      * @covers ::addParameter
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
      */
-    public function testAddParameterToServiceLocator()
+    public function testAddParameterToServiceLocator(): void
     {
         $resolver   = m::mock(FqsenResolver::class);
         $tagFactory = new StandardTagFactory($resolver);
@@ -177,7 +177,7 @@ class StandardTagFactoryTest extends TestCase
      * @covers ::addService
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::__construct
      */
-    public function testAddServiceToServiceLocator()
+    public function testAddServiceToServiceLocator(): void
     {
         $service = new PassthroughFormatter();
 
@@ -196,7 +196,7 @@ class StandardTagFactoryTest extends TestCase
      * @covers ::addService
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::__construct
      */
-    public function testInjectConcreteServiceForInterfaceToServiceLocator()
+    public function testInjectConcreteServiceForInterfaceToServiceLocator(): void
     {
         $interfaceName = Formatter::class;
         $service       = new PassthroughFormatter();
@@ -219,7 +219,7 @@ class StandardTagFactoryTest extends TestCase
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::create
      * @uses phpDocumentor\Reflection\DocBlock\Tags\Author
      */
-    public function testRegisteringAHandlerForANewTag()
+    public function testRegisteringAHandlerForANewTag(): void
     {
         $resolver   = m::mock(FqsenResolver::class);
         $tagFactory = new StandardTagFactory($resolver);
@@ -237,7 +237,7 @@ class StandardTagFactoryTest extends TestCase
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
      * @expectedException \InvalidArgumentException
      */
-    public function testHandlerRegistrationFailsIfProvidedTagNameIsNamespaceButNotFullyQualified()
+    public function testHandlerRegistrationFailsIfProvidedTagNameIsNamespaceButNotFullyQualified(): void
     {
         $resolver   = m::mock(FqsenResolver::class);
         $tagFactory = new StandardTagFactory($resolver);
@@ -251,7 +251,7 @@ class StandardTagFactoryTest extends TestCase
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
      * @expectedException \InvalidArgumentException
      */
-    public function testHandlerRegistrationFailsIfProvidedHandlerIsEmpty()
+    public function testHandlerRegistrationFailsIfProvidedHandlerIsEmpty(): void
     {
         $resolver   = m::mock(FqsenResolver::class);
         $tagFactory = new StandardTagFactory($resolver);
@@ -265,7 +265,7 @@ class StandardTagFactoryTest extends TestCase
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
      * @expectedException \InvalidArgumentException
      */
-    public function testHandlerRegistrationFailsIfProvidedHandlerIsNotAnExistingClassName()
+    public function testHandlerRegistrationFailsIfProvidedHandlerIsNotAnExistingClassName(): void
     {
         $resolver   = m::mock(FqsenResolver::class);
         $tagFactory = new StandardTagFactory($resolver);
@@ -279,7 +279,7 @@ class StandardTagFactoryTest extends TestCase
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
      * @expectedException \InvalidArgumentException
      */
-    public function testHandlerRegistrationFailsIfProvidedHandlerDoesNotImplementTheTagInterface()
+    public function testHandlerRegistrationFailsIfProvidedHandlerDoesNotImplementTheTagInterface(): void
     {
         $resolver   = m::mock(FqsenResolver::class);
         $tagFactory = new StandardTagFactory($resolver);
@@ -295,7 +295,7 @@ class StandardTagFactoryTest extends TestCase
      * @uses phpDocumentor\Reflection\Docblock\Tags\Return_
      * @uses phpDocumentor\Reflection\Docblock\Tags\BaseTag
      */
-    public function testReturntagIsMappedCorrectly()
+    public function testReturntagIsMappedCorrectly(): void
     {
         $context    = new Context('');
 

--- a/tests/unit/DocBlock/StandardTagFactoryTest.php
+++ b/tests/unit/DocBlock/StandardTagFactoryTest.php
@@ -144,13 +144,13 @@ class StandardTagFactoryTest extends TestCase
 
     /**
      * @covers ::create
-     * @uses                     phpDocumentor\Reflection\DocBlock\StandardTagFactory::__construct
-     * @uses                     phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The tag "@user[myuser" does not seem to be wellformed, please check it for errors
+     * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::__construct
+     * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
      */
-    public function testExceptionIsThrownIfProvidedTagIsNotWellformed(): void
+    public function testExceptionIsThrownIfProvidedTagIsNotWellformed() : void
     {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('The tag "@user[myuser" does not seem to be wellformed, please check it for errors');
         $tagFactory = new StandardTagFactory(m::mock(FqsenResolver::class));
         $tagFactory->create('@user[myuser');
     }
@@ -235,13 +235,12 @@ class StandardTagFactoryTest extends TestCase
      * @covers ::registerTagHandler
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::__construct
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
-     * @expectedException \InvalidArgumentException
      */
-    public function testHandlerRegistrationFailsIfProvidedTagNameIsNamespaceButNotFullyQualified(): void
+    public function testHandlerRegistrationFailsIfProvidedTagNameIsNamespaceButNotFullyQualified() : void
     {
+        $this->expectException('InvalidArgumentException');
         $resolver   = m::mock(FqsenResolver::class);
         $tagFactory = new StandardTagFactory($resolver);
-
         $tagFactory->registerTagHandler('Name\Spaced\Tag', Author::class);
     }
 
@@ -249,13 +248,12 @@ class StandardTagFactoryTest extends TestCase
      * @covers ::registerTagHandler
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::__construct
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
-     * @expectedException \InvalidArgumentException
      */
-    public function testHandlerRegistrationFailsIfProvidedHandlerIsEmpty(): void
+    public function testHandlerRegistrationFailsIfProvidedHandlerIsEmpty() : void
     {
+        $this->expectException('InvalidArgumentException');
         $resolver   = m::mock(FqsenResolver::class);
         $tagFactory = new StandardTagFactory($resolver);
-
         $tagFactory->registerTagHandler('my-tag', '');
     }
 
@@ -263,13 +261,12 @@ class StandardTagFactoryTest extends TestCase
      * @covers ::registerTagHandler
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::__construct
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
-     * @expectedException \InvalidArgumentException
      */
-    public function testHandlerRegistrationFailsIfProvidedHandlerIsNotAnExistingClassName(): void
+    public function testHandlerRegistrationFailsIfProvidedHandlerIsNotAnExistingClassName() : void
     {
+        $this->expectException('InvalidArgumentException');
         $resolver   = m::mock(FqsenResolver::class);
         $tagFactory = new StandardTagFactory($resolver);
-
         $tagFactory->registerTagHandler('my-tag', 'IDoNotExist');
     }
 
@@ -277,13 +274,12 @@ class StandardTagFactoryTest extends TestCase
      * @covers ::registerTagHandler
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::__construct
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
-     * @expectedException \InvalidArgumentException
      */
-    public function testHandlerRegistrationFailsIfProvidedHandlerDoesNotImplementTheTagInterface(): void
+    public function testHandlerRegistrationFailsIfProvidedHandlerDoesNotImplementTheTagInterface() : void
     {
+        $this->expectException('InvalidArgumentException');
         $resolver   = m::mock(FqsenResolver::class);
         $tagFactory = new StandardTagFactory($resolver);
-
         $tagFactory->registerTagHandler('my-tag', 'stdClass');
     }
 

--- a/tests/unit/DocBlock/StandardTagFactoryTest.php
+++ b/tests/unit/DocBlock/StandardTagFactoryTest.php
@@ -147,7 +147,7 @@ class StandardTagFactoryTest extends TestCase
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::__construct
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
      */
-    public function testExceptionIsThrownIfProvidedTagIsNotWellformed() : void
+    public function testExceptionIsThrownIfProvidedTagIsNotWellformed(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('The tag "@user[myuser" does not seem to be wellformed, please check it for errors');
@@ -236,7 +236,7 @@ class StandardTagFactoryTest extends TestCase
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::__construct
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
      */
-    public function testHandlerRegistrationFailsIfProvidedTagNameIsNamespaceButNotFullyQualified() : void
+    public function testHandlerRegistrationFailsIfProvidedTagNameIsNamespaceButNotFullyQualified(): void
     {
         $this->expectException('InvalidArgumentException');
         $resolver   = m::mock(FqsenResolver::class);
@@ -249,7 +249,7 @@ class StandardTagFactoryTest extends TestCase
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::__construct
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
      */
-    public function testHandlerRegistrationFailsIfProvidedHandlerIsEmpty() : void
+    public function testHandlerRegistrationFailsIfProvidedHandlerIsEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         $resolver   = m::mock(FqsenResolver::class);
@@ -262,7 +262,7 @@ class StandardTagFactoryTest extends TestCase
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::__construct
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
      */
-    public function testHandlerRegistrationFailsIfProvidedHandlerIsNotAnExistingClassName() : void
+    public function testHandlerRegistrationFailsIfProvidedHandlerIsNotAnExistingClassName(): void
     {
         $this->expectException('InvalidArgumentException');
         $resolver   = m::mock(FqsenResolver::class);
@@ -275,7 +275,7 @@ class StandardTagFactoryTest extends TestCase
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::__construct
      * @uses phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
      */
-    public function testHandlerRegistrationFailsIfProvidedHandlerDoesNotImplementTheTagInterface() : void
+    public function testHandlerRegistrationFailsIfProvidedHandlerDoesNotImplementTheTagInterface(): void
     {
         $this->expectException('InvalidArgumentException');
         $resolver   = m::mock(FqsenResolver::class);

--- a/tests/unit/DocBlock/StandardTagFactoryTest.php
+++ b/tests/unit/DocBlock/StandardTagFactoryTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/AuthorTest.php
+++ b/tests/unit/DocBlock/Tags/AuthorTest.php
@@ -98,7 +98,7 @@ class AuthorTest extends TestCase
     /**
      * @covers ::__construct
      */
-    public function testInitializationFailsIfEmailIsNotValid() : void
+    public function testInitializationFailsIfEmailIsNotValid(): void
     {
         $this->expectException('InvalidArgumentException');
         new Author('Mike van Riel', 'mike');

--- a/tests/unit/DocBlock/Tags/AuthorTest.php
+++ b/tests/unit/DocBlock/Tags/AuthorTest.php
@@ -10,6 +10,7 @@
  * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      http://phpdoc.org
  */
+
 namespace phpDocumentor\Reflection\DocBlock\Tags;
 
 use Mockery as m;

--- a/tests/unit/DocBlock/Tags/AuthorTest.php
+++ b/tests/unit/DocBlock/Tags/AuthorTest.php
@@ -97,10 +97,10 @@ class AuthorTest extends TestCase
 
     /**
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
-    public function testInitializationFailsIfEmailIsNotValid(): void
+    public function testInitializationFailsIfEmailIsNotValid() : void
     {
+        $this->expectException('InvalidArgumentException');
         new Author('Mike van Riel', 'mike');
     }
 

--- a/tests/unit/DocBlock/Tags/AuthorTest.php
+++ b/tests/unit/DocBlock/Tags/AuthorTest.php
@@ -25,7 +25,7 @@ class AuthorTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -34,7 +34,7 @@ class AuthorTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Tags\Author::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned()
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Author('Mike van Riel', 'mike@phpdoc.org');
 
@@ -48,7 +48,7 @@ class AuthorTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter()
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Author('Mike van Riel', 'mike@phpdoc.org');
 
@@ -59,7 +59,7 @@ class AuthorTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Tags\Author::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter()
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Author('Mike van Riel', 'mike@phpdoc.org');
 
@@ -73,7 +73,7 @@ class AuthorTest extends TestCase
      * @covers ::__construct
      * @covers ::getAuthorName
      */
-    public function testHasTheAuthorName()
+    public function testHasTheAuthorName(): void
     {
         $expected = 'Mike van Riel';
 
@@ -86,7 +86,7 @@ class AuthorTest extends TestCase
      * @covers ::__construct
      * @covers ::getEmail
      */
-    public function testHasTheAuthorMailAddress()
+    public function testHasTheAuthorMailAddress(): void
     {
         $expected = 'mike@phpdoc.org';
 
@@ -99,7 +99,7 @@ class AuthorTest extends TestCase
      * @covers ::__construct
      * @expectedException \InvalidArgumentException
      */
-    public function testInitializationFailsIfEmailIsNotValid()
+    public function testInitializationFailsIfEmailIsNotValid(): void
     {
         new Author('Mike van Riel', 'mike');
     }
@@ -108,7 +108,7 @@ class AuthorTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned()
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Author('Mike van Riel', 'mike@phpdoc.org');
 
@@ -119,7 +119,7 @@ class AuthorTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationWithEmtpyEmail()
+    public function testStringRepresentationWithEmtpyEmail(): void
     {
         $fixture = new Author('Mike van Riel', '');
 
@@ -130,7 +130,7 @@ class AuthorTest extends TestCase
      * @covers ::create
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Author::<public>
      */
-    public function testFactoryMethod()
+    public function testFactoryMethod(): void
     {
         $fixture = Author::create('Mike van Riel <mike@phpdoc.org>');
 
@@ -143,7 +143,7 @@ class AuthorTest extends TestCase
      * @covers ::create
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Author::<public>
      */
-    public function testFactoryMethodReturnsNullIfItCouldNotReadBody()
+    public function testFactoryMethodReturnsNullIfItCouldNotReadBody(): void
     {
         $this->assertNull(Author::create('dfgr<'));
     }

--- a/tests/unit/DocBlock/Tags/AuthorTest.php
+++ b/tests/unit/DocBlock/Tags/AuthorTest.php
@@ -83,16 +83,6 @@ class AuthorTest extends TestCase
 
     /**
      * @covers ::__construct
-     * @covers ::getAuthorName
-     * @expectedException \InvalidArgumentException
-     */
-    public function testInitializationFailsIfAuthorNameIsNotAString()
-    {
-        new Author([], 'mike@phpdoc.org');
-    }
-
-    /**
-     * @covers ::__construct
      * @covers ::getEmail
      */
     public function testHasTheAuthorMailAddress()
@@ -102,15 +92,6 @@ class AuthorTest extends TestCase
         $fixture = new Author('Mike van Riel', $expected);
 
         $this->assertSame($expected, $fixture->getEmail());
-    }
-
-    /**
-     * @covers ::__construct
-     * @expectedException \InvalidArgumentException
-     */
-    public function testInitializationFailsIfEmailIsNotAString()
-    {
-        new Author('Mike van Riel', []);
     }
 
     /**

--- a/tests/unit/DocBlock/Tags/AuthorTest.php
+++ b/tests/unit/DocBlock/Tags/AuthorTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/CoversTest.php
+++ b/tests/unit/DocBlock/Tags/CoversTest.php
@@ -149,7 +149,7 @@ class CoversTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty() : void
+    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->assertNull(Covers::create(''));

--- a/tests/unit/DocBlock/Tags/CoversTest.php
+++ b/tests/unit/DocBlock/Tags/CoversTest.php
@@ -31,7 +31,7 @@ class CoversTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -41,7 +41,7 @@ class CoversTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned()
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Covers(new Fqsen('\DateTime'), new Description('Description'));
 
@@ -56,7 +56,7 @@ class CoversTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter()
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Covers(new Fqsen('\DateTime'), new Description('Description'));
 
@@ -68,7 +68,7 @@ class CoversTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter()
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Covers(new Fqsen('\DateTime'), new Description('Description'));
 
@@ -82,7 +82,7 @@ class CoversTest extends TestCase
      * @covers ::__construct
      * @covers ::getReference
      */
-    public function testHasReferenceToFqsen()
+    public function testHasReferenceToFqsen(): void
     {
         $expected = new Fqsen('\DateTime');
 
@@ -96,7 +96,7 @@ class CoversTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testHasDescription()
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -110,7 +110,7 @@ class CoversTest extends TestCase
      * @covers ::__toString
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testStringRepresentationIsReturned()
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Covers(new Fqsen('\DateTime'), new Description('Description'));
 
@@ -126,7 +126,7 @@ class CoversTest extends TestCase
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethod()
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver = m::mock(FqsenResolver::class);
@@ -150,7 +150,7 @@ class CoversTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty()
+    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
     {
         $this->assertNull(Covers::create(''));
     }

--- a/tests/unit/DocBlock/Tags/CoversTest.php
+++ b/tests/unit/DocBlock/Tags/CoversTest.php
@@ -150,15 +150,6 @@ class CoversTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotString()
-    {
-        $this->assertNull(Covers::create([]));
-    }
-
-    /**
-     * @covers ::create
-     * @expectedException \InvalidArgumentException
-     */
     public function testFactoryMethodFailsIfBodyIsNotEmpty()
     {
         $this->assertNull(Covers::create(''));

--- a/tests/unit/DocBlock/Tags/CoversTest.php
+++ b/tests/unit/DocBlock/Tags/CoversTest.php
@@ -148,10 +148,10 @@ class CoversTest extends TestCase
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
+    public function testFactoryMethodFailsIfBodyIsNotEmpty() : void
     {
+        $this->expectException('InvalidArgumentException');
         $this->assertNull(Covers::create(''));
     }
 }

--- a/tests/unit/DocBlock/Tags/CoversTest.php
+++ b/tests/unit/DocBlock/Tags/CoversTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/DeprecatedTest.php
+++ b/tests/unit/DocBlock/Tags/DeprecatedTest.php
@@ -28,7 +28,7 @@ class DeprecatedTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -38,7 +38,7 @@ class DeprecatedTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned()
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Deprecated('1.0', new Description('Description'));
 
@@ -53,7 +53,7 @@ class DeprecatedTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter()
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Deprecated('1.0', new Description('Description'));
 
@@ -65,7 +65,7 @@ class DeprecatedTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter()
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Deprecated('1.0', new Description('Description'));
 
@@ -146,7 +146,7 @@ class DeprecatedTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethodCreatesEmptyDeprecatedTag()
+    public function testFactoryMethodCreatesEmptyDeprecatedTag(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $descriptionFactory->shouldReceive('create')->never();
@@ -162,7 +162,7 @@ class DeprecatedTest extends TestCase
      * @covers ::create
      * @uses   \phpDocumentor\Reflection\DocBlock\Tags\Deprecated::__construct
      */
-    public function testFactoryMethodReturnsNullIfBodyDoesNotMatchRegex()
+    public function testFactoryMethodReturnsNullIfBodyDoesNotMatchRegex(): void
     {
         $this->assertEquals(new Deprecated(), Deprecated::create('dkhf<'));
     }

--- a/tests/unit/DocBlock/Tags/DeprecatedTest.php
+++ b/tests/unit/DocBlock/Tags/DeprecatedTest.php
@@ -74,71 +74,70 @@ class DeprecatedTest extends TestCase
 
         $this->assertSame('Rendered output', $fixture->render($formatter));
     }
-//
-//    /**
-//     * @covers ::__construct
-//     * @covers ::getVersion
-//     */
-//    public function testHasVersionNumber()
-//    {
-//        $expected = '1.0';
-//
-//        $fixture = new Deprecated($expected);
-//
-//        $this->assertSame($expected, $fixture->getVersion());
-//    }
-//
-//    /**
-//     * @covers ::__construct
-//     * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
-//     * @uses   \phpDocumentor\Reflection\DocBlock\Description
-//     */
-//    public function testHasDescription()
-//    {
-//        $expected = new Description('Description');
-//
-//        $fixture = new Deprecated('1.0', $expected);
-//
-//        $this->assertSame($expected, $fixture->getDescription());
-//    }
-//
-//    /**
-//     * @covers ::__construct
-//     * @covers ::__toString
-//     * @uses   \phpDocumentor\Reflection\DocBlock\Description
-//     */
-//    public function testStringRepresentationIsReturned()
-//    {
-//        $fixture = new Deprecated('1.0', new Description('Description'));
-//
-//        $this->assertSame('1.0 Description', (string)$fixture);
-//    }
-//
-//    /**
-//     * @covers ::create
-//     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Deprecated::<public>
-//     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
-//     * @uses \phpDocumentor\Reflection\DocBlock\Description
-//     * @uses \phpDocumentor\Reflection\Types\Context
-//     */
-//    public function testFactoryMethod()
-//    {
-//        $descriptionFactory = m::mock(DescriptionFactory::class);
-//        $context = new Context('');
-//
-//        $version = '1.0';
-//        $description = new Description('My Description');
-//
-//        $descriptionFactory->shouldReceive('create')->with('My Description', $context)->andReturn($description);
-//
-//        $fixture = Deprecated::create('1.0 My Description', $descriptionFactory, $context);
-//
-//        $this->assertSame('1.0 My Description', (string)$fixture);
-//        $this->assertSame($version, $fixture->getVersion());
-//        $this->assertSame($description, $fixture->getDescription());
-//    }
 
-//
+    /**
+     * @covers ::__construct
+     * @covers ::getVersion
+     */
+    public function testHasVersionNumber()
+    {
+        $expected = '1.0';
+
+        $fixture = new Deprecated($expected);
+
+        $this->assertSame($expected, $fixture->getVersion());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
+     * @uses   \phpDocumentor\Reflection\DocBlock\Description
+     */
+    public function testHasDescription()
+    {
+        $expected = new Description('Description');
+
+        $fixture = new Deprecated('1.0', $expected);
+
+        $this->assertSame($expected, $fixture->getDescription());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::__toString
+     * @uses   \phpDocumentor\Reflection\DocBlock\Description
+     */
+    public function testStringRepresentationIsReturned()
+    {
+        $fixture = new Deprecated('1.0', new Description('Description'));
+
+        $this->assertSame('1.0 Description', (string)$fixture);
+    }
+
+    /**
+     * @covers ::create
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Deprecated::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\Context
+     */
+    public function testFactoryMethod()
+    {
+        $descriptionFactory = m::mock(DescriptionFactory::class);
+        $context = new Context('');
+
+        $version = '1.0';
+        $description = new Description('My Description');
+
+        $descriptionFactory->shouldReceive('create')->with('My Description', $context)->andReturn($description);
+
+        $fixture = Deprecated::create('1.0 My Description', $descriptionFactory, $context);
+
+        $this->assertSame('1.0 My Description', (string)$fixture);
+        $this->assertSame($version, $fixture->getVersion());
+        $this->assertSame($description, $fixture->getDescription());
+    }
+
     /**
      * @covers ::create
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Deprecated::<public>

--- a/tests/unit/DocBlock/Tags/DeprecatedTest.php
+++ b/tests/unit/DocBlock/Tags/DeprecatedTest.php
@@ -74,70 +74,71 @@ class DeprecatedTest extends TestCase
 
         $this->assertSame('Rendered output', $fixture->render($formatter));
     }
+//
+//    /**
+//     * @covers ::__construct
+//     * @covers ::getVersion
+//     */
+//    public function testHasVersionNumber()
+//    {
+//        $expected = '1.0';
+//
+//        $fixture = new Deprecated($expected);
+//
+//        $this->assertSame($expected, $fixture->getVersion());
+//    }
+//
+//    /**
+//     * @covers ::__construct
+//     * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
+//     * @uses   \phpDocumentor\Reflection\DocBlock\Description
+//     */
+//    public function testHasDescription()
+//    {
+//        $expected = new Description('Description');
+//
+//        $fixture = new Deprecated('1.0', $expected);
+//
+//        $this->assertSame($expected, $fixture->getDescription());
+//    }
+//
+//    /**
+//     * @covers ::__construct
+//     * @covers ::__toString
+//     * @uses   \phpDocumentor\Reflection\DocBlock\Description
+//     */
+//    public function testStringRepresentationIsReturned()
+//    {
+//        $fixture = new Deprecated('1.0', new Description('Description'));
+//
+//        $this->assertSame('1.0 Description', (string)$fixture);
+//    }
+//
+//    /**
+//     * @covers ::create
+//     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Deprecated::<public>
+//     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+//     * @uses \phpDocumentor\Reflection\DocBlock\Description
+//     * @uses \phpDocumentor\Reflection\Types\Context
+//     */
+//    public function testFactoryMethod()
+//    {
+//        $descriptionFactory = m::mock(DescriptionFactory::class);
+//        $context = new Context('');
+//
+//        $version = '1.0';
+//        $description = new Description('My Description');
+//
+//        $descriptionFactory->shouldReceive('create')->with('My Description', $context)->andReturn($description);
+//
+//        $fixture = Deprecated::create('1.0 My Description', $descriptionFactory, $context);
+//
+//        $this->assertSame('1.0 My Description', (string)$fixture);
+//        $this->assertSame($version, $fixture->getVersion());
+//        $this->assertSame($description, $fixture->getDescription());
+//    }
 
-    /**
-     * @covers ::__construct
-     * @covers ::getVersion
-     */
-    public function testHasVersionNumber()
-    {
-        $expected = '1.0';
-
-        $fixture = new Deprecated($expected);
-
-        $this->assertSame($expected, $fixture->getVersion());
-    }
-
-    /**
-     * @covers ::__construct
-     * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
-     * @uses   \phpDocumentor\Reflection\DocBlock\Description
-     */
-    public function testHasDescription()
-    {
-        $expected = new Description('Description');
-
-        $fixture = new Deprecated('1.0', $expected);
-
-        $this->assertSame($expected, $fixture->getDescription());
-    }
-
-    /**
-     * @covers ::__construct
-     * @covers ::__toString
-     * @uses   \phpDocumentor\Reflection\DocBlock\Description
-     */
-    public function testStringRepresentationIsReturned()
-    {
-        $fixture = new Deprecated('1.0', new Description('Description'));
-
-        $this->assertSame('1.0 Description', (string)$fixture);
-    }
-
-    /**
-     * @covers ::create
-     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Deprecated::<public>
-     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
-     * @uses \phpDocumentor\Reflection\DocBlock\Description
-     * @uses \phpDocumentor\Reflection\Types\Context
-     */
-    public function testFactoryMethod()
-    {
-        $descriptionFactory = m::mock(DescriptionFactory::class);
-        $context = new Context('');
-
-        $version = '1.0';
-        $description = new Description('My Description');
-
-        $descriptionFactory->shouldReceive('create')->with('My Description', $context)->andReturn($description);
-
-        $fixture = Deprecated::create('1.0 My Description', $descriptionFactory, $context);
-
-        $this->assertSame('1.0 My Description', (string)$fixture);
-        $this->assertSame($version, $fixture->getVersion());
-        $this->assertSame($description, $fixture->getDescription());
-    }
-
+//
     /**
      * @covers ::create
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Deprecated::<public>
@@ -152,18 +153,9 @@ class DeprecatedTest extends TestCase
 
         $fixture = Deprecated::create('', $descriptionFactory, new Context(''));
 
-        $this->assertSame('', (string)$fixture);
-        $this->assertSame(null, $fixture->getVersion());
-        $this->assertSame(null, $fixture->getDescription());
-    }
-
-    /**
-     * @covers ::create
-     * @expectedException \InvalidArgumentException
-     */
-    public function testFactoryMethodFailsIfVersionIsNotString()
-    {
-        $this->assertNull(Deprecated::create([]));
+        $this->assertSame('', (string) $fixture);
+        $this->assertNull($fixture->getVersion());
+        $this->assertNull($fixture->getDescription());
     }
 
     /**

--- a/tests/unit/DocBlock/Tags/DeprecatedTest.php
+++ b/tests/unit/DocBlock/Tags/DeprecatedTest.php
@@ -79,7 +79,7 @@ class DeprecatedTest extends TestCase
      * @covers ::__construct
      * @covers ::getVersion
      */
-    public function testHasVersionNumber()
+    public function testHasVersionNumber(): void
     {
         $expected = '1.0';
 
@@ -93,7 +93,7 @@ class DeprecatedTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testHasDescription()
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -107,7 +107,7 @@ class DeprecatedTest extends TestCase
      * @covers ::__toString
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testStringRepresentationIsReturned()
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Deprecated('1.0', new Description('Description'));
 
@@ -121,7 +121,7 @@ class DeprecatedTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethod()
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $context = new Context('');

--- a/tests/unit/DocBlock/Tags/DeprecatedTest.php
+++ b/tests/unit/DocBlock/Tags/DeprecatedTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/ExampleTest.php
+++ b/tests/unit/DocBlock/Tags/ExampleTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace DocBlock\Tags;
 

--- a/tests/unit/DocBlock/Tags/ExampleTest.php
+++ b/tests/unit/DocBlock/Tags/ExampleTest.php
@@ -15,7 +15,7 @@ class ExampleTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -26,7 +26,7 @@ class ExampleTest extends TestCase
      * @covers ::getContent
      * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      */
-    public function testExampleWithoutContent()
+    public function testExampleWithoutContent(): void
     {
         $tag = Example::create('"example1.php"');
         $this->assertEquals('"example1.php"', $tag->getContent());
@@ -41,7 +41,7 @@ class ExampleTest extends TestCase
      * @covers ::getDescription
      * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      */
-    public function testWithDescription()
+    public function testWithDescription(): void
     {
         $tag = Example::create('"example1.php" some text');
         $this->assertEquals('example1.php', $tag->getFilePath());
@@ -55,7 +55,7 @@ class ExampleTest extends TestCase
      * @covers ::getStartingLine
      * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      */
-    public function testStartlineIsParsed()
+    public function testStartlineIsParsed(): void
     {
         $tag = Example::create('"example1.php" 10');
         $this->assertEquals('example1.php', $tag->getFilePath());
@@ -70,7 +70,7 @@ class ExampleTest extends TestCase
      * @covers ::getDescription
      * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      */
-    public function testAllowOmitingLineCount()
+    public function testAllowOmitingLineCount(): void
     {
         $tag = Example::create('"example1.php" 10 some text');
         $this->assertEquals('example1.php', $tag->getFilePath());
@@ -86,7 +86,7 @@ class ExampleTest extends TestCase
      * @covers ::getLineCount
      * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      */
-    public function testLengthIsParsed()
+    public function testLengthIsParsed(): void
     {
         $tag = Example::create('"example1.php" 10 5');
         $this->assertEquals('example1.php', $tag->getFilePath());
@@ -103,7 +103,7 @@ class ExampleTest extends TestCase
      * @covers ::getDescription
      * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      */
-    public function testFullExample()
+    public function testFullExample(): void
     {
         $tag = Example::create('"example1.php" 10 5 test text');
         $this->assertEquals('example1.php', $tag->getFilePath());

--- a/tests/unit/DocBlock/Tags/Formatter/AlignFormatterTest.php
+++ b/tests/unit/DocBlock/Tags/Formatter/AlignFormatterTest.php
@@ -30,7 +30,7 @@ class AlignFormatterTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -45,7 +45,7 @@ class AlignFormatterTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Version
      * @uses \phpDocumentor\Reflection\Types\String_
      */
-    public function testFormatterCallsToStringAndReturnsAStandardRepresentation()
+    public function testFormatterCallsToStringAndReturnsAStandardRepresentation(): void
     {
         $tags = [
             new Param('foobar', new String_()),

--- a/tests/unit/DocBlock/Tags/Formatter/AlignFormatterTest.php
+++ b/tests/unit/DocBlock/Tags/Formatter/AlignFormatterTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/Formatter/PassthroughFormatterTest.php
+++ b/tests/unit/DocBlock/Tags/Formatter/PassthroughFormatterTest.php
@@ -26,7 +26,7 @@ class PassthroughFormatterTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -37,7 +37,7 @@ class PassthroughFormatterTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Generic
      */
-    public function testFormatterCallsToStringAndReturnsAStandardRepresentation()
+    public function testFormatterCallsToStringAndReturnsAStandardRepresentation(): void
     {
         $expected = '@unknown-tag This is a description';
 
@@ -55,7 +55,7 @@ class PassthroughFormatterTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Generic
      */
-    public function testFormatterToStringWitoutDescription()
+    public function testFormatterToStringWitoutDescription(): void
     {
         $expected = '@unknown-tag';
         $fixture = new PassthroughFormatter();

--- a/tests/unit/DocBlock/Tags/Formatter/PassthroughFormatterTest.php
+++ b/tests/unit/DocBlock/Tags/Formatter/PassthroughFormatterTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/GenericTest.php
+++ b/tests/unit/DocBlock/Tags/GenericTest.php
@@ -127,20 +127,20 @@ class GenericTest extends TestCase
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfNameIsNotEmpty(): void
+    public function testFactoryMethodFailsIfNameIsNotEmpty() : void
     {
+        $this->expectException('InvalidArgumentException');
         Generic::create('', '');
     }
 
     /**
      * @covers ::create
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfNameContainsIllegalCharacters(): void
+    public function testFactoryMethodFailsIfNameContainsIllegalCharacters() : void
     {
+        $this->expectException('InvalidArgumentException');
         Generic::create('', 'name/myname');
     }
 }

--- a/tests/unit/DocBlock/Tags/GenericTest.php
+++ b/tests/unit/DocBlock/Tags/GenericTest.php
@@ -129,15 +129,6 @@ class GenericTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfNameIsNotString()
-    {
-        Generic::create('', []);
-    }
-
-    /**
-     * @covers ::create
-     * @expectedException \InvalidArgumentException
-     */
     public function testFactoryMethodFailsIfNameIsNotEmpty()
     {
         Generic::create('', '');

--- a/tests/unit/DocBlock/Tags/GenericTest.php
+++ b/tests/unit/DocBlock/Tags/GenericTest.php
@@ -28,7 +28,7 @@ class GenericTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -37,7 +37,7 @@ class GenericTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned()
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Generic('generic', new Description('Description'));
 
@@ -52,7 +52,7 @@ class GenericTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter()
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Generic('generic', new Description('Description'));
 
@@ -64,7 +64,7 @@ class GenericTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter()
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Generic('generic', new Description('Description'));
 
@@ -79,7 +79,7 @@ class GenericTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testHasDescription()
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -94,7 +94,7 @@ class GenericTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @uses   \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testStringRepresentationIsReturned()
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Generic('generic', new Description('Description'));
 
@@ -108,7 +108,7 @@ class GenericTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethod()
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $context = new Context('');
@@ -129,7 +129,7 @@ class GenericTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfNameIsNotEmpty()
+    public function testFactoryMethodFailsIfNameIsNotEmpty(): void
     {
         Generic::create('', '');
     }
@@ -139,7 +139,7 @@ class GenericTest extends TestCase
      * @covers ::__construct
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfNameContainsIllegalCharacters()
+    public function testFactoryMethodFailsIfNameContainsIllegalCharacters(): void
     {
         Generic::create('', 'name/myname');
     }

--- a/tests/unit/DocBlock/Tags/GenericTest.php
+++ b/tests/unit/DocBlock/Tags/GenericTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/GenericTest.php
+++ b/tests/unit/DocBlock/Tags/GenericTest.php
@@ -128,7 +128,7 @@ class GenericTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfNameIsNotEmpty() : void
+    public function testFactoryMethodFailsIfNameIsNotEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         Generic::create('', '');
@@ -138,7 +138,7 @@ class GenericTest extends TestCase
      * @covers ::create
      * @covers ::__construct
      */
-    public function testFactoryMethodFailsIfNameContainsIllegalCharacters() : void
+    public function testFactoryMethodFailsIfNameContainsIllegalCharacters(): void
     {
         $this->expectException('InvalidArgumentException');
         Generic::create('', 'name/myname');

--- a/tests/unit/DocBlock/Tags/LinkTest.php
+++ b/tests/unit/DocBlock/Tags/LinkTest.php
@@ -156,13 +156,4 @@ class LinkTest extends TestCase
         $this->assertSame('', $fixture->getLink());
         $this->assertSame(null, $fixture->getDescription());
     }
-
-    /**
-     * @covers ::create
-     * @expectedException \InvalidArgumentException
-     */
-    public function testFactoryMethodFailsIfVersionIsNotString()
-    {
-        $this->assertNull(Link::create([]));
-    }
 }

--- a/tests/unit/DocBlock/Tags/LinkTest.php
+++ b/tests/unit/DocBlock/Tags/LinkTest.php
@@ -28,7 +28,7 @@ class LinkTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -38,7 +38,7 @@ class LinkTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned()
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Link('http://this.is.my/link', new Description('Description'));
 
@@ -53,7 +53,7 @@ class LinkTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter()
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Link('http://this.is.my/link', new Description('Description'));
 
@@ -65,7 +65,7 @@ class LinkTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter()
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Link('http://this.is.my/link', new Description('Description'));
 
@@ -79,7 +79,7 @@ class LinkTest extends TestCase
      * @covers ::__construct
      * @covers ::getLink
      */
-    public function testHasLinkUrl()
+    public function testHasLinkUrl(): void
     {
         $expected = 'http://this.is.my/link';
 
@@ -93,7 +93,7 @@ class LinkTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testHasDescription()
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -107,7 +107,7 @@ class LinkTest extends TestCase
      * @covers ::__toString
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testStringRepresentationIsReturned()
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Link('http://this.is.my/link', new Description('Description'));
 
@@ -121,7 +121,7 @@ class LinkTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethod()
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $context = new Context('');
@@ -145,7 +145,7 @@ class LinkTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethodCreatesEmptyLinkTag()
+    public function testFactoryMethodCreatesEmptyLinkTag(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $descriptionFactory->shouldReceive('create')->never();

--- a/tests/unit/DocBlock/Tags/LinkTest.php
+++ b/tests/unit/DocBlock/Tags/LinkTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -367,7 +367,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfBodyIsEmpty() : void
+    public function testFactoryMethodFailsIfBodyIsEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         Method::create('');
@@ -376,7 +376,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodReturnsNullIfBodyIsIncorrect() : void
+    public function testFactoryMethodReturnsNullIfBodyIsIncorrect(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->assertNull(Method::create('body('));
@@ -385,7 +385,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Method::create('body');
@@ -394,7 +394,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Method::create('body', new TypeResolver());
@@ -403,7 +403,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::__construct
      */
-    public function testCreationFailsIfBodyIsNotString() : void
+    public function testCreationFailsIfBodyIsNotString(): void
     {
         $this->expectException('InvalidArgumentException');
         new Method([]);
@@ -412,7 +412,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::__construct
      */
-    public function testCreationFailsIfBodyIsEmpty() : void
+    public function testCreationFailsIfBodyIsEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         new Method('');
@@ -421,7 +421,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::__construct
      */
-    public function testCreationFailsIfStaticIsNotBoolean() : void
+    public function testCreationFailsIfStaticIsNotBoolean(): void
     {
         $this->expectException('InvalidArgumentException');
         new Method('body', [], null, []);
@@ -430,7 +430,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::__construct
      */
-    public function testCreationFailsIfArgumentRecordContainsInvalidEntry() : void
+    public function testCreationFailsIfArgumentRecordContainsInvalidEntry(): void
     {
         $this->expectException('InvalidArgumentException');
         new Method('body', [ [ 'name' => 'myName', 'unknown' => 'nah' ] ]);

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -366,73 +366,73 @@ class MethodTest extends TestCase
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsEmpty(): void
+    public function testFactoryMethodFailsIfBodyIsEmpty() : void
     {
+        $this->expectException('InvalidArgumentException');
         Method::create('');
     }
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodReturnsNullIfBodyIsIncorrect(): void
+    public function testFactoryMethodReturnsNullIfBodyIsIncorrect() : void
     {
+        $this->expectException('InvalidArgumentException');
         $this->assertNull(Method::create('body('));
     }
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull(): void
+    public function testFactoryMethodFailsIfResolverIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         Method::create('body');
     }
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         Method::create('body', new TypeResolver());
     }
 
     /**
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
-    public function testCreationFailsIfBodyIsNotString(): void
+    public function testCreationFailsIfBodyIsNotString() : void
     {
+        $this->expectException('InvalidArgumentException');
         new Method([]);
     }
 
     /**
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
-    public function testCreationFailsIfBodyIsEmpty(): void
+    public function testCreationFailsIfBodyIsEmpty() : void
     {
+        $this->expectException('InvalidArgumentException');
         new Method('');
     }
 
     /**
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
-    public function testCreationFailsIfStaticIsNotBoolean(): void
+    public function testCreationFailsIfStaticIsNotBoolean() : void
     {
+        $this->expectException('InvalidArgumentException');
         new Method('body', [], null, []);
     }
 
     /**
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
-    public function testCreationFailsIfArgumentRecordContainsInvalidEntry(): void
+    public function testCreationFailsIfArgumentRecordContainsInvalidEntry() : void
     {
+        $this->expectException('InvalidArgumentException');
         new Method('body', [ [ 'name' => 'myName', 'unknown' => 'nah' ] ]);
     }
 

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -37,7 +37,7 @@ class MethodTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -46,7 +46,7 @@ class MethodTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Tags\Method::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned()
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Method('myMethod');
 
@@ -62,7 +62,7 @@ class MethodTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter()
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $arguments = [
             ['name' => 'argument1', 'type' => new String_()],
@@ -81,7 +81,7 @@ class MethodTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter()
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Method('myMethod');
 
@@ -95,7 +95,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @covers ::getMethodName
      */
-    public function testHasMethodName()
+    public function testHasMethodName(): void
     {
         $expected = 'myMethod';
 
@@ -108,7 +108,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @covers ::getArguments
      */
-    public function testHasArguments()
+    public function testHasArguments(): void
     {
         $arguments = [
             [ 'name' => 'argument1', 'type' => new String_() ]
@@ -123,7 +123,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @covers ::getArguments
      */
-    public function testArgumentsMayBePassedAsString()
+    public function testArgumentsMayBePassedAsString(): void
     {
         $arguments = ['argument1'];
         $expected = [
@@ -139,7 +139,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @covers ::getArguments
      */
-    public function testArgumentTypeCanBeInferredAsVoid()
+    public function testArgumentTypeCanBeInferredAsVoid(): void
     {
         $arguments = [ [ 'name' => 'argument1' ] ];
         $expected = [
@@ -157,7 +157,7 @@ class MethodTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Tags\Method::getArguments
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testRestArgumentIsParsedAsRegularArg()
+    public function testRestArgumentIsParsedAsRegularArg(): void
     {
         $expected = [
             [ 'name' => 'arg1', 'type' => new Void_() ],
@@ -185,7 +185,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @covers ::getReturnType
      */
-    public function testHasReturnType()
+    public function testHasReturnType(): void
     {
         $expected = new String_();
 
@@ -198,7 +198,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @covers ::getReturnType
      */
-    public function testReturnTypeCanBeInferredAsVoid()
+    public function testReturnTypeCanBeInferredAsVoid(): void
     {
         $fixture = new Method('myMethod', []);
 
@@ -209,7 +209,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @covers ::isStatic
      */
-    public function testMethodCanBeStatic()
+    public function testMethodCanBeStatic(): void
     {
         $expected = false;
         $fixture = new Method('myMethod', [], null, $expected);
@@ -225,7 +225,7 @@ class MethodTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testHasDescription()
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -240,7 +240,7 @@ class MethodTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @uses   \phpDocumentor\Reflection\DocBlock\Tags\Method::isStatic
      */
-    public function testStringRepresentationIsReturned()
+    public function testStringRepresentationIsReturned(): void
     {
         $arguments = [
             ['name' => 'argument1', 'type' => new String_()],
@@ -263,7 +263,7 @@ class MethodTest extends TestCase
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethod()
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();
@@ -298,7 +298,7 @@ class MethodTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testReturnTypeThis()
+    public function testReturnTypeThis(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();
@@ -347,9 +347,9 @@ class MethodTest extends TestCase
     public function testCollectionReturnTypes(
         string $returnType,
         string $expectedType,
-        string $expectedValueType = null,
-        string $expectedKeyType = null
-    ) {
+        ?string $expectedValueType = null,
+        ?string $expectedKeyType = null
+    ): void {
         $resolver           = new TypeResolver();
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $descriptionFactory->shouldReceive('create')->with('', null)->andReturn(new Description(''));
@@ -368,7 +368,7 @@ class MethodTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsEmpty()
+    public function testFactoryMethodFailsIfBodyIsEmpty(): void
     {
         Method::create('');
     }
@@ -377,7 +377,7 @@ class MethodTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodReturnsNullIfBodyIsIncorrect()
+    public function testFactoryMethodReturnsNullIfBodyIsIncorrect(): void
     {
         $this->assertNull(Method::create('body('));
     }
@@ -386,7 +386,7 @@ class MethodTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull()
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         Method::create('body');
     }
@@ -395,7 +395,7 @@ class MethodTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull()
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         Method::create('body', new TypeResolver());
     }
@@ -404,7 +404,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @expectedException \InvalidArgumentException
      */
-    public function testCreationFailsIfBodyIsNotString()
+    public function testCreationFailsIfBodyIsNotString(): void
     {
         new Method([]);
     }
@@ -413,7 +413,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @expectedException \InvalidArgumentException
      */
-    public function testCreationFailsIfBodyIsEmpty()
+    public function testCreationFailsIfBodyIsEmpty(): void
     {
         new Method('');
     }
@@ -422,7 +422,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @expectedException \InvalidArgumentException
      */
-    public function testCreationFailsIfStaticIsNotBoolean()
+    public function testCreationFailsIfStaticIsNotBoolean(): void
     {
         new Method('body', [], null, []);
     }
@@ -431,7 +431,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @expectedException \InvalidArgumentException
      */
-    public function testCreationFailsIfArgumentRecordContainsInvalidEntry()
+    public function testCreationFailsIfArgumentRecordContainsInvalidEntry(): void
     {
         new Method('body', [ [ 'name' => 'myName', 'unknown' => 'nah' ] ]);
     }
@@ -445,7 +445,7 @@ class MethodTest extends TestCase
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testCreateMethodParenthesisMissing()
+    public function testCreateMethodParenthesisMissing(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();
@@ -479,7 +479,7 @@ class MethodTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Void_
      */
-    public function testCreateWithoutReturnType()
+    public function testCreateWithoutReturnType(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();
@@ -516,7 +516,7 @@ class MethodTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Integer
      * @uses \phpDocumentor\Reflection\Types\Object_
      */
-    public function testCreateWithMixedReturnTypes()
+    public function testCreateWithMixedReturnTypes(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -371,15 +371,6 @@ class MethodTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotString()
-    {
-        Method::create([]);
-    }
-
-    /**
-     * @covers ::create
-     * @expectedException \InvalidArgumentException
-     */
     public function testFactoryMethodFailsIfBodyIsEmpty()
     {
         Method::create('');

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *
@@ -347,10 +348,10 @@ class MethodTest extends TestCase
      * @param string null $expectedKeyType
      */
     public function testCollectionReturnTypes(
-        $returnType,
-        $expectedType,
-        $expectedValueType = null,
-        $expectedKeyType = null
+        string $returnType,
+        string $expectedType,
+        string $expectedValueType = null,
+        string $expectedKeyType = null
     ) {
         $resolver           = new TypeResolver();
         $descriptionFactory = m::mock(DescriptionFactory::class);

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -342,9 +342,6 @@ class MethodTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\Integer
      * @uses \phpDocumentor\Reflection\Types\Object_
-     * @param string $returnType
-     * @param string $expectedType
-     * @param string $expectedValueType
      * @param string null $expectedKeyType
      */
     public function testCollectionReturnTypes(

--- a/tests/unit/DocBlock/Tags/ParamTest.php
+++ b/tests/unit/DocBlock/Tags/ParamTest.php
@@ -182,30 +182,30 @@ class ParamTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Param::<public>
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven() : void
     {
+        $this->expectException('InvalidArgumentException');
         $descriptionFactory = m::mock(DescriptionFactory::class);
         Param::create('', new TypeResolver(), $descriptionFactory);
     }
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull(): void
+    public function testFactoryMethodFailsIfResolverIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         Param::create('body');
     }
 
     /**
      * @covers ::create
      * @uses \phpDocumentor\Reflection\TypeResolver
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         Param::create('body', new TypeResolver());
     }
 }

--- a/tests/unit/DocBlock/Tags/ParamTest.php
+++ b/tests/unit/DocBlock/Tags/ParamTest.php
@@ -30,7 +30,7 @@ class ParamTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -40,7 +40,7 @@ class ParamTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned()
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Param('myParameter', null, false, new Description('Description'));
 
@@ -56,7 +56,7 @@ class ParamTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter()
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Param('myParameter', new String_(), true, new Description('Description'));
         $this->assertSame('@param string ...$myParameter Description', $fixture->render());
@@ -75,7 +75,7 @@ class ParamTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Tags\Param::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter()
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Param('myParameter');
 
@@ -89,7 +89,7 @@ class ParamTest extends TestCase
      * @covers ::__construct
      * @covers ::getVariableName
      */
-    public function testHasVariableName()
+    public function testHasVariableName(): void
     {
         $expected = 'myParameter';
 
@@ -102,7 +102,7 @@ class ParamTest extends TestCase
      * @covers ::__construct
      * @covers ::getType
      */
-    public function testHasType()
+    public function testHasType(): void
     {
         $expected = new String_();
 
@@ -115,7 +115,7 @@ class ParamTest extends TestCase
      * @covers ::__construct
      * @covers ::isVariadic
      */
-    public function testIfParameterIsVariadic()
+    public function testIfParameterIsVariadic(): void
     {
         $fixture = new Param('myParameter', new String_(), false);
         $this->assertFalse($fixture->isVariadic());
@@ -129,7 +129,7 @@ class ParamTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testHasDescription()
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -145,7 +145,7 @@ class ParamTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @uses   \phpDocumentor\Reflection\Types\String_
      */
-    public function testStringRepresentationIsReturned()
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Param('myParameter', new String_(), true, new Description('Description'));
 
@@ -159,7 +159,7 @@ class ParamTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethod()
+    public function testFactoryMethod(): void
     {
         $typeResolver = new TypeResolver();
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -184,7 +184,7 @@ class ParamTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven()
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         Param::create('', new TypeResolver(), $descriptionFactory);
@@ -194,7 +194,7 @@ class ParamTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull()
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         Param::create('body');
     }
@@ -204,7 +204,7 @@ class ParamTest extends TestCase
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull()
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         Param::create('body', new TypeResolver());
     }

--- a/tests/unit/DocBlock/Tags/ParamTest.php
+++ b/tests/unit/DocBlock/Tags/ParamTest.php
@@ -194,15 +194,6 @@ class ParamTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotString()
-    {
-        Param::create([]);
-    }
-
-    /**
-     * @covers ::create
-     * @expectedException \InvalidArgumentException
-     */
     public function testFactoryMethodFailsIfResolverIsNull()
     {
         Param::create('body');
@@ -216,23 +207,5 @@ class ParamTest extends TestCase
     public function testFactoryMethodFailsIfDescriptionFactoryIsNull()
     {
         Param::create('body', new TypeResolver());
-    }
-
-    /**
-     * @covers ::__construct
-     * @expectedException \InvalidArgumentException
-     */
-    public function testExceptionIsThrownIfVariableNameIsNotString()
-    {
-        new Param([]);
-    }
-
-    /**
-     * @covers ::__construct
-     * @expectedException \InvalidArgumentException
-     */
-    public function testExceptionIsThrownIfVariadicIsNotBoolean()
-    {
-        new Param('', null, []);
     }
 }

--- a/tests/unit/DocBlock/Tags/ParamTest.php
+++ b/tests/unit/DocBlock/Tags/ParamTest.php
@@ -183,7 +183,7 @@ class ParamTest extends TestCase
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven() : void
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
     {
         $this->expectException('InvalidArgumentException');
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -193,7 +193,7 @@ class ParamTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Param::create('body');
@@ -203,7 +203,7 @@ class ParamTest extends TestCase
      * @covers ::create
      * @uses \phpDocumentor\Reflection\TypeResolver
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Param::create('body', new TypeResolver());

--- a/tests/unit/DocBlock/Tags/ParamTest.php
+++ b/tests/unit/DocBlock/Tags/ParamTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/PropertyReadTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyReadTest.php
@@ -168,30 +168,30 @@ class PropertyReadTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\PropertyRead::<public>
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven() : void
     {
+        $this->expectException('InvalidArgumentException');
         $descriptionFactory = m::mock(DescriptionFactory::class);
         PropertyRead::create('', new TypeResolver(), $descriptionFactory);
     }
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull(): void
+    public function testFactoryMethodFailsIfResolverIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         PropertyRead::create('body');
     }
 
     /**
      * @covers ::create
      * @uses \phpDocumentor\Reflection\TypeResolver
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         PropertyRead::create('body', new TypeResolver());
     }
 }

--- a/tests/unit/DocBlock/Tags/PropertyReadTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyReadTest.php
@@ -30,7 +30,7 @@ class PropertyReadTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -40,7 +40,7 @@ class PropertyReadTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned()
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new PropertyRead('myProperty', null, new Description('Description'));
 
@@ -55,7 +55,7 @@ class PropertyReadTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter()
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new PropertyRead('myProperty', new String_(), new Description('Description'));
         $this->assertSame('@property-read string $myProperty Description', $fixture->render());
@@ -71,7 +71,7 @@ class PropertyReadTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Tags\PropertyRead::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter()
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new PropertyRead('myProperty');
 
@@ -85,7 +85,7 @@ class PropertyReadTest extends TestCase
      * @covers ::__construct
      * @covers ::getVariableName
      */
-    public function testHasVariableName()
+    public function testHasVariableName(): void
     {
         $expected = 'myProperty';
 
@@ -98,7 +98,7 @@ class PropertyReadTest extends TestCase
      * @covers ::__construct
      * @covers ::getType
      */
-    public function testHasType()
+    public function testHasType(): void
     {
         $expected = new String_();
 
@@ -112,7 +112,7 @@ class PropertyReadTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testHasDescription()
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -127,7 +127,7 @@ class PropertyReadTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @uses   \phpDocumentor\Reflection\Types\String_
      */
-    public function testStringRepresentationIsReturned()
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new PropertyRead('myProperty', new String_(), new Description('Description'));
 
@@ -141,7 +141,7 @@ class PropertyReadTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethod()
+    public function testFactoryMethod(): void
     {
         $typeResolver = new TypeResolver();
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -170,7 +170,7 @@ class PropertyReadTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven()
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         PropertyRead::create('', new TypeResolver(), $descriptionFactory);
@@ -180,7 +180,7 @@ class PropertyReadTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull()
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         PropertyRead::create('body');
     }
@@ -190,7 +190,7 @@ class PropertyReadTest extends TestCase
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull()
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         PropertyRead::create('body', new TypeResolver());
     }

--- a/tests/unit/DocBlock/Tags/PropertyReadTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyReadTest.php
@@ -169,7 +169,7 @@ class PropertyReadTest extends TestCase
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven() : void
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
     {
         $this->expectException('InvalidArgumentException');
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -179,7 +179,7 @@ class PropertyReadTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         PropertyRead::create('body');
@@ -189,7 +189,7 @@ class PropertyReadTest extends TestCase
      * @covers ::create
      * @uses \phpDocumentor\Reflection\TypeResolver
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         PropertyRead::create('body', new TypeResolver());

--- a/tests/unit/DocBlock/Tags/PropertyReadTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyReadTest.php
@@ -180,15 +180,6 @@ class PropertyReadTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotString()
-    {
-        PropertyRead::create([]);
-    }
-
-    /**
-     * @covers ::create
-     * @expectedException \InvalidArgumentException
-     */
     public function testFactoryMethodFailsIfResolverIsNull()
     {
         PropertyRead::create('body');
@@ -202,14 +193,5 @@ class PropertyReadTest extends TestCase
     public function testFactoryMethodFailsIfDescriptionFactoryIsNull()
     {
         PropertyRead::create('body', new TypeResolver());
-    }
-
-    /**
-     * @covers ::__construct
-     * @expectedException \InvalidArgumentException
-     */
-    public function testExceptionIsThrownIfVariableNameIsNotString()
-    {
-        new PropertyRead([]);
     }
 }

--- a/tests/unit/DocBlock/Tags/PropertyReadTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyReadTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/PropertyTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyTest.php
@@ -163,30 +163,30 @@ class PropertyTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Property::<public>
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven() : void
     {
+        $this->expectException('InvalidArgumentException');
         $descriptionFactory = m::mock(DescriptionFactory::class);
         Property::create('', new TypeResolver(), $descriptionFactory);
     }
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull(): void
+    public function testFactoryMethodFailsIfResolverIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         Property::create('body');
     }
 
     /**
      * @covers ::create
      * @uses \phpDocumentor\Reflection\TypeResolver
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         Property::create('body', new TypeResolver());
     }
 }

--- a/tests/unit/DocBlock/Tags/PropertyTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyTest.php
@@ -175,15 +175,6 @@ class PropertyTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotString()
-    {
-        Property::create([]);
-    }
-
-    /**
-     * @covers ::create
-     * @expectedException \InvalidArgumentException
-     */
     public function testFactoryMethodFailsIfResolverIsNull()
     {
         Property::create('body');
@@ -197,14 +188,5 @@ class PropertyTest extends TestCase
     public function testFactoryMethodFailsIfDescriptionFactoryIsNull()
     {
         Property::create('body', new TypeResolver());
-    }
-
-    /**
-     * @covers ::__construct
-     * @expectedException \InvalidArgumentException
-     */
-    public function testExceptionIsThrownIfVariableNameIsNotString()
-    {
-        new Property([]);
     }
 }

--- a/tests/unit/DocBlock/Tags/PropertyTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyTest.php
@@ -30,7 +30,7 @@ class PropertyTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -40,7 +40,7 @@ class PropertyTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned()
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Property('myProperty', null, new Description('Description'));
 
@@ -55,7 +55,7 @@ class PropertyTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter()
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Property('myProperty', new String_(), new Description('Description'));
         $this->assertSame('@property string $myProperty Description', $fixture->render());
@@ -71,7 +71,7 @@ class PropertyTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Tags\Property::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter()
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Property('myProperty');
 
@@ -85,7 +85,7 @@ class PropertyTest extends TestCase
      * @covers ::__construct
      * @covers ::getVariableName
      */
-    public function testHasVariableName()
+    public function testHasVariableName(): void
     {
         $expected = 'myProperty';
 
@@ -98,7 +98,7 @@ class PropertyTest extends TestCase
      * @covers ::__construct
      * @covers ::getType
      */
-    public function testHasType()
+    public function testHasType(): void
     {
         $expected = new String_();
 
@@ -112,7 +112,7 @@ class PropertyTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testHasDescription()
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -127,7 +127,7 @@ class PropertyTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @uses   \phpDocumentor\Reflection\Types\String_
      */
-    public function testStringRepresentationIsReturned()
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Property('myProperty', new String_(), new Description('Description'));
 
@@ -141,7 +141,7 @@ class PropertyTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethod()
+    public function testFactoryMethod(): void
     {
         $typeResolver = new TypeResolver();
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -165,7 +165,7 @@ class PropertyTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven()
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         Property::create('', new TypeResolver(), $descriptionFactory);
@@ -175,7 +175,7 @@ class PropertyTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull()
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         Property::create('body');
     }
@@ -185,7 +185,7 @@ class PropertyTest extends TestCase
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull()
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         Property::create('body', new TypeResolver());
     }

--- a/tests/unit/DocBlock/Tags/PropertyTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/PropertyTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyTest.php
@@ -164,7 +164,7 @@ class PropertyTest extends TestCase
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven() : void
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
     {
         $this->expectException('InvalidArgumentException');
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -174,7 +174,7 @@ class PropertyTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Property::create('body');
@@ -184,7 +184,7 @@ class PropertyTest extends TestCase
      * @covers ::create
      * @uses \phpDocumentor\Reflection\TypeResolver
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Property::create('body', new TypeResolver());

--- a/tests/unit/DocBlock/Tags/PropertyWriteTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyWriteTest.php
@@ -168,30 +168,30 @@ class PropertyWriteTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\PropertyWrite::<public>
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven() : void
     {
+        $this->expectException('InvalidArgumentException');
         $descriptionFactory = m::mock(DescriptionFactory::class);
         PropertyWrite::create('', new TypeResolver(), $descriptionFactory);
     }
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull(): void
+    public function testFactoryMethodFailsIfResolverIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         PropertyWrite::create('body');
     }
 
     /**
      * @covers ::create
      * @uses \phpDocumentor\Reflection\TypeResolver
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         PropertyWrite::create('body', new TypeResolver());
     }
 }

--- a/tests/unit/DocBlock/Tags/PropertyWriteTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyWriteTest.php
@@ -169,7 +169,7 @@ class PropertyWriteTest extends TestCase
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven() : void
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
     {
         $this->expectException('InvalidArgumentException');
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -179,7 +179,7 @@ class PropertyWriteTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         PropertyWrite::create('body');
@@ -189,7 +189,7 @@ class PropertyWriteTest extends TestCase
      * @covers ::create
      * @uses \phpDocumentor\Reflection\TypeResolver
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         PropertyWrite::create('body', new TypeResolver());

--- a/tests/unit/DocBlock/Tags/PropertyWriteTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyWriteTest.php
@@ -180,15 +180,6 @@ class PropertyWriteTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotString()
-    {
-        PropertyWrite::create([]);
-    }
-
-    /**
-     * @covers ::create
-     * @expectedException \InvalidArgumentException
-     */
     public function testFactoryMethodFailsIfResolverIsNull()
     {
         PropertyWrite::create('body');
@@ -202,14 +193,5 @@ class PropertyWriteTest extends TestCase
     public function testFactoryMethodFailsIfDescriptionFactoryIsNull()
     {
         PropertyWrite::create('body', new TypeResolver());
-    }
-
-    /**
-     * @covers ::__construct
-     * @expectedException \InvalidArgumentException
-     */
-    public function testExceptionIsThrownIfVariableNameIsNotString()
-    {
-        new PropertyWrite([]);
     }
 }

--- a/tests/unit/DocBlock/Tags/PropertyWriteTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyWriteTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/PropertyWriteTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyWriteTest.php
@@ -30,7 +30,7 @@ class PropertyWriteTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -40,7 +40,7 @@ class PropertyWriteTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned()
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new PropertyWrite('myProperty', null, new Description('Description'));
 
@@ -55,7 +55,7 @@ class PropertyWriteTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter()
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new PropertyWrite('myProperty', new String_(), new Description('Description'));
         $this->assertSame('@property-write string $myProperty Description', $fixture->render());
@@ -71,7 +71,7 @@ class PropertyWriteTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Tags\PropertyWrite::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter()
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new PropertyWrite('myProperty');
 
@@ -85,7 +85,7 @@ class PropertyWriteTest extends TestCase
      * @covers ::__construct
      * @covers ::getVariableName
      */
-    public function testHasVariableName()
+    public function testHasVariableName(): void
     {
         $expected = 'myProperty';
 
@@ -98,7 +98,7 @@ class PropertyWriteTest extends TestCase
      * @covers ::__construct
      * @covers ::getType
      */
-    public function testHasType()
+    public function testHasType(): void
     {
         $expected = new String_();
 
@@ -112,7 +112,7 @@ class PropertyWriteTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testHasDescription()
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -127,7 +127,7 @@ class PropertyWriteTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @uses   \phpDocumentor\Reflection\Types\String_
      */
-    public function testStringRepresentationIsReturned()
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new PropertyWrite('myProperty', new String_(), new Description('Description'));
 
@@ -141,7 +141,7 @@ class PropertyWriteTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethod()
+    public function testFactoryMethod(): void
     {
         $typeResolver = new TypeResolver();
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -170,7 +170,7 @@ class PropertyWriteTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven()
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         PropertyWrite::create('', new TypeResolver(), $descriptionFactory);
@@ -180,7 +180,7 @@ class PropertyWriteTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull()
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         PropertyWrite::create('body');
     }
@@ -190,7 +190,7 @@ class PropertyWriteTest extends TestCase
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull()
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         PropertyWrite::create('body', new TypeResolver());
     }

--- a/tests/unit/DocBlock/Tags/ReturnTest.php
+++ b/tests/unit/DocBlock/Tags/ReturnTest.php
@@ -146,15 +146,6 @@ class ReturnTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotString()
-    {
-        $this->assertNull(Return_::create([]));
-    }
-
-    /**
-     * @covers ::create
-     * @expectedException \InvalidArgumentException
-     */
     public function testFactoryMethodFailsIfBodyIsNotEmpty()
     {
         $this->assertNull(Return_::create(''));

--- a/tests/unit/DocBlock/Tags/ReturnTest.php
+++ b/tests/unit/DocBlock/Tags/ReturnTest.php
@@ -145,7 +145,7 @@ class ReturnTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty() : void
+    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->assertNull(Return_::create(''));
@@ -154,7 +154,7 @@ class ReturnTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Return_::create('body');
@@ -163,7 +163,7 @@ class ReturnTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Return_::create('body', new TypeResolver());

--- a/tests/unit/DocBlock/Tags/ReturnTest.php
+++ b/tests/unit/DocBlock/Tags/ReturnTest.php
@@ -144,28 +144,28 @@ class ReturnTest extends TestCase
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
+    public function testFactoryMethodFailsIfBodyIsNotEmpty() : void
     {
+        $this->expectException('InvalidArgumentException');
         $this->assertNull(Return_::create(''));
     }
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull(): void
+    public function testFactoryMethodFailsIfResolverIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         Return_::create('body');
     }
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         Return_::create('body', new TypeResolver());
     }
 }

--- a/tests/unit/DocBlock/Tags/ReturnTest.php
+++ b/tests/unit/DocBlock/Tags/ReturnTest.php
@@ -30,7 +30,7 @@ class ReturnTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -40,7 +40,7 @@ class ReturnTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned()
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Return_(new String_(), new Description('Description'));
 
@@ -55,7 +55,7 @@ class ReturnTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter()
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Return_(new String_(), new Description('Description'));
 
@@ -67,7 +67,7 @@ class ReturnTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter()
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Return_(new String_(), new Description('Description'));
 
@@ -81,7 +81,7 @@ class ReturnTest extends TestCase
      * @covers ::__construct
      * @covers ::getType
      */
-    public function testHasType()
+    public function testHasType(): void
     {
         $expected = new String_();
 
@@ -95,7 +95,7 @@ class ReturnTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testHasDescription()
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -109,7 +109,7 @@ class ReturnTest extends TestCase
      * @covers ::__toString
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testStringRepresentationIsReturned()
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Return_(new String_(), new Description('Description'));
 
@@ -125,7 +125,7 @@ class ReturnTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\String_
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethod()
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver = new TypeResolver();
@@ -146,7 +146,7 @@ class ReturnTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty()
+    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
     {
         $this->assertNull(Return_::create(''));
     }
@@ -155,7 +155,7 @@ class ReturnTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull()
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         Return_::create('body');
     }
@@ -164,7 +164,7 @@ class ReturnTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull()
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         Return_::create('body', new TypeResolver());
     }

--- a/tests/unit/DocBlock/Tags/ReturnTest.php
+++ b/tests/unit/DocBlock/Tags/ReturnTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/SeeTest.php
+++ b/tests/unit/DocBlock/Tags/SeeTest.php
@@ -192,28 +192,28 @@ class SeeTest extends TestCase
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
+    public function testFactoryMethodFailsIfBodyIsNotEmpty() : void
     {
+        $this->expectException('InvalidArgumentException');
         $this->assertNull(See::create(''));
     }
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull(): void
+    public function testFactoryMethodFailsIfResolverIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         See::create('body');
     }
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         See::create('body', new FqsenResolver());
     }
 }

--- a/tests/unit/DocBlock/Tags/SeeTest.php
+++ b/tests/unit/DocBlock/Tags/SeeTest.php
@@ -194,15 +194,6 @@ class SeeTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotString()
-    {
-        $this->assertNull(See::create([]));
-    }
-
-    /**
-     * @covers ::create
-     * @expectedException \InvalidArgumentException
-     */
     public function testFactoryMethodFailsIfBodyIsNotEmpty()
     {
         $this->assertNull(See::create(''));

--- a/tests/unit/DocBlock/Tags/SeeTest.php
+++ b/tests/unit/DocBlock/Tags/SeeTest.php
@@ -193,7 +193,7 @@ class SeeTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty() : void
+    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->assertNull(See::create(''));
@@ -202,7 +202,7 @@ class SeeTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         See::create('body');
@@ -211,7 +211,7 @@ class SeeTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         See::create('body', new FqsenResolver());

--- a/tests/unit/DocBlock/Tags/SeeTest.php
+++ b/tests/unit/DocBlock/Tags/SeeTest.php
@@ -32,7 +32,7 @@ class SeeTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -44,7 +44,7 @@ class SeeTest extends TestCase
      * @uses   \phpDocumentor\Reflection\Fqsen
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned()
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new See(new FqsenRef(new Fqsen('\DateTime')), new Description('Description'));
 
@@ -60,7 +60,7 @@ class SeeTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter()
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new See(new FqsenRef(new Fqsen('\DateTime')), new Description('Description'));
 
@@ -74,7 +74,7 @@ class SeeTest extends TestCase
      * @uses   \phpDocumentor\Reflection\Fqsen
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter()
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new See(new FqsenRef(new Fqsen('\DateTime')), new Description('Description'));
 
@@ -90,7 +90,7 @@ class SeeTest extends TestCase
      * @covers ::__construct
      * @covers ::getReference
      */
-    public function testHasReferenceToFqsen()
+    public function testHasReferenceToFqsen(): void
     {
         $expected = new FqsenRef(new Fqsen('\DateTime'));
 
@@ -106,7 +106,7 @@ class SeeTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Tags\Reference\Fqsen
      * @uses   \phpDocumentor\Reflection\Fqsen
      */
-    public function testHasDescription()
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -122,7 +122,7 @@ class SeeTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Tags\Reference\Fqsen
      * @uses   \phpDocumentor\Reflection\Fqsen
      */
-    public function testStringRepresentationIsReturned()
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new See(new FqsenRef(new Fqsen('\DateTime::format()')), new Description('Description'));
 
@@ -139,7 +139,7 @@ class SeeTest extends TestCase
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethod()
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver = m::mock(FqsenResolver::class);
@@ -169,7 +169,7 @@ class SeeTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Reference\Url
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethodWithUrl()
+    public function testFactoryMethodWithUrl(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver = m::mock(FqsenResolver::class);
@@ -194,7 +194,7 @@ class SeeTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty()
+    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
     {
         $this->assertNull(See::create(''));
     }
@@ -203,7 +203,7 @@ class SeeTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull()
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         See::create('body');
     }
@@ -212,7 +212,7 @@ class SeeTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull()
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         See::create('body', new FqsenResolver());
     }

--- a/tests/unit/DocBlock/Tags/SeeTest.php
+++ b/tests/unit/DocBlock/Tags/SeeTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/SinceTest.php
+++ b/tests/unit/DocBlock/Tags/SinceTest.php
@@ -29,7 +29,7 @@ class SinceTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -39,7 +39,7 @@ class SinceTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned()
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Since('1.0', new Description('Description'));
 
@@ -54,7 +54,7 @@ class SinceTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter()
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Since('1.0', new Description('Description'));
 
@@ -66,7 +66,7 @@ class SinceTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter()
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Since('1.0', new Description('Description'));
 
@@ -80,7 +80,7 @@ class SinceTest extends TestCase
      * @covers ::__construct
      * @covers ::getVersion
      */
-    public function testHasVersionNumber()
+    public function testHasVersionNumber(): void
     {
         $expected = '1.0';
 
@@ -94,7 +94,7 @@ class SinceTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testHasDescription()
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -108,7 +108,7 @@ class SinceTest extends TestCase
      * @covers ::__toString
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testStringRepresentationIsReturned()
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Since('1.0', new Description('Description'));
 
@@ -122,7 +122,7 @@ class SinceTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethod()
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $context            = new Context('');
@@ -146,7 +146,7 @@ class SinceTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethodCreatesEmptySinceTag()
+    public function testFactoryMethodCreatesEmptySinceTag(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $descriptionFactory->shouldReceive('create')->never();
@@ -161,7 +161,7 @@ class SinceTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodReturnsNullIfBodyDoesNotMatchRegex()
+    public function testFactoryMethodReturnsNullIfBodyDoesNotMatchRegex(): void
     {
         $this->assertNull(Since::create('dkhf<'));
     }

--- a/tests/unit/DocBlock/Tags/SinceTest.php
+++ b/tests/unit/DocBlock/Tags/SinceTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/SinceTest.php
+++ b/tests/unit/DocBlock/Tags/SinceTest.php
@@ -160,15 +160,6 @@ class SinceTest extends TestCase
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
-     */
-    public function testFactoryMethodFailsIfSinceIsNotString()
-    {
-        $this->assertNull(Since::create([]));
-    }
-
-    /**
-     * @covers ::create
      */
     public function testFactoryMethodReturnsNullIfBodyDoesNotMatchRegex()
     {

--- a/tests/unit/DocBlock/Tags/SourceTest.php
+++ b/tests/unit/DocBlock/Tags/SourceTest.php
@@ -161,7 +161,7 @@ class SourceTest extends TestCase
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven() : void
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
     {
         $this->expectException('InvalidArgumentException');
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -172,7 +172,7 @@ class SourceTest extends TestCase
      * @covers ::create
      * @uses \phpDocumentor\Reflection\TypeResolver
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Source::create('1');
@@ -181,7 +181,7 @@ class SourceTest extends TestCase
     /**
      * @covers ::__construct
      */
-    public function testExceptionIsThrownIfStartingLineIsNotInteger() : void
+    public function testExceptionIsThrownIfStartingLineIsNotInteger(): void
     {
         $this->expectException('InvalidArgumentException');
         new Source('blabla');
@@ -190,7 +190,7 @@ class SourceTest extends TestCase
     /**
      * @covers ::__construct
      */
-    public function testExceptionIsThrownIfLineCountIsNotIntegerOrNull() : void
+    public function testExceptionIsThrownIfLineCountIsNotIntegerOrNull(): void
     {
         $this->expectException('InvalidArgumentException');
         new Source('1', []);

--- a/tests/unit/DocBlock/Tags/SourceTest.php
+++ b/tests/unit/DocBlock/Tags/SourceTest.php
@@ -160,10 +160,10 @@ class SourceTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Source::<public>
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven() : void
     {
+        $this->expectException('InvalidArgumentException');
         $descriptionFactory = m::mock(DescriptionFactory::class);
         Source::create('', $descriptionFactory);
     }
@@ -171,28 +171,28 @@ class SourceTest extends TestCase
     /**
      * @covers ::create
      * @uses \phpDocumentor\Reflection\TypeResolver
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         Source::create('1');
     }
 
     /**
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
-    public function testExceptionIsThrownIfStartingLineIsNotInteger(): void
+    public function testExceptionIsThrownIfStartingLineIsNotInteger() : void
     {
+        $this->expectException('InvalidArgumentException');
         new Source('blabla');
     }
 
     /**
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
-    public function testExceptionIsThrownIfLineCountIsNotIntegerOrNull(): void
+    public function testExceptionIsThrownIfLineCountIsNotIntegerOrNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         new Source('1', []);
     }
 }

--- a/tests/unit/DocBlock/Tags/SourceTest.php
+++ b/tests/unit/DocBlock/Tags/SourceTest.php
@@ -28,7 +28,7 @@ class SourceTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -38,7 +38,7 @@ class SourceTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned()
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Source(1, null, new Description('Description'));
 
@@ -53,7 +53,7 @@ class SourceTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter()
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Source(1, 10, new Description('Description'));
         $this->assertSame('@source 1 10 Description', $fixture->render());
@@ -69,7 +69,7 @@ class SourceTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Tags\Source::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter()
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Source(1);
 
@@ -83,7 +83,7 @@ class SourceTest extends TestCase
      * @covers ::__construct
      * @covers ::getStartingLine
      */
-    public function testHasStartingLine()
+    public function testHasStartingLine(): void
     {
         $expected = 1;
 
@@ -96,7 +96,7 @@ class SourceTest extends TestCase
      * @covers ::__construct
      * @covers ::getLineCount
      */
-    public function testHasLineCount()
+    public function testHasLineCount(): void
     {
         $expected = 2;
 
@@ -110,7 +110,7 @@ class SourceTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testHasDescription()
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -125,7 +125,7 @@ class SourceTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @uses   \phpDocumentor\Reflection\Types\String_
      */
-    public function testStringRepresentationIsReturned()
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Source(1, 10, new Description('Description'));
 
@@ -139,7 +139,7 @@ class SourceTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethod()
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $context            = new Context('');
@@ -162,7 +162,7 @@ class SourceTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven()
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         Source::create('', $descriptionFactory);
@@ -173,7 +173,7 @@ class SourceTest extends TestCase
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull()
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         Source::create('1');
     }
@@ -182,7 +182,7 @@ class SourceTest extends TestCase
      * @covers ::__construct
      * @expectedException \InvalidArgumentException
      */
-    public function testExceptionIsThrownIfStartingLineIsNotInteger()
+    public function testExceptionIsThrownIfStartingLineIsNotInteger(): void
     {
         new Source('blabla');
     }
@@ -191,7 +191,7 @@ class SourceTest extends TestCase
      * @covers ::__construct
      * @expectedException \InvalidArgumentException
      */
-    public function testExceptionIsThrownIfLineCountIsNotIntegerOrNull()
+    public function testExceptionIsThrownIfLineCountIsNotIntegerOrNull(): void
     {
         new Source('1', []);
     }

--- a/tests/unit/DocBlock/Tags/SourceTest.php
+++ b/tests/unit/DocBlock/Tags/SourceTest.php
@@ -170,15 +170,6 @@ class SourceTest extends TestCase
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
-     */
-    public function testFactoryMethodFailsIfBodyIsNotString()
-    {
-        Source::create([]);
-    }
-
-    /**
-     * @covers ::create
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @expectedException \InvalidArgumentException
      */

--- a/tests/unit/DocBlock/Tags/SourceTest.php
+++ b/tests/unit/DocBlock/Tags/SourceTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/ThrowsTest.php
+++ b/tests/unit/DocBlock/Tags/ThrowsTest.php
@@ -145,7 +145,7 @@ class ThrowsTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty() : void
+    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->assertNull(Throws::create(''));
@@ -154,7 +154,7 @@ class ThrowsTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Throws::create('body');
@@ -163,7 +163,7 @@ class ThrowsTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Throws::create('body', new TypeResolver());

--- a/tests/unit/DocBlock/Tags/ThrowsTest.php
+++ b/tests/unit/DocBlock/Tags/ThrowsTest.php
@@ -146,15 +146,6 @@ class ThrowsTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotString()
-    {
-        $this->assertNull(Throws::create([]));
-    }
-
-    /**
-     * @covers ::create
-     * @expectedException \InvalidArgumentException
-     */
     public function testFactoryMethodFailsIfBodyIsNotEmpty()
     {
         $this->assertNull(Throws::create(''));

--- a/tests/unit/DocBlock/Tags/ThrowsTest.php
+++ b/tests/unit/DocBlock/Tags/ThrowsTest.php
@@ -30,7 +30,7 @@ class ThrowsTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -40,7 +40,7 @@ class ThrowsTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned()
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Throws(new String_(), new Description('Description'));
 
@@ -55,7 +55,7 @@ class ThrowsTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter()
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Throws(new String_(), new Description('Description'));
 
@@ -67,7 +67,7 @@ class ThrowsTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter()
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Throws(new String_(), new Description('Description'));
 
@@ -81,7 +81,7 @@ class ThrowsTest extends TestCase
      * @covers ::__construct
      * @covers ::getType
      */
-    public function testHasType()
+    public function testHasType(): void
     {
         $expected = new String_();
 
@@ -95,7 +95,7 @@ class ThrowsTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testHasDescription()
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -109,7 +109,7 @@ class ThrowsTest extends TestCase
      * @covers ::__toString
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testStringRepresentationIsReturned()
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Throws(new String_(), new Description('Description'));
 
@@ -125,7 +125,7 @@ class ThrowsTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\String_
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethod()
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();
@@ -146,7 +146,7 @@ class ThrowsTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty()
+    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
     {
         $this->assertNull(Throws::create(''));
     }
@@ -155,7 +155,7 @@ class ThrowsTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull()
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         Throws::create('body');
     }
@@ -164,7 +164,7 @@ class ThrowsTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull()
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         Throws::create('body', new TypeResolver());
     }

--- a/tests/unit/DocBlock/Tags/ThrowsTest.php
+++ b/tests/unit/DocBlock/Tags/ThrowsTest.php
@@ -144,28 +144,28 @@ class ThrowsTest extends TestCase
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
+    public function testFactoryMethodFailsIfBodyIsNotEmpty() : void
     {
+        $this->expectException('InvalidArgumentException');
         $this->assertNull(Throws::create(''));
     }
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull(): void
+    public function testFactoryMethodFailsIfResolverIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         Throws::create('body');
     }
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         Throws::create('body', new TypeResolver());
     }
 }

--- a/tests/unit/DocBlock/Tags/ThrowsTest.php
+++ b/tests/unit/DocBlock/Tags/ThrowsTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/UsesTest.php
+++ b/tests/unit/DocBlock/Tags/UsesTest.php
@@ -148,7 +148,7 @@ class UsesTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty() : void
+    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->assertNull(Uses::create(''));
@@ -157,7 +157,7 @@ class UsesTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Uses::create('body');
@@ -166,7 +166,7 @@ class UsesTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Uses::create('body', new FqsenResolver());

--- a/tests/unit/DocBlock/Tags/UsesTest.php
+++ b/tests/unit/DocBlock/Tags/UsesTest.php
@@ -30,7 +30,7 @@ class UsesTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -40,7 +40,7 @@ class UsesTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned()
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Uses(new Fqsen('\DateTime'), new Description('Description'));
 
@@ -55,7 +55,7 @@ class UsesTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter()
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Uses(new Fqsen('\DateTime'), new Description('Description'));
 
@@ -67,7 +67,7 @@ class UsesTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter()
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Uses(new Fqsen('\DateTime'), new Description('Description'));
 
@@ -81,7 +81,7 @@ class UsesTest extends TestCase
      * @covers ::__construct
      * @covers ::getReference
      */
-    public function testHasReferenceToFqsen()
+    public function testHasReferenceToFqsen(): void
     {
         $expected = new Fqsen('\DateTime');
 
@@ -95,7 +95,7 @@ class UsesTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testHasDescription()
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -109,7 +109,7 @@ class UsesTest extends TestCase
      * @covers ::__toString
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testStringRepresentationIsReturned()
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Uses(new Fqsen('\DateTime'), new Description('Description'));
 
@@ -125,7 +125,7 @@ class UsesTest extends TestCase
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethod()
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = m::mock(FqsenResolver::class);
@@ -149,7 +149,7 @@ class UsesTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty()
+    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
     {
         $this->assertNull(Uses::create(''));
     }
@@ -158,7 +158,7 @@ class UsesTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull()
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         Uses::create('body');
     }
@@ -167,7 +167,7 @@ class UsesTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull()
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         Uses::create('body', new FqsenResolver());
     }

--- a/tests/unit/DocBlock/Tags/UsesTest.php
+++ b/tests/unit/DocBlock/Tags/UsesTest.php
@@ -147,28 +147,28 @@ class UsesTest extends TestCase
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
+    public function testFactoryMethodFailsIfBodyIsNotEmpty() : void
     {
+        $this->expectException('InvalidArgumentException');
         $this->assertNull(Uses::create(''));
     }
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull(): void
+    public function testFactoryMethodFailsIfResolverIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         Uses::create('body');
     }
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         Uses::create('body', new FqsenResolver());
     }
 }

--- a/tests/unit/DocBlock/Tags/UsesTest.php
+++ b/tests/unit/DocBlock/Tags/UsesTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/UsesTest.php
+++ b/tests/unit/DocBlock/Tags/UsesTest.php
@@ -149,15 +149,6 @@ class UsesTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotString()
-    {
-        $this->assertNull(Uses::create([]));
-    }
-
-    /**
-     * @covers ::create
-     * @expectedException \InvalidArgumentException
-     */
     public function testFactoryMethodFailsIfBodyIsNotEmpty()
     {
         $this->assertNull(Uses::create(''));

--- a/tests/unit/DocBlock/Tags/VarTest.php
+++ b/tests/unit/DocBlock/Tags/VarTest.php
@@ -186,15 +186,6 @@ class VarTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfBodyIsNotString()
-    {
-        Var_::create([]);
-    }
-
-    /**
-     * @covers ::create
-     * @expectedException \InvalidArgumentException
-     */
     public function testFactoryMethodFailsIfResolverIsNull()
     {
         Var_::create('body');
@@ -208,14 +199,5 @@ class VarTest extends TestCase
     public function testFactoryMethodFailsIfDescriptionFactoryIsNull()
     {
         Var_::create('body', new TypeResolver());
-    }
-
-    /**
-     * @covers ::__construct
-     * @expectedException \InvalidArgumentException
-     */
-    public function testExceptionIsThrownIfVariableNameIsNotString()
-    {
-        new Var_([]);
     }
 }

--- a/tests/unit/DocBlock/Tags/VarTest.php
+++ b/tests/unit/DocBlock/Tags/VarTest.php
@@ -175,7 +175,7 @@ class VarTest extends TestCase
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven() : void
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
     {
         $this->expectException('InvalidArgumentException');
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -185,7 +185,7 @@ class VarTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Var_::create('body');
@@ -195,7 +195,7 @@ class VarTest extends TestCase
      * @covers ::create
      * @uses \phpDocumentor\Reflection\TypeResolver
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Var_::create('body', new TypeResolver());

--- a/tests/unit/DocBlock/Tags/VarTest.php
+++ b/tests/unit/DocBlock/Tags/VarTest.php
@@ -30,7 +30,7 @@ class VarTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -40,7 +40,7 @@ class VarTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned()
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Var_('myVariable', null, new Description('Description'));
 
@@ -51,7 +51,7 @@ class VarTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Tags\Var_::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfVariableNameIsOmmitedIfEmpty()
+    public function testIfVariableNameIsOmmitedIfEmpty(): void
     {
         $fixture = new Var_('', null, null);
 
@@ -66,7 +66,7 @@ class VarTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter()
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Var_('myVariable', new String_(), new Description('Description'));
         $this->assertSame('@var string $myVariable Description', $fixture->render());
@@ -82,7 +82,7 @@ class VarTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Tags\Var_::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter()
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Var_('myVariable');
 
@@ -96,7 +96,7 @@ class VarTest extends TestCase
      * @covers ::__construct
      * @covers ::getVariableName
      */
-    public function testHasVariableName()
+    public function testHasVariableName(): void
     {
         $expected = 'myVariable';
 
@@ -109,7 +109,7 @@ class VarTest extends TestCase
      * @covers ::__construct
      * @covers ::getType
      */
-    public function testHasType()
+    public function testHasType(): void
     {
         $expected = new String_();
 
@@ -123,7 +123,7 @@ class VarTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testHasDescription()
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -138,7 +138,7 @@ class VarTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @uses   \phpDocumentor\Reflection\Types\String_
      */
-    public function testStringRepresentationIsReturned()
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Var_('myVariable', new String_(), new Description('Description'));
 
@@ -152,7 +152,7 @@ class VarTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethod()
+    public function testFactoryMethod(): void
     {
         $typeResolver       = new TypeResolver();
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -176,7 +176,7 @@ class VarTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven()
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         Var_::create('', new TypeResolver(), $descriptionFactory);
@@ -186,7 +186,7 @@ class VarTest extends TestCase
      * @covers ::create
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull()
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         Var_::create('body');
     }
@@ -196,7 +196,7 @@ class VarTest extends TestCase
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull()
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         Var_::create('body', new TypeResolver());
     }

--- a/tests/unit/DocBlock/Tags/VarTest.php
+++ b/tests/unit/DocBlock/Tags/VarTest.php
@@ -174,30 +174,30 @@ class VarTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Var_::<public>
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven() : void
     {
+        $this->expectException('InvalidArgumentException');
         $descriptionFactory = m::mock(DescriptionFactory::class);
         Var_::create('', new TypeResolver(), $descriptionFactory);
     }
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfResolverIsNull(): void
+    public function testFactoryMethodFailsIfResolverIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         Var_::create('body');
     }
 
     /**
      * @covers ::create
      * @uses \phpDocumentor\Reflection\TypeResolver
-     * @expectedException \InvalidArgumentException
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
     {
+        $this->expectException('InvalidArgumentException');
         Var_::create('body', new TypeResolver());
     }
 }

--- a/tests/unit/DocBlock/Tags/VarTest.php
+++ b/tests/unit/DocBlock/Tags/VarTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlock/Tags/VersionTest.php
+++ b/tests/unit/DocBlock/Tags/VersionTest.php
@@ -159,15 +159,6 @@ class VersionTest extends TestCase
 
     /**
      * @covers ::create
-     * @expectedException \InvalidArgumentException
-     */
-    public function testFactoryMethodFailsIfVersionIsNotString()
-    {
-        $this->assertNull(Version::create([]));
-    }
-
-    /**
-     * @covers ::create
      */
     public function testFactoryMethodReturnsNullIfBodyDoesNotMatchRegex()
     {

--- a/tests/unit/DocBlock/Tags/VersionTest.php
+++ b/tests/unit/DocBlock/Tags/VersionTest.php
@@ -28,7 +28,7 @@ class VersionTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -38,7 +38,7 @@ class VersionTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned()
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Version('1.0', new Description('Description'));
 
@@ -53,7 +53,7 @@ class VersionTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter()
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Version('1.0', new Description('Description'));
 
@@ -65,7 +65,7 @@ class VersionTest extends TestCase
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter()
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Version('1.0', new Description('Description'));
 
@@ -79,7 +79,7 @@ class VersionTest extends TestCase
      * @covers ::__construct
      * @covers ::getVersion
      */
-    public function testHasVersionNumber()
+    public function testHasVersionNumber(): void
     {
         $expected = '1.0';
 
@@ -93,7 +93,7 @@ class VersionTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testHasDescription()
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -107,7 +107,7 @@ class VersionTest extends TestCase
      * @covers ::__toString
      * @uses   \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testStringRepresentationIsReturned()
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Version('1.0', new Description('Description'));
 
@@ -121,7 +121,7 @@ class VersionTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethod()
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $context            = new Context('');
@@ -145,7 +145,7 @@ class VersionTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testFactoryMethodCreatesEmptyVersionTag()
+    public function testFactoryMethodCreatesEmptyVersionTag(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $descriptionFactory->shouldReceive('create')->never();
@@ -160,7 +160,7 @@ class VersionTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodReturnsNullIfBodyDoesNotMatchRegex()
+    public function testFactoryMethodReturnsNullIfBodyDoesNotMatchRegex(): void
     {
         $this->assertNull(Version::create('dkhf<'));
     }

--- a/tests/unit/DocBlock/Tags/VersionTest.php
+++ b/tests/unit/DocBlock/Tags/VersionTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlockFactoryTest.php
+++ b/tests/unit/DocBlockFactoryTest.php
@@ -33,7 +33,7 @@ class DocBlockFactoryTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -44,7 +44,7 @@ class DocBlockFactoryTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\StandardTagFactory
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      */
-    public function testCreateFactoryUsingFactoryMethod()
+    public function testCreateFactoryUsingFactoryMethod(): void
     {
         $fixture = DocBlockFactory::createInstance();
 
@@ -56,7 +56,7 @@ class DocBlockFactoryTest extends TestCase
      * @covers ::create
      * @uses   phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testCreateDocBlockFromReflection()
+    public function testCreateDocBlockFromReflection(): void
     {
         $fixture = new DocBlockFactory(m::mock(DescriptionFactory::class), m::mock(TagFactory::class));
 
@@ -78,7 +78,7 @@ class DocBlockFactoryTest extends TestCase
      * @covers ::create
      * @uses   phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testCreateDocBlockFromStringWithDocComment()
+    public function testCreateDocBlockFromStringWithDocComment(): void
     {
         $fixture = new DocBlockFactory(m::mock(DescriptionFactory::class), m::mock(TagFactory::class));
 
@@ -97,7 +97,7 @@ class DocBlockFactoryTest extends TestCase
      * @covers ::__construct
      * @uses   phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testCreateDocBlockFromStringWithoutDocComment()
+    public function testCreateDocBlockFromStringWithoutDocComment(): void
     {
         $fixture = new DocBlockFactory(m::mock(DescriptionFactory::class), m::mock(TagFactory::class));
 
@@ -118,7 +118,7 @@ class DocBlockFactoryTest extends TestCase
      * @uses         phpDocumentor\Reflection\DocBlock\Description
      * @dataProvider provideSummaryAndDescriptions
      */
-    public function testSummaryAndDescriptionAreSeparated($given, $summary, $description)
+    public function testSummaryAndDescriptionAreSeparated($given, $summary, $description): void
     {
         $tagFactory = m::mock(TagFactory::class);
         $fixture    = new DocBlockFactory(new DescriptionFactory($tagFactory), $tagFactory);
@@ -135,7 +135,7 @@ class DocBlockFactoryTest extends TestCase
      * @uses phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @uses phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testDescriptionsRetainFormatting()
+    public function testDescriptionsRetainFormatting(): void
     {
         $tagFactory = m::mock(TagFactory::class);
         $fixture    = new DocBlockFactory(new DescriptionFactory($tagFactory), $tagFactory);
@@ -168,7 +168,7 @@ DESCRIPTION;
      * @uses phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @uses phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testTagsAreInterpretedUsingFactory()
+    public function testTagsAreInterpretedUsingFactory(): void
     {
         $tagString = <<<TAG
 @author Mike van Riel <me@mikevanriel.com> This is with
@@ -255,7 +255,7 @@ DOCBLOCK
      * @uses   phpDocumentor\Reflection\Types\Context
      * @uses   phpDocumentor\Reflection\DocBlock\Tags\Param
      */
-    public function testTagsWithContextNamespace()
+    public function testTagsWithContextNamespace(): void
     {
         $tagFactoryMock = m::mock(TagFactory::class);
         $fixture = new DocBlockFactory(m::mock(DescriptionFactory::class), $tagFactoryMock);
@@ -274,7 +274,7 @@ DOCBLOCK
      * @uses phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @uses phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testTagsAreFilteredForNullValues()
+    public function testTagsAreFilteredForNullValues(): void
     {
         $tagString = <<<TAG
 @author Mike van Riel <me@mikevanriel.com> This is with

--- a/tests/unit/DocBlockFactoryTest.php
+++ b/tests/unit/DocBlockFactoryTest.php
@@ -263,6 +263,8 @@ DOCBLOCK
 
         $tagFactoryMock->shouldReceive('create')->with(m::any(), $context)->andReturn(new Param('param'));
         $docblock = $fixture->create('/** @param MyType $param */', $context);
+
+        $this->assertInstanceOf(DocBlock::class, $docblock);
     }
 
     /**

--- a/tests/unit/DocBlockFactoryTest.php
+++ b/tests/unit/DocBlockFactoryTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *

--- a/tests/unit/DocBlockTest.php
+++ b/tests/unit/DocBlockTest.php
@@ -28,7 +28,7 @@ class DocBlockTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         m::close();
     }
@@ -39,7 +39,7 @@ class DocBlockTest extends TestCase
      *
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testDocBlockCanHaveASummary()
+    public function testDocBlockCanHaveASummary(): void
     {
         $summary = 'This is a summary';
 
@@ -54,7 +54,7 @@ class DocBlockTest extends TestCase
      *
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testDocBlockCanHaveADescription()
+    public function testDocBlockCanHaveADescription(): void
     {
         $description = new DocBlock\Description('');
 
@@ -70,7 +70,7 @@ class DocBlockTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\DocBlock\Tag
      */
-    public function testDocBlockCanHaveTags()
+    public function testDocBlockCanHaveTags(): void
     {
         $tags = [
             m::mock(DocBlock\Tag::class)
@@ -90,7 +90,7 @@ class DocBlockTest extends TestCase
      *
      * @expectedException \InvalidArgumentException
      */
-    public function testDocBlockAllowsOnlyTags()
+    public function testDocBlockAllowsOnlyTags(): void
     {
         $tags = [
             null
@@ -107,7 +107,7 @@ class DocBlockTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\DocBlock\Tag
      */
-    public function testFindTagsInDocBlockByName()
+    public function testFindTagsInDocBlockByName(): void
     {
         $tag1 = m::mock(DocBlock\Tag::class);
         $tag2 = m::mock(DocBlock\Tag::class);
@@ -132,7 +132,7 @@ class DocBlockTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\DocBlock\Tag
      */
-    public function testCheckIfThereAreTagsWithAGivenName()
+    public function testCheckIfThereAreTagsWithAGivenName(): void
     {
         $tag1 = m::mock(DocBlock\Tag::class);
         $tag2 = m::mock(DocBlock\Tag::class);
@@ -156,7 +156,7 @@ class DocBlockTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Types\Context
      */
-    public function testDocBlockKnowsInWhichNamespaceItIsAndWhichAliasesThereAre()
+    public function testDocBlockKnowsInWhichNamespaceItIsAndWhichAliasesThereAre(): void
     {
         $context = new Context('');
 
@@ -172,7 +172,7 @@ class DocBlockTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Location
      */
-    public function testDocBlockKnowsAtWhichLineItIs()
+    public function testDocBlockKnowsAtWhichLineItIs(): void
     {
         $location = new Location(10);
 
@@ -187,7 +187,7 @@ class DocBlockTest extends TestCase
      *
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testDocBlockKnowsIfItIsTheStartOfADocBlockTemplate()
+    public function testDocBlockKnowsIfItIsTheStartOfADocBlockTemplate(): void
     {
         $fixture = new DocBlock('', null, [], null, null, true);
 
@@ -200,7 +200,7 @@ class DocBlockTest extends TestCase
      *
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      */
-    public function testDocBlockKnowsIfItIsTheEndOfADocBlockTemplate()
+    public function testDocBlockKnowsIfItIsTheEndOfADocBlockTemplate(): void
     {
         $fixture = new DocBlock('', null, [], null, null, false, true);
 
@@ -213,7 +213,7 @@ class DocBlockTest extends TestCase
      *
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Deprecated
      */
-    public function testRemoveTag()
+    public function testRemoveTag(): void
     {
         $someTag = new Deprecated();
         $anotherTag = new Deprecated();

--- a/tests/unit/DocBlockTest.php
+++ b/tests/unit/DocBlockTest.php
@@ -84,18 +84,15 @@ class DocBlockTest extends TestCase
     /**
      * @covers ::__construct
      * @covers ::getTags
-     *
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\DocBlock\Tag
-     *
-     * @expectedException \InvalidArgumentException
      */
-    public function testDocBlockAllowsOnlyTags(): void
+    public function testDocBlockAllowsOnlyTags() : void
     {
+        $this->expectException('InvalidArgumentException');
         $tags = [
             null
         ];
-
         $fixture = new DocBlock('', null, $tags);
     }
 

--- a/tests/unit/DocBlockTest.php
+++ b/tests/unit/DocBlockTest.php
@@ -50,36 +50,6 @@ class DocBlockTest extends TestCase
 
     /**
      * @covers ::__construct
-     *
-     * @expectedException \InvalidArgumentException
-     */
-    public function testExceptionIsThrownIfSummaryIsNotAString()
-    {
-        new DocBlock([]);
-    }
-
-    /**
-     * @covers ::__construct
-     *
-     * @expectedException \InvalidArgumentException
-     */
-    public function testExceptionIsThrownIfTemplateStartIsNotABoolean()
-    {
-        new DocBlock('', null, [], null, null, ['is not boolean']);
-    }
-
-    /**
-     * @covers ::__construct
-     *
-     * @expectedException \InvalidArgumentException
-     */
-    public function testExceptionIsThrownIfTemplateEndIsNotABoolean()
-    {
-        new DocBlock('', null, [], null, null, false, ['is not boolean']);
-    }
-
-    /**
-     * @covers ::__construct
      * @covers ::getDescription
      *
      * @uses \phpDocumentor\Reflection\DocBlock\Description
@@ -156,18 +126,6 @@ class DocBlockTest extends TestCase
 
     /**
      * @covers ::__construct
-     * @covers ::getTagsByName
-     * @uses \phpDocumentor\Reflection\DocBlock\Description
-     * @expectedException \InvalidArgumentException
-     */
-    public function testExceptionIsThrownIfNameForTagsIsNotString()
-    {
-        $fixture = new DocBlock();
-        $fixture->getTagsByName([]);
-    }
-
-    /**
-     * @covers ::__construct
      * @covers ::hasTag
      *
      * @uses \phpDocumentor\Reflection\DocBlock::getTags
@@ -189,18 +147,6 @@ class DocBlockTest extends TestCase
 
         $this->assertTrue($fixture->hasTag('abcd'));
         $this->assertFalse($fixture->hasTag('Ebcd'));
-    }
-
-    /**
-     * @covers ::__construct
-     * @covers ::hasTag
-     * @uses \phpDocumentor\Reflection\DocBlock\Description
-     * @expectedException \InvalidArgumentException
-     */
-    public function testExceptionIsThrownIfNameForCheckingTagsIsNotString()
-    {
-        $fixture = new DocBlock();
-        $fixture->hasTag([]);
     }
 
     /**

--- a/tests/unit/DocBlockTest.php
+++ b/tests/unit/DocBlockTest.php
@@ -87,7 +87,7 @@ class DocBlockTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\DocBlock\Tag
      */
-    public function testDocBlockAllowsOnlyTags() : void
+    public function testDocBlockAllowsOnlyTags(): void
     {
         $this->expectException('InvalidArgumentException');
         $tags = [

--- a/tests/unit/DocBlockTest.php
+++ b/tests/unit/DocBlockTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 /**
  * This file is part of phpDocumentor.
  *


### PR DESCRIPTION
### Why?

- majority of [PHP world big players are bumping to PHP 7.1](https://gophp71.org/)
- upcoming [PHP 7.2](https://github.com/php-ai/php-ml/pull/147) in few days
- we could add PHP 7.0/7.1 typehints via coding standards more easily in the future
- [as measured on Packagist - 67 % people](https://seld.be/notes/php-versions-stats-2017-2-edition) are on PHP 7.0+ and growing
- easier to maintain, more reliable code without testing it
- thanks to typehints, I could found and prevent some bugs already


### Related Changes

- use PHPUnit 6.0 syntax for `@expectedException`