### PR TITLE
Replace dflydev/markdown suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "phpunit/phpunit": "~4.0"
     },
     "suggest": {
-        "dflydev/markdown": "~1.0",
+        "michelf/php-markdown": "~1.0",
         "erusev/parsedown": "~1.0"
     },
     "extra": {


### PR DESCRIPTION
Since dflydev/markdown is abandoned, replace it with michelf/php-markdown instead.