### PR TITLE
Update the branch alias for 5.x releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.x-dev"
+            "dev-master": "5.x-dev"
         }
     }
 }


### PR DESCRIPTION
It's time to update the branch alias since BC breaking changes were merged and the first 5.0.0-alpha1 release has been made.

I got bitten by this while testing my library with instable deps.