### PR TITLE
Fix issue when processing invalid tags

### DIFF
--- a/src/DocBlock/DescriptionFactory.php
+++ b/src/DocBlock/DescriptionFactory.php
@@ -69,10 +69,7 @@ class DescriptionFactory
         $tags     = [];
 
         for ($i = 1; $i < $count; $i += 2) {
-            $tag = $this->tagFactory->create($tokens[$i], $context);
-            if ($tag !== null) {
-                $tags[] = $tag;
-            }
+            $tags[]     = $this->tagFactory->create($tokens[$i], $context);
             $tokens[$i] = '%' . ++$tagCount . '$s';
         }
 

--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -229,7 +229,7 @@ final class StandardTagFactory implements TagFactory
             $callable = [$handlerClassName, 'create'];
             return call_user_func_array($callable, $arguments);
         } catch (InvalidArgumentException $e) {
-            return InvalidTag::create($body, $name, $e);
+            return InvalidTag::create($body, $name)->withError($e);
         }
     }
 

--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -19,6 +19,7 @@ use phpDocumentor\Reflection\DocBlock\Tags\Covers;
 use phpDocumentor\Reflection\DocBlock\Tags\Deprecated;
 use phpDocumentor\Reflection\DocBlock\Tags\Factory\StaticMethod;
 use phpDocumentor\Reflection\DocBlock\Tags\Generic;
+use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
 use phpDocumentor\Reflection\DocBlock\Tags\Link as LinkTag;
 use phpDocumentor\Reflection\DocBlock\Tags\Method;
 use phpDocumentor\Reflection\DocBlock\Tags\Param;
@@ -138,7 +139,7 @@ final class StandardTagFactory implements TagFactory
     /**
      * {@inheritDoc}
      */
