### PR TITLE
Use ReflectionParameter::getType() instead of getClass()

### DIFF
--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -36,6 +36,7 @@ use phpDocumentor\Reflection\DocBlock\Tags\Version;
 use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use ReflectionMethod;
+use ReflectionNamedType;
 use ReflectionParameter;
 use Webmozart\Assert\Assert;
 use function array_merge;
@@ -256,8 +257,14 @@ final class StandardTagFactory implements TagFactory
         foreach ($parameters as $parameter) {
             $type     = $parameter->getType();
             $typeHint = null;
-            if ($type instanceof \ReflectionNamedType) {
+            if ($type instanceof ReflectionNamedType) {
                 $typeHint = $type->getName();
+                if ($typeHint === 'self') {
+                    $declaringClass = $parameter->getDeclaringClass();
+                    if ($declaringClass !== null) {
+                        $typeHint = $declaringClass->getName();
+                    }
+                }
             }
 
             if (isset($locator[$typeHint])) {

--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -254,10 +254,10 @@ final class StandardTagFactory implements TagFactory
     {
         $arguments = [];
         foreach ($parameters as $parameter) {
-            $class    = $parameter->getClass();
+            $type     = $parameter->getType();
             $typeHint = null;
-            if ($class !== null) {
-                $typeHint = $class->getName();
+            if ($type instanceof \ReflectionNamedType) {
+                $typeHint = $type->getName();
             }
 
             if (isset($locator[$typeHint])) {


### PR DESCRIPTION
`ReflectionParameter::getClass()` is deprecated as of PHP 8 and will trigger a warning.