### PR TITLE
PHP 7.4 fix - Ensure the existence of the 'args' key.

### DIFF
--- a/src/DocBlock/Tags/InvalidTag.php
+++ b/src/DocBlock/Tags/InvalidTag.php
@@ -104,6 +104,7 @@ final class InvalidTag implements Tag
         do {
             $trace = array_map(
                 static function (array $call) use ($flatten) : array {
+                    $call += ['args' => []];
                     array_walk_recursive($call['args'], $flatten);
 
                     return $call;

--- a/src/DocBlock/Tags/InvalidTag.php
+++ b/src/DocBlock/Tags/InvalidTag.php
@@ -104,9 +104,9 @@ final class InvalidTag implements Tag
         do {
             $trace = array_map(
                 static function (array $call) use ($flatten) : array {
-                    $args = $call['args'] ?? [];
+                    $call['args'] = $call['args'] ?? [];
 
-                    array_walk_recursive($args, $flatten);
+                    array_walk_recursive($call['args'], $flatten);
 
                     return $call;
                 },

--- a/src/DocBlock/Tags/InvalidTag.php
+++ b/src/DocBlock/Tags/InvalidTag.php
@@ -104,7 +104,9 @@ final class InvalidTag implements Tag
         do {
             $trace = array_map(
                 static function (array $call) use ($flatten) : array {
-                    array_walk_recursive($call['args'] ?? [], $flatten);
+                    $args = $call['args'] ?? [];
+
+                    array_walk_recursive($args, $flatten);
 
                     return $call;
                 },

--- a/src/DocBlock/Tags/InvalidTag.php
+++ b/src/DocBlock/Tags/InvalidTag.php
@@ -104,8 +104,7 @@ final class InvalidTag implements Tag
         do {
             $trace = array_map(
                 static function (array $call) use ($flatten) : array {
-                    $call += ['args' => []];
-                    array_walk_recursive($call['args'], $flatten);
+                    array_walk_recursive($call['args'] ?? [], $flatten);
 
                     return $call;
                 },


### PR DESCRIPTION
This simple fix for ensuring the existence of the 'args' key.

With PHP 7.4 on Linux and Windows, it fails without it.
Weird thing is that it doesn't break on MacOSX.

See it live here: https://github.com/ecphp/cas-bundle/actions/runs/36937260