-    public function create(string $tagLine, ?TypeContext $context = null) : ?Tag
+    public function create(string $tagLine, ?TypeContext $context = null) : Tag
     {
         if (!$context) {
             $context = new TypeContext('');
@@ -215,7 +216,7 @@ final class StandardTagFactory implements TagFactory
      * Creates a new tag object with the given name and body or returns null if the tag name was recognized but the
      * body was invalid.
      */
-    private function createTag(string $body, string $name, TypeContext $context) : ?Tag
+    private function createTag(string $body, string $name, TypeContext $context) : Tag
     {
         $handlerClassName = $this->findHandlerClassName($name, $context);
         $arguments        = $this->getArgumentsForParametersFromWiring(
@@ -228,7 +229,7 @@ final class StandardTagFactory implements TagFactory
             $callable = [$handlerClassName, 'create'];
             return call_user_func_array($callable, $arguments);
         } catch (InvalidArgumentException $e) {
-            return null;
+            return InvalidTag::create($body, $name, $e);
         }
     }
 

--- a/src/DocBlock/TagFactory.php
+++ b/src/DocBlock/TagFactory.php
@@ -49,7 +49,7 @@ interface TagFactory
      *
      * @throws InvalidArgumentException If an invalid tag line was presented.
      */
-    public function create(string $tagLine, ?TypeContext $context = null) : ?Tag;
+    public function create(string $tagLine, ?TypeContext $context = null) : Tag;
 
     /**
      * Registers a service with the Service Locator using the FQCN of the class or the alias, if provided.

--- a/src/DocBlock/Tags/InvalidTag.php
+++ b/src/DocBlock/Tags/InvalidTag.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\DocBlock\Tags;
+
+use phpDocumentor\Reflection\DocBlock\Tag;
+use Throwable;
+use Webmozart\Assert\Assert;
+
+/**
+ * This class represents an exception during the tag creation
+ *
+ * Since the internals of the library are relaying on the correct syntax of a docblock
+ * we cannot simply throw exceptions at all time because the exceptions will break the creation of a
+ * docklock. Just silently ignore the exceptions is not an option because the user as an issue to fix.
+ *
+ * This tag holds that error information until a using application is able to display it. The object wil just behave
+ * like any normal tag. So the normal application flow will not break.
+ */
+final class InvalidTag implements Tag
+{
+    /** @var string */
+    private $name;
+
+    /** @var string */
+    private $body;
+
+    /** @var Throwable */
+    private $throwable;
+
+    private function __construct(string $name, string $body, Throwable $throwable)
+    {
+        $this->name      = $name;
+        $this->body      = $body;
+        $this->throwable = $throwable;
+    }
+
+    public function getException() : Throwable
+    {
+        return $this->throwable;
+    }
+
+    public function getName() : string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function create(string $body, string $name = '', ?Throwable $exception = null)
+    {
+        Assert::notNull($exception);
+
+        return new self($name, $body, $exception);
+    }
+
+    public function render(?Formatter $formatter = null) : string
+    {
+        if ($formatter === null) {
+            $formatter = new Formatter\PassthroughFormatter();
+        }
+
+        return $formatter->format($this);
+    }
+
+    public function __toString() : string
+    {
+        return $this->body;
+    }
+}

--- a/src/DocBlock/Tags/InvalidTag.php
+++ b/src/DocBlock/Tags/InvalidTag.php
@@ -6,7 +6,6 @@ namespace phpDocumentor\Reflection\DocBlock\Tags;
 
 use phpDocumentor\Reflection\DocBlock\Tag;
 use Throwable;
-use Webmozart\Assert\Assert;
 
 /**
  * This class represents an exception during the tag creation
@@ -26,17 +25,16 @@ final class InvalidTag implements Tag
     /** @var string */
     private $body;
 
-    /** @var Throwable */
+    /** @var Throwable|null */
     private $throwable;
 
-    private function __construct(string $name, string $body, Throwable $throwable)
+    private function __construct(string $name, string $body)
     {
-        $this->name      = $name;
-        $this->body      = $body;
-        $this->throwable = $throwable;
+        $this->name = $name;
+        $this->body = $body;
     }
 
-    public function getException() : Throwable
+    public function getException() : ?Throwable
     {
         return $this->throwable;
     }
@@ -47,13 +45,21 @@ final class InvalidTag implements Tag
     }
 
     /**
+     * @return self
+     *
      * @inheritDoc
      */
-    public static function create(string $body, string $name = '', ?Throwable $exception = null)
+    public static function create(string $body, string $name = '')
     {
-        Assert::notNull($exception);
+        return new self($name, $body);
+    }
 
-        return new self($name, $body, $exception);
+    public function withError(Throwable $exception) : self
+    {
+        $tag            = new self($this->name, $this->body);
+        $tag->throwable = $exception;
+
+        return $tag;
     }
 
     public function render(?Formatter $formatter = null) : string

--- a/src/DocBlockFactory.php
+++ b/src/DocBlockFactory.php
@@ -17,7 +17,6 @@ use InvalidArgumentException;
 use LogicException;
 use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
 use phpDocumentor\Reflection\DocBlock\StandardTagFactory;
-use phpDocumentor\Reflection\DocBlock\Tag;
 use phpDocumentor\Reflection\DocBlock\TagFactory;
 use Webmozart\Assert\Assert;
 use function array_shift;
@@ -236,12 +235,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
         $result = [];
         $lines  = $this->splitTagBlockIntoTagLines($tags);
         foreach ($lines as $key => $tagLine) {
-            $tag = $this->tagFactory->create(trim($tagLine), $context);
-            if (!($tag instanceof Tag)) {
-                continue;
-            }
-
-            $result[$key] = $tag;
+            $result[$key] = $this->tagFactory->create(trim($tagLine), $context);
         }
 
         return $result;

--- a/tests/unit/DocBlock/DescriptionFactoryTest.php
+++ b/tests/unit/DocBlock/DescriptionFactoryTest.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Reflection\DocBlock;
 
+use Exception;
 use Mockery as m;
+use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
 use phpDocumentor\Reflection\DocBlock\Tags\Link as LinkTag;
 use phpDocumentor\Reflection\Types\Context;
 use PHPUnit\Framework\TestCase;
@@ -160,6 +162,31 @@ DESCRIPTION;
         $description = $factory->create($descriptionText, new Context(''));
 
         $this->assertSame($expectedDescription, $description->render());
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\InvalidTag
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Formatter\PassthroughFormatter
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::__construct
+     * @covers ::create
+     */
+    public function testDescriptionWithBrokenInlineTags() : void
+    {
+        $contents   = 'This {@see $name} is a broken use case, but used in real life.';
+        $context    = new Context('');
+        $tagFactory = m::mock(TagFactory::class);
+        $tagFactory->shouldReceive('create')
+            ->once()
+            ->with('@see $name', $context)
+            ->andReturn(InvalidTag::create('$name', 'see', new Exception()));
+
+        $factory     = new DescriptionFactory($tagFactory);
+        $description = $factory->create($contents, $context);
+
+        $this->assertSame($contents, $description->render());
     }
 
     /**

--- a/tests/unit/DocBlock/StandardTagFactoryTest.php
+++ b/tests/unit/DocBlock/StandardTagFactoryTest.php
@@ -332,7 +332,7 @@ class StandardTagFactoryTest extends TestCase
         $this->assertSame('return', $tag->getName());
     }
 
-    public function testInvalidTagIsReturnedOnFailure()
+    public function testInvalidTagIsReturnedOnFailure() : void
     {
         $tagFactory = new StandardTagFactory(m::mock(FqsenResolver::class));
 

--- a/tests/unit/DocBlock/StandardTagFactoryTest.php
+++ b/tests/unit/DocBlock/StandardTagFactoryTest.php
@@ -18,6 +18,7 @@ use phpDocumentor\Reflection\DocBlock\Tags\Author;
 use phpDocumentor\Reflection\DocBlock\Tags\Formatter;
 use phpDocumentor\Reflection\DocBlock\Tags\Formatter\PassthroughFormatter;
 use phpDocumentor\Reflection\DocBlock\Tags\Generic;
+use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
 use phpDocumentor\Reflection\DocBlock\Tags\Return_;
 use phpDocumentor\Reflection\DocBlock\Tags\See;
 use phpDocumentor\Reflection\Fqsen;
@@ -329,5 +330,15 @@ class StandardTagFactoryTest extends TestCase
 
         $this->assertInstanceOf(Return_::class, $tag);
         $this->assertSame('return', $tag->getName());
+    }
+
+    public function testInvalidTagIsReturnedOnFailure()
+    {
+        $tagFactory = new StandardTagFactory(m::mock(FqsenResolver::class));
+
+        /** @var InvalidTag $tag */
+        $tag = $tagFactory->create('@see $name some invalid tag');
+
+        $this->assertInstanceOf(InvalidTag::class, $tag);
     }
 }

