### PR TITLE
Support braces in types for @return

### DIFF
--- a/tests/unit/DocBlock/Tags/ReturnTest.php
+++ b/tests/unit/DocBlock/Tags/ReturnTest.php
@@ -112,7 +112,7 @@ class ReturnTest extends TestCase
     {
         $fixture = new Return_(new String_(), new Description('Description'));
 
-        $this->assertSame('string Description', (string)$fixture);
+        $this->assertSame('string Description', (string) $fixture);
     }
 
     /**
@@ -136,9 +136,44 @@ class ReturnTest extends TestCase
 
         $fixture = Return_::create('string My Description', $resolver, $descriptionFactory, $context);
 
-        $this->assertSame('string My Description', (string)$fixture);
+        $this->assertSame('string My Description', (string) $fixture);
         $this->assertEquals($type, $fixture->getType());
         $this->assertSame($description, $fixture->getDescription());
+    }
+
+    /**
+     * This test checks whether a braces in a Type are allowed.
+     *
+     * The advent of generics poses a few issues, one of them is that spaces can now be part of a type. In the past we
+     * could purely rely on spaces to split the individual parts of the body of a tag; but when there is a type in play
+     * we now need to check for braces.
+     *
+     * This test tests whether an error occurs demonstrating that the braces were taken into account; this test is still
+     * expected to produce an exception because the TypeResolver does not support generics.
+     *
+     * @covers ::create
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Return_::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\TypeResolver
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\String_
+     * @uses \phpDocumentor\Reflection\Types\Context
+     */
+    public function testFactoryMethodWithGenericWithSpace()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('"\array😁<string,😁 😁string>" is not a valid Fqsen.');
+
+        $descriptionFactory = m::mock(DescriptionFactory::class);
+        $resolver = new TypeResolver();
+        $context = new Context('');
+
+        $description = new Description('My Description');
+        $descriptionFactory->shouldReceive('create')
+            ->with('My Description', $context)
+            ->andReturn($description);
+
+        Return_::create('array😁<string,😁 string> My Description', $resolver, $descriptionFactory, $context);
     }
 
     /**

--- a/tests/unit/DocBlock/Tags/ReturnTest.php
+++ b/tests/unit/DocBlock/Tags/ReturnTest.php
@@ -162,6 +162,34 @@ class ReturnTest extends TestCase
     public function testFactoryMethodWithGenericWithSpace()
     {
         $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('"\array<string, string>" is not a valid Fqsen.');
+
+        $descriptionFactory = m::mock(DescriptionFactory::class);
+        $resolver = new TypeResolver();
+        $context = new Context('');
+
+        $description = new Description('My Description');
+        $descriptionFactory->shouldReceive('create')
+            ->with('My Description', $context)
+            ->andReturn($description);
+
+        Return_::create('array<string, string> My Description', $resolver, $descriptionFactory, $context);
+    }
+
+    /**
+     * @see self::testFactoryMethodWithGenericWithSpace()
+     *
+     * @covers ::create
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Return_::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\TypeResolver
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\String_
+     * @uses \phpDocumentor\Reflection\Types\Context
+     */
+    public function testFactoryMethodWithGenericWithSpaceAndAddedEmojisToVerifyMultiByteBehaviour()
+    {
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('"\array😁<string,😁 😁string>" is not a valid Fqsen.');
 
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -173,7 +201,34 @@ class ReturnTest extends TestCase
             ->with('My Description', $context)
             ->andReturn($description);
 
-        Return_::create('array😁<string,😁 string> My Description', $resolver, $descriptionFactory, $context);
+        Return_::create('array😁<string,😁 😁string> My Description', $resolver, $descriptionFactory, $context);
+    }
+
+    /**
+     * @covers ::create
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Return_::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\TypeResolver
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\String_
+     * @uses \phpDocumentor\Reflection\Types\Context
+     */
+    public function testFactoryMethodWithEmojisToVerifyMultiByteBehaviour()
+    {
+        $descriptionFactory = m::mock(DescriptionFactory::class);
+        $resolver = new TypeResolver();
+        $context = new Context('');
+
+        $description = new Description('My Description');
+        $descriptionFactory->shouldReceive('create')
+            ->with('My Description', $context)
+            ->andReturn($description);
+
+        $fixture = Return_::create('\My😁Class My Description', $resolver, $descriptionFactory, $context);
+
+        $this->assertSame('\My😁Class My Description', (string) $fixture);
+        $this->assertEquals('\My😁Class', $fixture->getType());
+        $this->assertSame($description, $fixture->getDescription());
     }
 
     /**


### PR DESCRIPTION
In this change, I have introduced a miniature automaton-light to parse
the type from the @return body. This will prevent issues with people
using generics and other unsupported forms of types.

This change does _not_ allow for the use of Generics or similar; the
TypeResolver will still fail to resolve this type. This will remove a
breaking issue in consuming applications where a runtime exception used
to be thrown.

Please note that this change is only for @return; other tags still need
to be done. This will resolve issue #186