### PR TITLE
bump phpstan to master

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -131,7 +131,7 @@ jobs:
             all-build-${{ hashFiles('**/composer.lock') }}
             all-build-
       - name: Code style check
-        uses: phpDocumentor/coding-standard@v1.0.0
+        uses: phpDocumentor/coding-standard@master
         with:
           args: -s
 
@@ -153,7 +153,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: analyse src --level max --configuration phpstan.neon
+          args: analyse src --configuration phpstan.neon
 
   psalm:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ phpcbf:
 
 .PHONY: phpstan
 phpstan:
-	docker run -it --rm -v${PWD}:/opt/project -w /opt/project phpdoc/phpstan-ga:latest analyse src --no-progress --level max --configuration phpstan.neon
+	docker run -it --rm -v${PWD}:/opt/project -w /opt/project phpdoc/phpstan-ga:latest analyse src --no-progress --configuration phpstan.neon
 
 .PHONY: psaml
 psalm:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,6 @@ includes:
     - /composer/vendor/phpstan/phpstan-webmozart-assert/extension.neon
 
 parameters:
+    level: max
     ignoreErrors:
-        # false positive
-        - '#Method phpDocumentor\Reflection\DocBlock\Tags\Method::filterArguments() should return array<array> but returns array<array|string>#'
+        - '#Call to static method Webmozart\\Assert\\Assert::implementsInterface\(\) with class-string#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -14,5 +14,12 @@
 
     <issueHandlers>
         <LessSpecificReturnType errorLevel="info" />
+        
+        <RedundantConditionGivenDocblockType>
+            <errorLevel type="info">
+                <!-- Psalm is very strict and believe that because we documented a type, it is redundant to assert it -->
+                <file name="src/DocBlock/StandardTagFactory.php"/>
+            </errorLevel>
+        </RedundantConditionGivenDocblockType>
     </issueHandlers>
 </psalm>