--- a/tests/unit/DocBlock/Tags/InvalidTagTest.php
+++ b/tests/unit/DocBlock/Tags/InvalidTagTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\DocBlock\Tags;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \phpDocumentor\Reflection\DocBlock\Tags\InvalidTag
+ * @covers ::<private>
+ * @covers ::getName
+ * @covers ::render
+ * @covers ::getException
+ * @covers ::create
+ */
+final class InvalidTagTest extends TestCase
+{
+    public function testCreationWithoutError() : void
+    {
+        $tag = InvalidTag::create('Body', 'name');
+
+        self::assertSame('name', $tag->getName());
+        self::assertSame('@name Body', $tag->render());
+        self::assertNull($tag->getException());
+    }
+
+    /**
+     * @covers ::withError
+     */
+    public function testCreationWithError() : void
+    {
+        $exception = new Exception();
+        $tag       = InvalidTag::create('Body', 'name')->withError($exception);
+
+        self::assertSame('name', $tag->getName());
+        self::assertSame('@name Body', $tag->render());
+        self::assertSame($exception, $tag->getException());
+    }
+}

--- a/tests/unit/DocBlockFactoryTest.php
+++ b/tests/unit/DocBlockFactoryTest.php
@@ -279,37 +279,4 @@ DOCBLOCK
 
         $this->assertInstanceOf(DocBlock::class, $docblock);
     }
-
-    /**
-     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
-     * @uses \phpDocumentor\Reflection\DocBlock\Description
-     *
-     * @covers ::__construct
-     * @covers ::create
-     */
-    public function testTagsAreFilteredForNullValues() : void
-    {
-        $tagString = <<<TAG
-@author Mike van Riel <me@mikevanriel.com> This is with
-  multiline description.
-TAG;
-
-        $tagFactory = m::mock(TagFactory::class);
-        $tagFactory->shouldReceive('create')->with($tagString, m::any())->andReturn(null);
-
-        $fixture = new DocBlockFactory(new DescriptionFactory($tagFactory), $tagFactory);
-
-        $given = <<<DOCBLOCK
-/**
- * This is a summary.
- *
- * @author Mike van Riel <me@mikevanriel.com> This is with
- *   multiline description.
- */
-DOCBLOCK;
-
-        $docblock = $fixture->create($given, new Context(''));
-
-        $this->assertEquals([], $docblock->getTags());
-    }
 }


### PR DESCRIPTION
When invalid tags are processed a null was returned causing all kind
of issues in the normal behavior of this libary. As a solution a generic tag
could be created. But that would just drop the error information in.
Therefore a new tag was introduced, `invalidTag` the tag is just like the
generic tag but does contain the error triggered during the creation of the
tag. Which might help applications like phpdocumentor to display validation issues.