### PR TITLE
Use package name in link to packagist

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
 [![Coveralls Coverage](https://img.shields.io/coveralls/github/phpDocumentor/ReflectionDocBlock.svg)](https://coveralls.io/github/phpDocumentor/ReflectionDocBlock?branch=master)
 [![Scrutinizer Code Coverage](https://img.shields.io/scrutinizer/coverage/g/phpDocumentor/ReflectionDocBlock.svg)](https://scrutinizer-ci.com/g/phpDocumentor/ReflectionDocBlock/?branch=master)
 [![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/g/phpDocumentor/ReflectionDocBlock.svg)](https://scrutinizer-ci.com/g/phpDocumentor/ReflectionDocBlock/?branch=master)
-[![Stable Version](https://img.shields.io/packagist/v/phpDocumentor/ReflectionDocBlock.svg)](https://packagist.org/packages/phpDocumentor/ReflectionDocBlock)
-[![Unstable Version](https://img.shields.io/packagist/vpre/phpDocumentor/ReflectionDocBlock.svg)](https://packagist.org/packages/phpDocumentor/ReflectionDocBlock)
-
+[![Stable Version](https://img.shields.io/packagist/v/phpdocumentor/reflection-docblock.svg)](https://packagist.org/packages/phpdocumentor/reflection-docblock)
+[![Unstable Version](https://img.shields.io/packagist/vpre/phpdocumentor/reflection-docblock.svg)](https://packagist.org/packages/phpdocumentor/reflection-docblock)
 
 ReflectionDocBlock 
 ==================


### PR DESCRIPTION
Use the proper URLs in badges. It looks a bit sad with invalid paths: 

<img width="320" alt="screen shot 2018-01-29 at 20 57 14" src="https://user-images.githubusercontent.com/1275206/35531411-33769388-0537-11e8-85e6-54c5f52f1b11.png">

