### PR TITLE
Fix return types and make it codebase more static analyser-friendly

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,9 +2,6 @@ parameters:
     ignoreErrors:
         # false positive
         - '#Call to an undefined method object::getDocComment\(\)#'
-        - '#Cannot call method render\(\) on phpDocumentor\\Reflection\\DocBlock\\Description\|string#'
+        - '#Calling method render\(\) on possibly null value of type phpDocumentor\\Reflection\\DocBlock\\Description\|null#'
         - '#Calling method create\(\) on possibly null value of type phpDocumentor\\Reflection\\DocBlock\\DescriptionFactory\|null#'
         - '#Calling method resolve\(\) on possibly null value of type phpDocumentor\\Reflection\\(TypeResolver|FqsenResolver)\|null#'
-
-        # nested parents
-        - '#Calling method render\(\) on possibly null value of type phpDocumentor\\Reflection\\DocBlock\\Description\|string\|null#'

--- a/src/DocBlock/DescriptionFactory.php
+++ b/src/DocBlock/DescriptionFactory.php
@@ -106,7 +106,8 @@ class DescriptionFactory
      *
      * @param string[] $tokens
      *
-     * @return string[]|Tag[]
+     * @return string[]|Tag[][]
+     * @psalm-return array{0: string, 1: Tag[]}
      */
     private function parse($tokens, ?TypeContext $context = null): array
     {

--- a/src/DocBlock/ExampleFinder.php
+++ b/src/DocBlock/ExampleFinder.php
@@ -88,7 +88,7 @@ class ExampleFinder
      * 3. Checks the 'examples' folder in the current working directory for examples
      * 4. Checks the path relative to the current working directory for the given filename
      */
-    private function getExampleFileContents(string $filename): ?string
+    private function getExampleFileContents(string $filename): ?array
     {
         $normalizedPath = null;
 

--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -226,8 +226,9 @@ final class StandardTagFactory implements TagFactory
     {
         $arguments = [];
         foreach ($parameters as $index => $parameter) {
-            $typeHint = $parameter->getClass() ? $parameter->getClass()->getName() : null;
-            if (isset($locator[$typeHint])) {
+            $parameterClass = $parameter->getClass();
+            $typeHint = $parameterClass ? $parameterClass->getName() : null;
+            if ($typeHint && isset($locator[$typeHint])) {
                 $arguments[] = $locator[$typeHint];
                 continue;
             }

--- a/src/DocBlock/Tags/Covers.php
+++ b/src/DocBlock/Tags/Covers.php
@@ -30,6 +30,9 @@ final class Covers extends BaseTag implements Factory\StaticMethod
     /** @var Fqsen */
     private $refers;
 
+    /** @var Description|null Description of the tag. */
+    protected $description;
+
     /**
      * Initializes this tag.
      */

--- a/src/DocBlock/Tags/Deprecated.php
+++ b/src/DocBlock/Tags/Deprecated.php
@@ -25,6 +25,9 @@ final class Deprecated extends BaseTag implements Factory\StaticMethod
 {
     protected $name = 'deprecated';
 
+    /** @var Description|null Description of the tag. */
+    protected $description;
+
     /**
      * PCRE regular expression matching a version vector.
      * Assumes the "x" modifier.

--- a/src/DocBlock/Tags/Generic.php
+++ b/src/DocBlock/Tags/Generic.php
@@ -24,6 +24,9 @@ use Webmozart\Assert\Assert;
  */
 class Generic extends BaseTag implements Factory\StaticMethod
 {
+    /** @var Description|null Description of the tag. */
+    protected $description;
+
     /**
      * Parses a tag and populates the member variables.
      *

--- a/src/DocBlock/Tags/Link.php
+++ b/src/DocBlock/Tags/Link.php
@@ -25,6 +25,9 @@ final class Link extends BaseTag implements Factory\StaticMethod
 {
     protected $name = 'link';
 
+    /** @var Description|null Description of the tag. */
+    protected $description;
+
     /** @var string */
     private $link = '';
 

--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -28,10 +28,13 @@ final class Method extends BaseTag implements Factory\StaticMethod
 {
     protected $name = 'method';
 
+    /** @var Description|null Description of the tag. */
+    protected $description;
+
     /** @var string */
     private $methodName = '';
 
-    /** @var string[] */
+    /** @var string[][] */
     private $arguments = [];
 
     /** @var bool */
@@ -168,7 +171,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
     }
 
     /**
-     * @return string[]
+     * @return string[][]
      */
     public function getArguments()
     {

--- a/src/DocBlock/Tags/See.php
+++ b/src/DocBlock/Tags/See.php
@@ -29,6 +29,9 @@ class See extends BaseTag implements Factory\StaticMethod
 {
     protected $name = 'see';
 
+    /** @var Description|null Description of the tag. */
+    protected $description;
+
     /** @var Reference */
     protected $refers;
 

--- a/src/DocBlock/Tags/Since.php
+++ b/src/DocBlock/Tags/Since.php
@@ -26,6 +26,9 @@ final class Since extends BaseTag implements Factory\StaticMethod
 {
     protected $name = 'since';
 
+    /** @var Description|null Description of the tag. */
+    protected $description;
+
     /**
      * PCRE regular expression matching a version vector.
      * Assumes the "x" modifier.

--- a/src/DocBlock/Tags/Source.php
+++ b/src/DocBlock/Tags/Source.php
@@ -26,6 +26,9 @@ final class Source extends BaseTag implements Factory\StaticMethod
     /** @var string */
     protected $name = 'source';
 
+    /** @var Description|null Description of the tag. */
+    protected $description;
+
     /** @var int The starting line, relative to the structural element's location. */
     private $startingLine = 1;
 

--- a/src/DocBlock/Tags/Uses.php
+++ b/src/DocBlock/Tags/Uses.php
@@ -27,6 +27,9 @@ final class Uses extends BaseTag implements Factory\StaticMethod
 {
     protected $name = 'uses';
 
+    /** @var Description|null Description of the tag. */
+    protected $description;
+
     /** @var Fqsen */
     protected $refers;
 

--- a/src/DocBlock/Tags/Version.php
+++ b/src/DocBlock/Tags/Version.php
@@ -25,6 +25,9 @@ final class Version extends BaseTag implements Factory\StaticMethod
 {
     protected $name = 'version';
 
+    /** @var Description|null Description of the tag. */
+    protected $description;
+
     /**
      * PCRE regular expression matching a version vector.
      * Assumes the "x" modifier.


### PR DESCRIPTION
- Fixes a bad typehinted return type in `src/DocBlock/ExampleFinder.php`
- Fixes the same docblock as #141, plus a bunch of others
- Adds a more specific property type for `phpDocumentor\Reflection\DocBlock\Tags\BaseTag::$description` to stop PHPStan and Psalm complaining about its type within those classes.

Passing Psalm config [here](https://github.com/muglug/ReflectionDocBlock/blob/a28842cf2663e751d4f5e6e51e01fa6289fc4415/psalm.xml)