### PR TITLE
Restore PHP version 5.5 support in 3.x branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^5.5 || ^5.6 || ^7.0",
         "phpdocumentor/reflection-common": "^1.0.0",
         "phpdocumentor/type-resolver": "^0.4.0",
         "webmozart/assert": "^1.0"


### PR DESCRIPTION
The PHP version support shouldn't have been changed on a patch version update. There's no reason to require 5.6 or 7. This breaks other projects that support 5.5 as composer won't install this package now because of this change from php 5.5 > php 5.6