### PR TITLE
Make getter for bodyTemplate public

### DIFF
--- a/src/DocBlock/Description.php
+++ b/src/DocBlock/Description.php
@@ -66,6 +66,15 @@ class Description
         $this->bodyTemplate = $bodyTemplate;
         $this->tags = $tags;
     }
+    
+    /**
+     * Returns the body template
+     * @return string
+     */
+    public function getBodyTemplate(): string
+    {
+        return $this->bodyTemplate;
+    }
 
     /**
      * Returns the tags for this DocBlock.


### PR DESCRIPTION
in order to make conversion of existig Description to custom Description class easier (e.g. new MyDescriptionClass($origionalDescription->getBodyTemplate(), $origionalDescription->getTags();)