### PR TITLE
Fix phpdoc for DocBlockFactoryInterface::create

### DIFF
--- a/src/DocBlockFactoryInterface.php
+++ b/src/DocBlockFactoryInterface.php
@@ -13,7 +13,7 @@ interface DocBlockFactoryInterface
     public static function createInstance(array $additionalTags = []);
 
     /**
-     * @param string $docblock
+     * @param object|string $docblock
      * @param Types\Context $context
      * @param Location $location
      *


### PR DESCRIPTION
`DocBlockFactoryInterface::create` actually accepts an object for the `$docblock` parameter too.