--- a/src/DocBlock.php
+++ b/src/DocBlock.php
@@ -150,7 +150,6 @@ final class DocBlock
     {
         $result = [];
 
-        /** @var Tag $tag */
         foreach ($this->getTags() as $tag) {
             if ($tag->getName() !== $name) {
                 continue;
@@ -169,7 +168,6 @@ final class DocBlock
      */
     public function hasTag(string $name) : bool
     {
-        /** @var Tag $tag */
         foreach ($this->getTags() as $tag) {
             if ($tag->getName() === $name) {
                 return true;

--- a/src/DocBlock/DescriptionFactory.php
+++ b/src/DocBlock/DescriptionFactory.php
@@ -15,7 +15,6 @@ namespace phpDocumentor\Reflection\DocBlock;
 
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use Webmozart\Assert\Assert;
-use const PREG_SPLIT_DELIM_CAPTURE;
 use function count;
 use function explode;
 use function implode;
@@ -27,6 +26,7 @@ use function strlen;
 use function strpos;
 use function substr;
 use function trim;
+use const PREG_SPLIT_DELIM_CAPTURE;
 
 /**
  * Creates a new Description object given a body of text.
@@ -128,6 +128,7 @@ class DescriptionFactory
             PREG_SPLIT_DELIM_CAPTURE
         );
         Assert::isArray($parts);
+
         return $parts;
     }
 

--- a/src/DocBlock/ExampleFinder.php
+++ b/src/DocBlock/ExampleFinder.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\DocBlock;
 
 use phpDocumentor\Reflection\DocBlock\Tags\Example;
-use const DIRECTORY_SEPARATOR;
 use function array_slice;
 use function file;
 use function getcwd;
@@ -23,6 +22,7 @@ use function is_readable;
 use function rtrim;
 use function sprintf;
 use function trim;
+use const DIRECTORY_SEPARATOR;
 
 /**
  * Class used to find an example file's location based on a given ExampleDescriptor.
@@ -122,6 +122,7 @@ class ExampleFinder
         }
 
         $lines = $normalizedPath && is_readable($normalizedPath) ? file($normalizedPath) : false;
+
         return $lines !== false ? $lines : null;
     }
 

--- a/src/DocBlock/Serializer.php
+++ b/src/DocBlock/Serializer.php
@@ -94,6 +94,7 @@ class Serializer
         }
 
         $comment = $this->addTagBlock($docblock, $wrapLength, $indent, $comment);
+
         return $comment . $indent . ' */';
     }
 
@@ -127,6 +128,7 @@ class Serializer
                 : '');
         if ($wrapLength !== null) {
             $text = wordwrap($text, $wrapLength);
+
             return $text;
         }
 

--- a/src/DocBlock/TagFactory.php
+++ b/src/DocBlock/TagFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\DocBlock;
 
 use InvalidArgumentException;
+use phpDocumentor\Reflection\DocBlock\Tags\Factory\StaticMethod;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 
 interface TagFactory
@@ -69,9 +70,9 @@ interface TagFactory
      * to register the name of a tag with the FQCN of a 'Tag Handler'. The Tag handler should implement
      * the {@see Tag} interface (and thus the create method).
      *
-     * @param string $tagName Name of tag to register a handler for. When registering a namespaced tag,
-     *                        the full name, along with a prefixing slash MUST be provided.
-     * @param string $handler FQCN of handler.
+     * @param string                     $tagName Name of tag to register a handler for. When registering a namespaced
+     *                                   tag, the full name, along with a prefixing slash MUST be provided.
+     * @param class-string<StaticMethod> $handler FQCN of handler.
      *
      * @throws InvalidArgumentException If the tag name is not a string.
      * @throws InvalidArgumentException If the tag name is namespaced (contains backslashes) but

--- a/src/DocBlock/Tags/Author.php
+++ b/src/DocBlock/Tags/Author.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\DocBlock\Tags;
 
 use InvalidArgumentException;
-use const FILTER_VALIDATE_EMAIL;
 use function filter_var;
 use function preg_match;
 use function strlen;
 use function trim;
+use const FILTER_VALIDATE_EMAIL;
 
 /**
  * Reflection class for an {@}author tag in a Docblock.

--- a/src/DocBlock/Tags/Covers.php
+++ b/src/DocBlock/Tags/Covers.php
@@ -41,9 +41,6 @@ final class Covers extends BaseTag implements Factory\StaticMethod
         $this->description = $description;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public static function create(
         string $body,
         ?DescriptionFactory $descriptionFactory = null,

--- a/src/DocBlock/Tags/Deprecated.php
+++ b/src/DocBlock/Tags/Deprecated.php
@@ -75,6 +75,7 @@ final class Deprecated extends BaseTag implements Factory\StaticMethod
         }
 
         Assert::notNull($descriptionFactory);
+
         return new static(
             $matches[1],
             $descriptionFactory->create($matches[2] ?? '', $context)

--- a/src/DocBlock/Tags/Example.php
+++ b/src/DocBlock/Tags/Example.php
@@ -82,9 +82,6 @@ final class Example implements Tag, Factory\StaticMethod
         return $this->content;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public static function create(string $body) : ?Tag
     {
         // File component: File path in quotes or File URI / Source information

--- a/src/DocBlock/Tags/Link.php
+++ b/src/DocBlock/Tags/Link.php
@@ -39,9 +39,6 @@ final class Link extends BaseTag implements Factory\StaticMethod
         $this->description = $description;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public static function create(
         string $body,
         ?DescriptionFactory $descriptionFactory = null,

--- a/src/DocBlock/Tags/Param.php
+++ b/src/DocBlock/Tags/Param.php
@@ -19,7 +19,6 @@ use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use Webmozart\Assert\Assert;
-use const PREG_SPLIT_DELIM_CAPTURE;
 use function array_shift;
 use function array_unshift;
 use function implode;
@@ -27,6 +26,7 @@ use function preg_split;
 use function strlen;
 use function strpos;
 use function substr;
+use const PREG_SPLIT_DELIM_CAPTURE;
 
 /**
  * Reflection class for the {@}param tag in a Docblock.
@@ -52,9 +52,6 @@ final class Param extends TagWithType implements Factory\StaticMethod
         $this->description  = $description;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public static function create(
         string $body,
         ?TypeResolver $typeResolver = null,
@@ -69,6 +66,7 @@ final class Param extends TagWithType implements Factory\StaticMethod
 
         $type         = null;
         $parts        = preg_split('/(\s+)/Su', $body, 2, PREG_SPLIT_DELIM_CAPTURE);
+        Assert::isArray($parts);
         $variableName = '';
         $isVariadic   = false;
 

--- a/src/DocBlock/Tags/Property.php
+++ b/src/DocBlock/Tags/Property.php
@@ -19,7 +19,6 @@ use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use Webmozart\Assert\Assert;
-use const PREG_SPLIT_DELIM_CAPTURE;
 use function array_shift;
 use function array_unshift;
 use function implode;
@@ -27,6 +26,7 @@ use function preg_split;
 use function strlen;
 use function strpos;
 use function substr;
+use const PREG_SPLIT_DELIM_CAPTURE;
 
 /**
  * Reflection class for a {@}property tag in a Docblock.
@@ -46,9 +46,6 @@ final class Property extends TagWithType implements Factory\StaticMethod
         $this->description  = $description;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public static function create(
         string $body,
         ?TypeResolver $typeResolver = null,
@@ -62,7 +59,8 @@ final class Property extends TagWithType implements Factory\StaticMethod
         [$firstPart, $body] = self::extractTypeFromBody($body);
         $type               = null;
         $parts              = preg_split('/(\s+)/Su', $body, 2, PREG_SPLIT_DELIM_CAPTURE);
-        $variableName       = '';
+        Assert::isArray($parts);
+        $variableName = '';
 
         // if the first item that is encountered is not a variable; it is a type
         if ($firstPart && (strlen($firstPart) > 0) && ($firstPart[0] !== '$')) {

--- a/src/DocBlock/Tags/PropertyRead.php
+++ b/src/DocBlock/Tags/PropertyRead.php
@@ -19,7 +19,6 @@ use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use Webmozart\Assert\Assert;
-use const PREG_SPLIT_DELIM_CAPTURE;
 use function array_shift;
 use function array_unshift;
 use function implode;
@@ -27,6 +26,7 @@ use function preg_split;
 use function strlen;
 use function strpos;
 use function substr;
+use const PREG_SPLIT_DELIM_CAPTURE;
 
 /**
  * Reflection class for a {@}property-read tag in a Docblock.
@@ -46,9 +46,6 @@ final class PropertyRead extends TagWithType implements Factory\StaticMethod
         $this->description  = $description;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public static function create(
         string $body,
         ?TypeResolver $typeResolver = null,
@@ -62,7 +59,8 @@ final class PropertyRead extends TagWithType implements Factory\StaticMethod
         [$firstPart, $body] = self::extractTypeFromBody($body);
         $type               = null;
         $parts              = preg_split('/(\s+)/Su', $body, 2, PREG_SPLIT_DELIM_CAPTURE);
-        $variableName       = '';
+        Assert::isArray($parts);
+        $variableName = '';
 
         // if the first item that is encountered is not a variable; it is a type
         if ($firstPart && (strlen($firstPart) > 0) && ($firstPart[0] !== '$')) {

--- a/src/DocBlock/Tags/PropertyWrite.php
+++ b/src/DocBlock/Tags/PropertyWrite.php
@@ -19,7 +19,6 @@ use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use Webmozart\Assert\Assert;
-use const PREG_SPLIT_DELIM_CAPTURE;
 use function array_shift;
 use function array_unshift;
 use function implode;
@@ -27,6 +26,7 @@ use function preg_split;
 use function strlen;
 use function strpos;
 use function substr;
+use const PREG_SPLIT_DELIM_CAPTURE;
 
 /**
  * Reflection class for a {@}property-write tag in a Docblock.
@@ -46,9 +46,6 @@ final class PropertyWrite extends TagWithType implements Factory\StaticMethod
         $this->description  = $description;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public static function create(
         string $body,
         ?TypeResolver $typeResolver = null,
@@ -62,7 +59,8 @@ final class PropertyWrite extends TagWithType implements Factory\StaticMethod
         [$firstPart, $body] = self::extractTypeFromBody($body);
         $type               = null;
         $parts              = preg_split('/(\s+)/Su', $body, 2, PREG_SPLIT_DELIM_CAPTURE);
-        $variableName       = '';
+        Assert::isArray($parts);
+        $variableName = '';
 
         // if the first item that is encountered is not a variable; it is a type
         if ($firstPart && (strlen($firstPart) > 0) && ($firstPart[0] !== '$')) {

--- a/src/DocBlock/Tags/Return_.php
+++ b/src/DocBlock/Tags/Return_.php
@@ -32,9 +32,6 @@ final class Return_ extends TagWithType implements Factory\StaticMethod
         $this->description = $description;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public static function create(
         string $body,
         ?TypeResolver $typeResolver = null,

--- a/src/DocBlock/Tags/See.php
+++ b/src/DocBlock/Tags/See.php
@@ -44,9 +44,6 @@ final class See extends BaseTag implements Factory\StaticMethod
         $this->description = $description;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public static function create(
         string $body,
         ?FqsenResolver $typeResolver = null,

--- a/src/DocBlock/Tags/Since.php
+++ b/src/DocBlock/Tags/Since.php
@@ -69,6 +69,7 @@ final class Since extends BaseTag implements Factory\StaticMethod
         }
 
         Assert::notNull($descriptionFactory);
+
         return new static(
             $matches[1],
             $descriptionFactory->create($matches[2] ?? '', $context)

--- a/src/DocBlock/Tags/Source.php
+++ b/src/DocBlock/Tags/Source.php
@@ -47,9 +47,6 @@ final class Source extends BaseTag implements Factory\StaticMethod
         $this->description  = $description;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public static function create(
         string $body,
         ?DescriptionFactory $descriptionFactory = null,

--- a/src/DocBlock/Tags/Throws.php
+++ b/src/DocBlock/Tags/Throws.php
@@ -32,9 +32,6 @@ final class Throws extends TagWithType implements Factory\StaticMethod
         $this->description = $description;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public static function create(
         string $body,
         ?TypeResolver $typeResolver = null,

--- a/src/DocBlock/Tags/Uses.php
+++ b/src/DocBlock/Tags/Uses.php
@@ -41,9 +41,6 @@ final class Uses extends BaseTag implements Factory\StaticMethod
         $this->description = $description;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public static function create(
         string $body,
         ?FqsenResolver $resolver = null,

--- a/src/DocBlock/Tags/Var_.php
+++ b/src/DocBlock/Tags/Var_.php
@@ -19,7 +19,6 @@ use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use Webmozart\Assert\Assert;
-use const PREG_SPLIT_DELIM_CAPTURE;
 use function array_shift;
 use function array_unshift;
 use function implode;
@@ -27,6 +26,7 @@ use function preg_split;
 use function strlen;
 use function strpos;
 use function substr;
+use const PREG_SPLIT_DELIM_CAPTURE;
 
 /**
  * Reflection class for a {@}var tag in a Docblock.
@@ -46,9 +46,6 @@ final class Var_ extends TagWithType implements Factory\StaticMethod
         $this->description  = $description;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public static function create(
         string $body,
         ?TypeResolver $typeResolver = null,
@@ -61,7 +58,8 @@ final class Var_ extends TagWithType implements Factory\StaticMethod
 
         [$firstPart, $body] = self::extractTypeFromBody($body);
 
-        $parts        = preg_split('/(\s+)/Su', $body, 2, PREG_SPLIT_DELIM_CAPTURE);
+        $parts = preg_split('/(\s+)/Su', $body, 2, PREG_SPLIT_DELIM_CAPTURE);
+        Assert::isArray($parts);
         $type         = null;
         $variableName = '';
 
@@ -102,7 +100,7 @@ final class Var_ extends TagWithType implements Factory\StaticMethod
     public function __toString() : string
     {
         return ($this->type ? $this->type . ' ' : '')
-            . (empty($this->variableName) ? '' : ('$' . $this->variableName))
+            . (empty($this->variableName) ? '' : '$' . $this->variableName)
             . ($this->description ? ' ' . $this->description : '');
     }
 }

--- a/src/DocBlockFactoryInterface.php
+++ b/src/DocBlockFactoryInterface.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Reflection;
 
+use phpDocumentor\Reflection\DocBlock\Tags\Factory\StaticMethod;
+
 // phpcs:ignore SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix
 interface DocBlockFactoryInterface
 {
     /**
      * Factory method for easy instantiation.
      *
-     * @param string[] $additionalTags
+     * @param array<class-string<StaticMethod>> $additionalTags
      */
     public static function createInstance(array $additionalTags = []) : DocBlockFactory;
 

--- a/tests/unit/DocBlock/StandardTagFactoryTest.php
+++ b/tests/unit/DocBlock/StandardTagFactoryTest.php
@@ -68,7 +68,6 @@ class StandardTagFactoryTest extends TestCase
         $tagFactory = new StandardTagFactory(m::mock(FqsenResolver::class));
         $tagFactory->addService($descriptionFactory, DescriptionFactory::class);
 
-        /** @var Generic $tag */
         $tag = $tagFactory->create('@' . $expectedTagName . ' This is a description', $context);
 
         $this->assertInstanceOf(Generic::class, $tag);
@@ -89,7 +88,6 @@ class StandardTagFactoryTest extends TestCase
         $context    = new Context('');
         $tagFactory = new StandardTagFactory(m::mock(FqsenResolver::class));
 
-        /** @var Author $tag */
         $tag = $tagFactory->create('@author Mike van Riel <me@mikevanriel.com>', $context);
 
         $this->assertInstanceOf(Author::class, $tag);
@@ -120,7 +118,6 @@ class StandardTagFactoryTest extends TestCase
         $tagFactory = new StandardTagFactory($resolver);
         $tagFactory->addService($descriptionFactory, DescriptionFactory::class);
 
-        /** @var See $tag */
         $tag = $tagFactory->create('@see Tag');
 
         $this->assertInstanceOf(See::class, $tag);
@@ -140,7 +137,6 @@ class StandardTagFactoryTest extends TestCase
         $context    = new Context('');
         $tagFactory = new StandardTagFactory(m::mock(FqsenResolver::class), ['user' => Author::class]);
 
-        /** @var Author $tag */
         $tag = $tagFactory->create('@user Mike van Riel <me@mikevanriel.com>', $context);
 
         $this->assertInstanceOf(Author::class, $tag);
@@ -326,7 +322,6 @@ class StandardTagFactoryTest extends TestCase
         $tagFactory->addService($descriptionFactory, DescriptionFactory::class);
         $tagFactory->addService($typeResolver, TypeResolver::class);
 
-        /** @var Return_ $tag */
         $tag = $tagFactory->create('@return mixed', $context);
 
         $this->assertInstanceOf(Return_::class, $tag);
@@ -337,7 +332,6 @@ class StandardTagFactoryTest extends TestCase
     {
         $tagFactory = new StandardTagFactory(m::mock(FqsenResolver::class));
 
-        /** @var InvalidTag $tag */
         $tag = $tagFactory->create('@see $name some invalid tag');
 
         $this->assertInstanceOf(InvalidTag::class, $tag);


### PR DESCRIPTION
Also fixed ignored errors (FYI, PHPStan ignore rule are regexes. The previous error had "|string>" at the end. The effect was that every error ending by "|string>" was being ignored. Newer versions of PHPStan now warn about that)