### PR TITLE
don't rely on 'args' in trace, not available in 7.4

### DIFF
--- a/src/DocBlock/Tags/InvalidTag.php
+++ b/src/DocBlock/Tags/InvalidTag.php
@@ -102,16 +102,16 @@ final class InvalidTag implements Tag
             };
 
         do {
-            $trace = array_map(
-                static function (array $call) use ($flatten) : array {
-                    $call['args'] = $call['args'] ?? [];
-
-                    array_walk_recursive($call['args'], $flatten);
-
-                    return $call;
-                },
-                $exception->getTrace()
-            );
+            $trace = $exception->getTrace();
+            if (isset($trace[0]['args'])) {
+                $trace = array_map(
+                    static function (array $call) use ($flatten) : array {
+                        array_walk_recursive($call['args'], $flatten);
+                        return $call;
+                    },
+                    $trace
+                );
+            }
             $traceProperty->setValue($exception, $trace);
             $exception = $exception->getPrevious();
         } while ($exception !== null);

--- a/tests/unit/DocBlock/Tags/InvalidTagTest.php
+++ b/tests/unit/DocBlock/Tags/InvalidTagTest.php
@@ -56,8 +56,11 @@ final class InvalidTagTest extends TestCase
             self::assertSame('name', $tag->getName());
             self::assertSame('@name Body', $tag->render());
             self::assertSame($parentException, $tag->getException());
-            self::assertStringStartsWith('(Closure at', $tag->getException()->getPrevious()->getTrace()[0]['args'][0]);
-            self::assertStringContainsString(__FILE__, $tag->getException()->getPrevious()->getTrace()[0]['args'][0]);
+            $trace = $tag->getException()->getPrevious()->getTrace();
+            if (isset($trace[0]['args'])) { // Not set by default on 7.4
+                self::assertStringStartsWith('(Closure at', $trace[0]['args'][0]);
+                self::assertStringContainsString(__FILE__, $trace[0]['args'][0]);
+            }
             self::assertEquals($parentException, unserialize(serialize($parentException)));
         }
     }
@@ -81,10 +84,13 @@ final class InvalidTagTest extends TestCase
             self::assertSame('name', $tag->getName());
             self::assertSame('@name Body', $tag->render());
             self::assertSame($parentException, $tag->getException());
-            self::assertStringStartsWith(
-                'resource(stream)',
-                $tag->getException()->getPrevious()->getTrace()[0]['args'][0]
-            );
+            $trace = $tag->getException()->getPrevious()->getTrace();
+            if (isset($trace[0]['args'])) { // Not set by default on 7.4
+                self::assertStringStartsWith(
+                    'resource(stream)',
+                    $trace[0]['args'][0]
+                );
+            }
             self::assertEquals($parentException, unserialize(serialize($parentException)));
         }
     }


### PR DESCRIPTION
Rather than adding an empty 'args' array, seems simpler to skip the full array_map / array_walk

Also fix the test suite.

```
PHPUnit 8.5.2 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.3RC1
Configuration: /dev/shm/BUILD/ReflectionDocBlock-a48807183a4b819072f26e347bbd0b5199a9d15f/phpunit.xml
Error:         No code coverage driver is available

.........................WWW...................................  63 / 297 ( 21%)
............................................................... 126 / 297 ( 42%)
.........................................................S..... 189 / 297 ( 63%)
.......................................S....................... 252 / 297 ( 84%)
.............................................                   297 / 297 (100%)

Time: 113 ms, Memory: 8,00 MB

There were 3 warnings:

1) phpDocumentor\Reflection\DocBlock\StandardTagFactoryTest::testAddParameterToServiceLocator
assertAttributeSame() is deprecated and will be removed in PHPUnit 9.
readAttribute() is deprecated and will be removed in PHPUnit 9.
getObjectAttribute() is deprecated and will be removed in PHPUnit 9.

2) phpDocumentor\Reflection\DocBlock\StandardTagFactoryTest::testAddServiceToServiceLocator
assertAttributeSame() is deprecated and will be removed in PHPUnit 9.
readAttribute() is deprecated and will be removed in PHPUnit 9.
getObjectAttribute() is deprecated and will be removed in PHPUnit 9.

3) phpDocumentor\Reflection\DocBlock\StandardTagFactoryTest::testInjectConcreteServiceForInterfaceToServiceLocator
assertAttributeSame() is deprecated and will be removed in PHPUnit 9.
readAttribute() is deprecated and will be removed in PHPUnit 9.
getObjectAttribute() is deprecated and will be removed in PHPUnit 9.

--

There were 2 skipped tests:

1) phpDocumentor\Reflection\DocBlock\Tags\ReturnTest::testFactoryMethodWithGenericWithSpaceAndAddedEmojisToVerifyMultiByteBehaviour
A bug in the TypeResolver breaks this test

/dev/shm/BUILD/ReflectionDocBlock-a48807183a4b819072f26e347bbd0b5199a9d15f/tests/unit/DocBlock/Tags/ReturnTest.php:202

2) phpDocumentor\Reflection\DocBlock\Tags\ThrowsTest::testFactoryMethodWithGenericWithSpaceAndAddedEmojisToVerifyMultiByteBehaviour
A bug in the TypeResolver breaks this test

/dev/shm/BUILD/ReflectionDocBlock-a48807183a4b819072f26e347bbd0b5199a9d15f/tests/unit/DocBlock/Tags/ThrowsTest.php:202

WARNINGS!
Tests: 297, Assertions: 487, Warnings: 3, Skipped: 2.

```