### PR TITLE
Check on leading "[" removed as this check makes it very difficult to…

### DIFF
--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -113,12 +113,6 @@ final class StandardTagFactory implements TagFactory
 
         [$tagName, $tagBody] = $this->extractTagParts($tagLine);
 
-        if ($tagBody !== '' && $tagBody[0] === '[') {
-            throw new \InvalidArgumentException(
-                'The tag "' . $tagLine . '" does not seem to be wellformed, please check it for errors'
-            );
-        }
-
         return $this->createTag($tagBody, $tagName, $context);
     }
 


### PR DESCRIPTION
… implement custom tags which might want to allow or require this character in the tag body.

A leading square bracket might not be necessary for standard tags, but StandardTagFactory allows registering or overriding of tag implementations which might want to accept this character right after the tag.