### PR TITLE
Fix method tag for longer method names

### DIFF
--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -117,7 +117,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
                             (?:[\w\|_\\\\]+)
                             # array notation
                             (?:\[\])*
-                        )*
+                        )*+
                     )
                     \s+
                 )?

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -343,6 +343,37 @@ class MethodTest extends TestCase
     }
 
     /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Method::<public>
+     * @uses \phpDocumentor\Reflection\TypeResolver
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::create
+     */
+    public function testReturnTypeNoneWithLongMethodName() : void
+    {
+        $descriptionFactory = m::mock(DescriptionFactory::class);
+        $resolver           = new TypeResolver();
+        $context            = new Context('');
+
+        $description = new Description('');
+
+        $descriptionFactory->shouldReceive('create')->with('', $context)->andReturn($description);
+
+        $fixture = Method::create(
+            'myVeryLongMethodName($node)',
+            $resolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertFalse($fixture->isStatic());
+        $this->assertSame('void myVeryLongMethodName(mixed $node)', (string) $fixture);
+        $this->assertSame('myVeryLongMethodName', $fixture->getMethodName());
+        $this->assertInstanceOf(Void_::class, $fixture->getReturnType());
+    }
+
+    /**
      * @return string[][]
      */
     public function collectionReturnTypesProvider() : array


### PR DESCRIPTION
I have added a testcase that currently fails, although it shouldn't. There seems to be a problem with `@method` annotations, when the method name gets a little bit longer. According to Regex101 it seems to result in a [catastrophic backtrack](https://regex101.com/r/6WZ0XK/1/), which gives me the feeling that this regex is too complicated. I tried to simplify it, but couldn't find any solution that generally worked.

The problem is [this regex](https://github.com/phpDocumentor/ReflectionDocBlock/blob/1e5bd86/src/DocBlock/Tags/Method.php#L104-L133), if anybody has an idea how to improve it, I am happy to implement it.