### PR TITLE
Dealing with erroneous/incomplete docblock

### DIFF
--- a/src/DocBlock/Tags/InvalidTag.php
+++ b/src/DocBlock/Tags/InvalidTag.php
@@ -23,16 +23,13 @@ use function sprintf;
  *
  * Since the internals of the library are relaying on the correct syntax of a docblock
  * we cannot simply throw exceptions at all time because the exceptions will break the creation of a
- * docklock. Just silently ignore the exceptions is not an option because the user as an issue to fix.
+ * docblock. Just silently ignore the exceptions is not an option because the user as an issue to fix.
  *
  * This tag holds that error information until a using application is able to display it. The object wil just behave
  * like any normal tag. So the normal application flow will not break.
  */
-final class InvalidTag implements Tag
+final class InvalidTag extends BaseTag implements Tag
 {
-    /** @var string */
-    private $name;
-
     /** @var string */
     private $body;
 
@@ -48,11 +45,6 @@ final class InvalidTag implements Tag
     public function getException() : ?Throwable
     {
         return $this->throwable;
-    }
-
-    public function getName() : string
-    {
-        return $this->name;
     }
 
     public static function create(string $body, string $name = '') : self

--- a/tests/integration/DocblocksWithIncompleteAnnotationsTest.php
+++ b/tests/integration/DocblocksWithIncompleteAnnotationsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection;
+
+use Mockery as m;
+use phpDocumentor\Reflection\DocBlock\Description;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversNothing
+ */
+final class DocblocksWithIncompleteAnnotationsTest extends TestCase
+{
+    /**
+     * Call Mockery::close after each test.
+     */
+    public function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testDocblockWithIncompleteAnnotations(): void
+    {
+        $docComment = <<<DOCCOMMENT
+            /**
+     * Hello just a test
+     *
+     * @var
+     */
+DOCCOMMENT;
+
+        $factory = DocBlockFactory::createInstance();
+        $docblock = $factory->create($docComment);
+
+        $this::assertCount(1, $docblock->getTags());
+
+        foreach ($docblock->getTags() as $index => $tag) {
+            $this::assertNull($tag->getDescription());
+        }
+    }
+}


### PR DESCRIPTION
This PR:

- [x] Has origin here: https://github.com/api-platform/core/issues/3565
- [x] Provide a new test
- [x] Provide a potential fix
- [x] Does not pass the CI because of an issue in the CI. Tests are passing locally.

Related to #220 