### PR TITLE
Danrot long method annotation

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,8 @@
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 name: Qa workflow
 jobs:
   setup:

--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -111,13 +111,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
                 # Return type
                 (?:
                     (
-                        (?:[\w\|_\\\\]*\$this[\w\|_\\\\]*)
-                        |
-                        (?:
-                            (?:[\w\|_\\\\]+)
-                            # array notation
-                            (?:\[\])*
-                        )*
+                        [^\s]+
                     )
                     \s+
                 )?

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -343,6 +343,37 @@ class MethodTest extends TestCase
     }
 
     /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Method::<public>
+     * @uses \phpDocumentor\Reflection\TypeResolver
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::create
+     */
+    public function testReturnTypeNoneWithLongMethodName() : void
+    {
+        $descriptionFactory = m::mock(DescriptionFactory::class);
+        $resolver           = new TypeResolver();
+        $context            = new Context('');
+
+        $description = new Description('');
+
+        $descriptionFactory->shouldReceive('create')->with('', $context)->andReturn($description);
+
+        $fixture = Method::create(
+            'myVeryLongMethodName($node)',
+            $resolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertFalse($fixture->isStatic());
+        $this->assertSame('void myVeryLongMethodName()', (string) $fixture);
+        $this->assertSame('myVeryLongMethodName', $fixture->getMethodName());
+        $this->assertInstanceOf(This::class, $fixture->getReturnType());
+    }
+
+    /**
      * @return string[][]
      */
     public function collectionReturnTypesProvider() : array

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -368,9 +368,9 @@ class MethodTest extends TestCase
         );
 
         $this->assertFalse($fixture->isStatic());
-        $this->assertSame('void myVeryLongMethodName()', (string) $fixture);
+        $this->assertSame('void myVeryLongMethodName(mixed $node)', (string) $fixture);
         $this->assertSame('myVeryLongMethodName', $fixture->getMethodName());
-        $this->assertInstanceOf(This::class, $fixture->getReturnType());
+        $this->assertInstanceOf(Void_::class, $fixture->getReturnType());
     }
 
     /**


### PR DESCRIPTION
This is a POC to see what happens when we handover the return type of a method tag to our type resolver. 
First results look promising. 

refs #203   