### PR TITLE
Fixed @method annotations with an empty argument list and description

### DIFF
--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -120,12 +120,8 @@ final class Method extends BaseTag implements Factory\StaticMethod
                     )
                     \s+
                 )?
-                # Legacy method name (not captured)
-                (?:
-                    [\w_]+\(\)\s+
-                )?
                 # Method name
-                ([\w\|_\\\\]+)
+                ([\w_]+)
                 # Arguments
                 (?:
                     \(([^\)]*)\)

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -479,6 +479,40 @@ class MethodTest extends TestCase
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::create
+     */
+    public function testCreateMethodEmptyArguments() : void
+    {
+        $descriptionFactory = m::mock(DescriptionFactory::class);
+        $resolver           = new TypeResolver();
+        $context            = new Context('');
+
+        $description = new Description('My Description');
+
+        $descriptionFactory->shouldReceive('create')->with('My Description', $context)->andReturn($description);
+
+        $fixture = Method::create(
+            'static void myMethod() My Description',
+            $resolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertSame('static void myMethod() My Description', (string) $fixture);
+        $this->assertSame('myMethod', $fixture->getMethodName());
+        $this->assertEquals([], $fixture->getArguments());
+        $this->assertInstanceOf(Void_::class, $fixture->getReturnType());
+        $this->assertSame($description, $fixture->getDescription());
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Method::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\TypeResolver
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Fqsen
+     * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Void_
      *
      * @covers ::create


### PR DESCRIPTION
https://github.com/phpDocumentor/ReflectionDocBlock/issues/174

This also removes some extra characters from the method name character block. I think they were copied from the return types regex up above.