### PR TITLE
Limit characters after tag name

### DIFF
--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -46,6 +46,7 @@ use function count;
 use function get_class;
 use function preg_match;
 use function strpos;
+use function trim;
 
 /**
  * Creates a Tag object given the contents of a tag.
@@ -147,13 +148,7 @@ final class StandardTagFactory implements TagFactory
 
         [$tagName, $tagBody] = $this->extractTagParts($tagLine);
 
-        if ($tagBody !== '' && strpos($tagBody, '[') === 0) {
-            throw new InvalidArgumentException(
-                'The tag "' . $tagLine . '" does not seem to be wellformed, please check it for errors'
-            );
-        }
-
-        return $this->createTag($tagBody, $tagName, $context);
+        return $this->createTag(trim($tagBody), $tagName, $context);
     }
 
     /**
@@ -199,7 +194,7 @@ final class StandardTagFactory implements TagFactory
     private function extractTagParts(string $tagLine) : array
     {
         $matches = [];
-        if (!preg_match('/^@(' . self::REGEX_TAGNAME . ')(?:\s*([^\s].*)|$)/us', $tagLine, $matches)) {
+        if (!preg_match('/^@(' . self::REGEX_TAGNAME . ')((?:[\s\(\{:])\s*([^\s].*)|$)/us', $tagLine, $matches)) {
             throw new InvalidArgumentException(
                 'The tag "' . $tagLine . '" does not seem to be wellformed, please check it for errors'
             );

--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -68,7 +68,7 @@ use function trim;
 final class StandardTagFactory implements TagFactory
 {
     /** PCRE regular expression matching a tag name. */
-    public const REGEX_TAGNAME = '[\w\-\_\\\\]+';
+    public const REGEX_TAGNAME = '[\w\-\_\\\\:]+';
 
     /**
      * @var string[] An array with a tag as a key, and an
@@ -194,7 +194,7 @@ final class StandardTagFactory implements TagFactory
     private function extractTagParts(string $tagLine) : array
     {
         $matches = [];
-        if (!preg_match('/^@(' . self::REGEX_TAGNAME . ')((?:[\s\(\{:])\s*([^\s].*)|$)/us', $tagLine, $matches)) {
+        if (!preg_match('/^@(' . self::REGEX_TAGNAME . ')((?:[\s\(\{])\s*([^\s].*)|$)/us', $tagLine, $matches)) {
             throw new InvalidArgumentException(
                 'The tag "' . $tagLine . '" does not seem to be wellformed, please check it for errors'
             );

--- a/tests/unit/DocBlock/StandardTagFactoryTest.php
+++ b/tests/unit/DocBlock/StandardTagFactoryTest.php
@@ -372,9 +372,14 @@ class StandardTagFactoryTest extends TestCase
                 '@tag',
             ],
             'tag specialization' => [
-                '@tag:some-spec',
-                'tag',
-                '@tag :some-spec',
+                '@tag:some-spec body',
+                'tag:some-spec',
+                '@tag:some-spec body',
+            ],
+            'tag specialization(a)' => [
+                '@tag:some-spec(body)',
+                'tag:some-spec',
+                '@tag:some-spec (body)',
             ],
             'tag with textual description' => [
                 '@tag some text',

--- a/tests/unit/DocBlock/StandardTagFactoryTest.php
+++ b/tests/unit/DocBlock/StandardTagFactoryTest.php
@@ -376,7 +376,7 @@ class StandardTagFactoryTest extends TestCase
                 'tag:some-spec',
                 '@tag:some-spec body',
             ],
-            'tag specialization(a)' => [
+            'tag specialization followed by parenthesis' => [
                 '@tag:some-spec(body)',
                 'tag:some-spec',
                 '@tag:some-spec (body)',
@@ -386,22 +386,22 @@ class StandardTagFactoryTest extends TestCase
                 'tag',
                 '@tag some text',
             ],
-            'tag [a]' => [
+            'tag body starting with sqare brackets is allowed' => [
                 '@tag [is valid]',
                 'tag',
                 '@tag [is valid]',
             ],
-            'tag {a}' => [
+            'tag body starting with curly brackets is allowed' => [
                 '@tag {is valid}',
                 'tag',
                 '@tag {is valid}',
             ],
-            'tag{a}' => [
+            'tag name followed by curly brackets directly is allowed' => [
                 '@tag{is valid}',
                 'tag',
                 '@tag {is valid}',
             ],
-            'tag(a)' => [
+            'parenthesis directly following a tag name is valid' => [
                 '@tag(is valid)',
                 'tag',
                 '@tag (is valid)',


### PR DESCRIPTION
Previously we allowed all characters after a tag name which made
it a bit fuzzy how tags are handled. Psr-5 is more strict about
the characters that are allowed in tags and those that are part of
the body. A tag name can now be followed by `(`, <space> and `{` all
other characters are forbidden. The first character of the body is
not restricted anymore.

fixes #165