### PR TITLE
Serializer - add  test for tag removal extra spaces

### DIFF
--- a/src/DocBlock/Serializer.php
+++ b/src/DocBlock/Serializer.php
@@ -86,6 +86,7 @@ class Serializer
             $comment .= "{$indent} * {$text}\n";
             $comment .= "{$indent} *\n";
         }
+
         $comment = $this->addTagBlock($docblock, $wrapLength, $indent, $comment);
         $comment .= $indent . ' */';
 

--- a/src/DocBlock/Serializer.php
+++ b/src/DocBlock/Serializer.php
@@ -81,7 +81,11 @@ class Serializer
             )
         );
 
-        $comment = "{$firstIndent}/**\n{$indent} * {$text}\n{$indent} *\n";
+        $comment = "{$firstIndent}/**\n";
+        if ($text) {
+            $comment .= "{$indent} * {$text}\n";
+            $comment .= "{$indent} *\n";
+        }
         $comment = $this->addTagBlock($docblock, $wrapLength, $indent, $comment);
         $comment .= $indent . ' */';
 

--- a/tests/unit/DocBlock/SerializerTest.php
+++ b/tests/unit/DocBlock/SerializerTest.php
@@ -192,7 +192,7 @@ DOCCOMMENT_AFTER_REMOVE;
         $fixture = new Serializer(0, '', true, 15);
         $genericTag = new DocBlock\Tags\Generic('unknown-tag');
 
-        $docBlock = new DocBlock('',null, [$genericTag]);
+        $docBlock = new DocBlock('', null, [$genericTag]);
         $this->assertSame($expected, $fixture->getDocComment($docBlock));
 
         $docBlock->removeTag($genericTag);

--- a/tests/unit/DocBlock/SerializerTest.php
+++ b/tests/unit/DocBlock/SerializerTest.php
@@ -174,6 +174,33 @@ DOCCOMMENT;
 
     /**
      * @covers ::__construct
+     * @covers ::getDocComment
+     */
+    public function testNoExtraSpacesAfterTagRemoval()
+    {
+        $expected = <<<'DOCCOMMENT'
+/**
+ * @unknown-tag
+ */
+DOCCOMMENT;
+
+        $expectedAfterRemove = <<<'DOCCOMMENT_AFTER_REMOVE'
+/**
+ */
+DOCCOMMENT_AFTER_REMOVE;
+
+        $fixture = new Serializer(0, '', true, 15);
+        $genericTag = new DocBlock\Tags\Generic('unknown-tag');
+
+        $docBlock = new DocBlock('',null, [$genericTag]);
+        $this->assertSame($expected, $fixture->getDocComment($docBlock));
+
+        $docBlock->removeTag($genericTag);
+        $this->assertSame($expectedAfterRemove, $fixture->getDocComment($docBlock));
+    }
+
+    /**
+     * @covers ::__construct
      * @expectedException \InvalidArgumentException
      */
     public function testInitializationFailsIfIndentIsNotAnInteger()


### PR DESCRIPTION
When I remove last tag, extra spaces are added, that mailform the docblock. Especially with space after asterix: `{$indent}* \n`.

I fixed it by condition on value in `$text`.

See tests for more 
