### PR TITLE
do not resolve types if it's not possible

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -46,7 +46,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Quick check code coverage level
-        run: php tests/coverage-checker.php 89
+        run: php tests/coverage-checker.php 91
 
   phpunit:
     name: Unit tests for PHP version ${{ matrix.php-versions }} on ${{ matrix.operating-system }}

--- a/src/DocBlock/Tags/Author.php
+++ b/src/DocBlock/Tags/Author.php
@@ -71,7 +71,15 @@ final class Author extends BaseTag implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return $this->authorName . ($this->authorEmail !== '' ? ' <' . $this->authorEmail . '>' : '');
+        if ($this->authorEmail) {
+            $authorEmail = '<' . $this->authorEmail . '>';
+        } else {
+            $authorEmail = '';
+        }
+
+        $authorName = (string) $this->authorName;
+
+        return $authorName . ($authorEmail !== '' ? ($authorName !== '' ? ' ' : '') . $authorEmail : '');
     }
 
     /**

--- a/src/DocBlock/Tags/Covers.php
+++ b/src/DocBlock/Tags/Covers.php
@@ -49,7 +49,7 @@ final class Covers extends BaseTag implements Factory\StaticMethod
         ?FqsenResolver $resolver = null,
         ?TypeContext $context = null
     ) : self {
-        Assert::notEmpty($body);
+        Assert::stringNotEmpty($body);
         Assert::notNull($descriptionFactory);
         Assert::notNull($resolver);
 

--- a/src/DocBlock/Tags/Covers.php
+++ b/src/DocBlock/Tags/Covers.php
@@ -72,6 +72,14 @@ final class Covers extends BaseTag implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return $this->refers . ($this->description ? ' ' . $this->description->render() : '');
+        if ($this->description) {
+            $description = $this->description->render();
+        } else {
+            $description = '';
+        }
+
+        $refers = (string) $this->refers;
+
+        return $refers . ($description !== '' ? ($refers !== '' ? ' ' : '') . $description : '');
     }
 }

--- a/src/DocBlock/Tags/Deprecated.php
+++ b/src/DocBlock/Tags/Deprecated.php
@@ -95,6 +95,14 @@ final class Deprecated extends BaseTag implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return ($this->version ?? '') . ($this->description ? ' ' . $this->description->render() : '');
+        if ($this->description) {
+            $description = $this->description->render();
+        } else {
+            $description = '';
+        }
+
+        $version = (string) $this->version;
+
+        return $version . ($description !== '' ? ($version !== '' ? ' ' : '') . $description : '');
     }
 }

--- a/src/DocBlock/Tags/Example.php
+++ b/src/DocBlock/Tags/Example.php
@@ -154,9 +154,15 @@ final class Example implements Tag, Factory\StaticMethod
         $content = (string) $this->content;
 
         return $filePath
-            . ($startingLine !== '' ? ($filePath !== '' ? ' ' : '') . $startingLine : '')
-            . ($lineCount !== '' ? ($filePath !== '' || $startingLine !== '' ? ' ' : '') . $lineCount : '')
-            . ($content !== '' ? ($filePath !== '' || $startingLine !== '' || $lineCount !== '' ? ' ' : '') . $content : '');
+            . ($startingLine !== ''
+                ? ($filePath !== '' ? ' ' : '') . $startingLine
+                : '')
+            . ($lineCount !== ''
+                ? ($filePath !== '' || $startingLine !== '' ? ' ' : '') . $lineCount
+                : '')
+            . ($content !== ''
+                ? ($filePath !== '' || $startingLine !== '' || $lineCount !== '' ? ' ' : '') . $content
+                : '');
     }
 
     /**

--- a/src/DocBlock/Tags/Example.php
+++ b/src/DocBlock/Tags/Example.php
@@ -142,7 +142,10 @@ final class Example implements Tag, Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return $this->filePath . ($this->content ? ' ' . $this->content : '');
+        $filePath = (string) $this->filePath;
+        $content = (string) $this->content;
+
+        return $filePath . ($content !== '' ? ($filePath !== '' ? ' ' : '') . $content : '');
     }
 
     /**

--- a/src/DocBlock/Tags/Example.php
+++ b/src/DocBlock/Tags/Example.php
@@ -45,9 +45,14 @@ final class Example implements Tag, Factory\StaticMethod
     /** @var string|null */
     private $content;
 
-    public function __construct(string $filePath, bool $isURI, int $startingLine, int $lineCount, ?string $content)
-    {
-        Assert::notEmpty($filePath);
+    public function __construct(
+        string $filePath,
+        bool $isURI,
+        int $startingLine,
+        int $lineCount,
+        ?string $content
+    ) {
+        Assert::stringNotEmpty($filePath);
         Assert::greaterThanEq($startingLine, 1);
         Assert::greaterThanEq($lineCount, 0);
 
@@ -64,7 +69,7 @@ final class Example implements Tag, Factory\StaticMethod
     public function getContent() : string
     {
         if ($this->content === null || $this->content === '') {
-            $filePath = '"' . $this->filePath . '"';
+            $filePath = $this->filePath;
             if ($this->isURI) {
                 $filePath = $this->isUriRelative($this->filePath)
                     ? str_replace('%2F', '/', rawurlencode($this->filePath))
@@ -85,7 +90,7 @@ final class Example implements Tag, Factory\StaticMethod
     public static function create(string $body) : ?Tag
     {
         // File component: File path in quotes or File URI / Source information
-        if (!preg_match('/^(?:\"([^\"]+)\"|(\S+))(?:\s+(.*))?$/sux', $body, $matches)) {
+        if (!preg_match('/^\s*(?:(\"[^\"]+\")|(\S+))(?:\s+(.*))?$/sux', $body, $matches)) {
             return null;
         }
 
@@ -134,7 +139,7 @@ final class Example implements Tag, Factory\StaticMethod
      */
     public function getFilePath() : string
     {
-        return $this->filePath;
+        return trim($this->filePath, '"');
     }
 
     /**
@@ -143,9 +148,15 @@ final class Example implements Tag, Factory\StaticMethod
     public function __toString() : string
     {
         $filePath = (string) $this->filePath;
+        $isDefaultLine = $this->startingLine === 1 && $this->lineCount === 0;
+        $startingLine = !$isDefaultLine ? (string) $this->startingLine : '';
+        $lineCount = !$isDefaultLine ? (string) $this->lineCount : '';
         $content = (string) $this->content;
 
-        return $filePath . ($content !== '' ? ($filePath !== '' ? ' ' : '') . $content : '');
+        return $filePath
+            . ($startingLine !== '' ? ($filePath !== '' ? ' ' : '') . $startingLine : '')
+            . ($lineCount !== '' ? ($filePath !== '' || $startingLine !== '' ? ' ' : '') . $lineCount : '')
+            . ($content !== '' ? ($filePath !== '' || $startingLine !== '' || $lineCount !== '' ? ' ' : '') . $content : '');
     }
 
     /**

--- a/src/DocBlock/Tags/Generic.php
+++ b/src/DocBlock/Tags/Generic.php
@@ -64,7 +64,13 @@ final class Generic extends BaseTag implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return $this->description ? $this->description->render() : '';
+        if ($this->description) {
+            $description = $this->description->render();
+        } else {
+            $description = '';
+        }
+
+        return $description;
     }
 
     /**

--- a/src/DocBlock/Tags/Link.php
+++ b/src/DocBlock/Tags/Link.php
@@ -65,6 +65,14 @@ final class Link extends BaseTag implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return $this->link . ($this->description ? ' ' . $this->description->render() : '');
+        if ($this->description) {
+            $description = $this->description->render();
+        } else {
+            $description = '';
+        }
+
+        $link = (string) $this->link;
+
+        return $link . ($description !== '' ? ($link !== '' ? ' ' : '') . $description : '');
     }
 }

--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -212,12 +212,25 @@ final class Method extends BaseTag implements Factory\StaticMethod
         foreach ($this->arguments as $argument) {
             $arguments[] = $argument['type'] . ' $' . $argument['name'];
         }
+        $argumentStr = '(' . implode(', ', $arguments) . ')';
 
-        return trim(($this->isStatic() ? 'static ' : '')
-            . (string) $this->returnType . ' '
-            . $this->methodName
-            . '(' . implode(', ', $arguments) . ')'
-            . ($this->description ? ' ' . $this->description->render() : ''));
+        if ($this->description) {
+            $description = $this->description->render();
+        } else {
+            $description = '';
+        }
+
+        $static = $this->isStatic ? 'static' : '';
+
+        $returnType = (string) $this->returnType;
+
+        $methodName = (string) $this->methodName;
+
+        return $static
+            . ($returnType !== '' ? ($static !== '' ? ' ' : '') . $returnType : '')
+            . ($methodName !== '' ? ($static !== '' || $returnType !== '' ? ' ' : '') . $methodName : '')
+            . $argumentStr
+            . ($description !== '' ? ' ' . $description : '');
     }
 
     /**

--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -212,6 +212,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
         foreach ($this->arguments as $argument) {
             $arguments[] = $argument['type'] . ' $' . $argument['name'];
         }
+
         $argumentStr = '(' . implode(', ', $arguments) . ')';
 
         if ($this->description) {

--- a/src/DocBlock/Tags/Param.php
+++ b/src/DocBlock/Tags/Param.php
@@ -140,11 +140,23 @@ final class Param extends TagWithType implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return ($this->type ? $this->type . ($this->variableName ? ' ' : '') : '')
-            . ($this->isReference() ? '&' : '')
-            . ($this->isVariadic() ? '...' : '')
-            . ($this->variableName ? '$' . $this->variableName : '')
-            . (('' . $this->description) ? ' ' . $this->description : '');
+        if ($this->description) {
+            $description = $this->description->render();
+        } else {
+            $description = '';
+        }
+
+        $variableName = '';
+        if ($this->variableName) {
+            $variableName .= ($this->isReference ? '&' : '') . ($this->isVariadic ? '...' : '');
+            $variableName .= ($this->variableName ? '$' . $this->variableName : '');
+        }
+
+        $type = (string) $this->type;
+
+        return $type
+            . ($variableName !== '' ? ($type !== '' ? ' ' : '') . $variableName : '')
+            . ($description !== '' ? ($type !== '' || $variableName !== '' ? ' ' : '') . $description : '');
     }
 
     private static function strStartsWithVariable(string $str) : bool

--- a/src/DocBlock/Tags/Param.php
+++ b/src/DocBlock/Tags/Param.php
@@ -149,7 +149,7 @@ final class Param extends TagWithType implements Factory\StaticMethod
         $variableName = '';
         if ($this->variableName) {
             $variableName .= ($this->isReference ? '&' : '') . ($this->isVariadic ? '...' : '');
-            $variableName .= ($this->variableName ? '$' . $this->variableName : '');
+            $variableName .= '$' . $this->variableName;
         }
 
         $type = (string) $this->type;

--- a/src/DocBlock/Tags/Param.php
+++ b/src/DocBlock/Tags/Param.php
@@ -85,7 +85,9 @@ final class Param extends TagWithType implements Factory\StaticMethod
         // if the next item starts with a $ or ...$ or &$ or &...$ it must be the variable name
         if (isset($parts[0]) && self::strStartsWithVariable($parts[0])) {
             $variableName = array_shift($parts);
-            array_shift($parts);
+            if ($type) {
+                array_shift($parts);
+            }
 
             Assert::notNull($variableName);
 
@@ -141,8 +143,8 @@ final class Param extends TagWithType implements Factory\StaticMethod
         return ($this->type ? $this->type . ' ' : '')
             . ($this->isReference() ? '&' : '')
             . ($this->isVariadic() ? '...' : '')
-            . ($this->variableName !== null ? '$' . $this->variableName : '')
-            . ($this->description ? ' ' . $this->description : '');
+            . ($this->variableName ? '$' . $this->variableName : '')
+            . ($this->description ? ($this->variableName ? ' ' : '') . $this->description : '');
     }
 
     private static function strStartsWithVariable(string $str) : bool

--- a/src/DocBlock/Tags/Param.php
+++ b/src/DocBlock/Tags/Param.php
@@ -75,7 +75,7 @@ final class Param extends TagWithType implements Factory\StaticMethod
         $isReference   = false;
 
         // if the first item that is encountered is not a variable; it is a type
-        if ($firstPart && $firstPart[0] !== '$') {
+        if ($firstPart && !self::strStartsWithVariable($firstPart)) {
             $type = $typeResolver->resolve($firstPart, $context);
         } else {
             // first part is not a type; we should prepend it to the parts array for further processing
@@ -83,18 +83,7 @@ final class Param extends TagWithType implements Factory\StaticMethod
         }
 
         // if the next item starts with a $ or ...$ or &$ or &...$ it must be the variable name
-        if (isset($parts[0])
-            &&
-            (
-                strpos($parts[0], '$') === 0
-                ||
-                strpos($parts[0], '...$') === 0
-                ||
-                strpos($parts[0], '&$') === 0
-                ||
-                strpos($parts[0], '&...$') === 0
-            )
-        ) {
+        if (isset($parts[0]) && self::strStartsWithVariable($parts[0])) {
             $variableName = array_shift($parts);
             array_shift($parts);
 
@@ -154,5 +143,21 @@ final class Param extends TagWithType implements Factory\StaticMethod
             . ($this->isVariadic() ? '...' : '')
             . ($this->variableName !== null ? '$' . $this->variableName : '')
             . ($this->description ? ' ' . $this->description : '');
+    }
+
+    /**
+     * @param string $str
+     *
+     * @return bool
+     */
+    private static function strStartsWithVariable(string $str): bool
+    {
+        return strpos($str, '$') === 0
+               ||
+               strpos($str, '...$') === 0
+               ||
+               strpos($str, '&$') === 0
+               ||
+               strpos($str, '&...$') === 0;
     }
 }

--- a/src/DocBlock/Tags/Param.php
+++ b/src/DocBlock/Tags/Param.php
@@ -140,11 +140,11 @@ final class Param extends TagWithType implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return ($this->type ? $this->type . ' ' : '')
+        return ($this->type ? $this->type . ($this->variableName ? ' ' : '') : '')
             . ($this->isReference() ? '&' : '')
             . ($this->isVariadic() ? '...' : '')
             . ($this->variableName ? '$' . $this->variableName : '')
-            . ($this->description ? ($this->variableName ? ' ' : '') . $this->description : '');
+            . (('' . $this->description) ? ' ' . $this->description : '');
     }
 
     private static function strStartsWithVariable(string $str) : bool

--- a/src/DocBlock/Tags/Param.php
+++ b/src/DocBlock/Tags/Param.php
@@ -145,12 +145,7 @@ final class Param extends TagWithType implements Factory\StaticMethod
             . ($this->description ? ' ' . $this->description : '');
     }
 
-    /**
-     * @param string $str
-     *
-     * @return bool
-     */
-    private static function strStartsWithVariable(string $str): bool
+    private static function strStartsWithVariable(string $str) : bool
     {
         return strpos($str, '$') === 0
                ||

--- a/src/DocBlock/Tags/Property.php
+++ b/src/DocBlock/Tags/Property.php
@@ -98,8 +98,8 @@ final class Property extends TagWithType implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return ($this->type ? $this->type . ' ' : '')
+        return ($this->type ? $this->type . ($this->variableName ? ' ' : '') : '')
             . ($this->variableName ? '$' . $this->variableName : '')
-            . ($this->description ? ($this->variableName ? ' ' : '') . $this->description : '');
+            . (('' . $this->description) ? ' ' . $this->description : '');
     }
 }

--- a/src/DocBlock/Tags/Property.php
+++ b/src/DocBlock/Tags/Property.php
@@ -105,7 +105,7 @@ final class Property extends TagWithType implements Factory\StaticMethod
         }
 
         if ($this->variableName) {
-            $variableName = ($this->variableName ? '$' . $this->variableName : '');
+            $variableName = '$' . $this->variableName;
         } else {
             $variableName = '';
         }

--- a/src/DocBlock/Tags/Property.php
+++ b/src/DocBlock/Tags/Property.php
@@ -68,10 +68,12 @@ final class Property extends TagWithType implements Factory\StaticMethod
             array_unshift($parts, $firstPart);
         }
 
-        // if the next item starts with a $ or ...$ it must be the variable name
+        // if the next item starts with a $ it must be the variable name
         if (isset($parts[0]) && strpos($parts[0], '$') === 0) {
             $variableName = array_shift($parts);
-            array_shift($parts);
+            if ($type) {
+                array_shift($parts);
+            }
 
             Assert::notNull($variableName);
 
@@ -98,6 +100,6 @@ final class Property extends TagWithType implements Factory\StaticMethod
     {
         return ($this->type ? $this->type . ' ' : '')
             . ($this->variableName ? '$' . $this->variableName : '')
-            . ($this->description ? ' ' . $this->description : '');
+            . ($this->description ? ($this->variableName ? ' ' : '') . $this->description : '');
     }
 }

--- a/src/DocBlock/Tags/Property.php
+++ b/src/DocBlock/Tags/Property.php
@@ -98,8 +98,22 @@ final class Property extends TagWithType implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return ($this->type ? $this->type . ($this->variableName ? ' ' : '') : '')
-            . ($this->variableName ? '$' . $this->variableName : '')
-            . (('' . $this->description) ? ' ' . $this->description : '');
+        if ($this->description) {
+            $description = $this->description->render();
+        } else {
+            $description = '';
+        }
+
+        if ($this->variableName) {
+            $variableName = ($this->variableName ? '$' . $this->variableName : '');
+        } else {
+            $variableName = '';
+        }
+
+        $type = (string) $this->type;
+
+        return $type
+            . ($variableName !== '' ? ($type !== '' ? ' ' : '') . $variableName : '')
+            . ($description !== '' ? ($type !== '' || $variableName !== '' ? ' ' : '') . $description : '');
     }
 }

--- a/src/DocBlock/Tags/PropertyRead.php
+++ b/src/DocBlock/Tags/PropertyRead.php
@@ -105,7 +105,7 @@ final class PropertyRead extends TagWithType implements Factory\StaticMethod
         }
 
         if ($this->variableName) {
-            $variableName = ($this->variableName ? '$' . $this->variableName : '');
+            $variableName = '$' . $this->variableName;
         } else {
             $variableName = '';
         }

--- a/src/DocBlock/Tags/PropertyRead.php
+++ b/src/DocBlock/Tags/PropertyRead.php
@@ -68,7 +68,7 @@ final class PropertyRead extends TagWithType implements Factory\StaticMethod
             array_unshift($parts, $firstPart);
         }
 
-        // if the next item starts with a $ or ...$ it must be the variable name
+        // if the next item starts with a $ it must be the variable name
         if (isset($parts[0]) && strpos($parts[0], '$') === 0) {
             $variableName = array_shift($parts);
             if ($type) {

--- a/src/DocBlock/Tags/PropertyRead.php
+++ b/src/DocBlock/Tags/PropertyRead.php
@@ -98,8 +98,22 @@ final class PropertyRead extends TagWithType implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return ($this->type ? $this->type . ($this->variableName ? ' ' : '') : '')
-            . ($this->variableName ? '$' . $this->variableName : '')
-            . (('' . $this->description) ? ' ' . $this->description : '');
+        if ($this->description) {
+            $description = $this->description->render();
+        } else {
+            $description = '';
+        }
+
+        if ($this->variableName) {
+            $variableName = ($this->variableName ? '$' . $this->variableName : '');
+        } else {
+            $variableName = '';
+        }
+
+        $type = (string) $this->type;
+
+        return $type
+            . ($variableName !== '' ? ($type !== '' ? ' ' : '') . $variableName : '')
+            . ($description !== '' ? ($type !== '' || $variableName !== '' ? ' ' : '') . $description : '');
     }
 }

--- a/src/DocBlock/Tags/PropertyRead.php
+++ b/src/DocBlock/Tags/PropertyRead.php
@@ -71,7 +71,9 @@ final class PropertyRead extends TagWithType implements Factory\StaticMethod
         // if the next item starts with a $ or ...$ it must be the variable name
         if (isset($parts[0]) && strpos($parts[0], '$') === 0) {
             $variableName = array_shift($parts);
-            array_shift($parts);
+            if ($type) {
+                array_shift($parts);
+            }
 
             Assert::notNull($variableName);
 
@@ -98,6 +100,6 @@ final class PropertyRead extends TagWithType implements Factory\StaticMethod
     {
         return ($this->type ? $this->type . ' ' : '')
             . ($this->variableName ? '$' . $this->variableName : '')
-            . ($this->description ? ' ' . $this->description : '');
+            . ($this->description ? ($this->variableName ? ' ' : '') . $this->description : '');
     }
 }

--- a/src/DocBlock/Tags/PropertyRead.php
+++ b/src/DocBlock/Tags/PropertyRead.php
@@ -98,8 +98,8 @@ final class PropertyRead extends TagWithType implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return ($this->type ? $this->type . ' ' : '')
+        return ($this->type ? $this->type . ($this->variableName ? ' ' : '') : '')
             . ($this->variableName ? '$' . $this->variableName : '')
-            . ($this->description ? ($this->variableName ? ' ' : '') . $this->description : '');
+            . (('' . $this->description) ? ' ' . $this->description : '');
     }
 }

--- a/src/DocBlock/Tags/PropertyWrite.php
+++ b/src/DocBlock/Tags/PropertyWrite.php
@@ -98,8 +98,8 @@ final class PropertyWrite extends TagWithType implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return ($this->type ? $this->type . ' ' : '')
+        return ($this->type ? $this->type . ($this->variableName ? ' ' : '') : '')
             . ($this->variableName ? '$' . $this->variableName : '')
-            . ($this->description ? ($this->variableName ? ' ' : '') . $this->description : '');
+            . (('' . $this->description) ? ' ' . $this->description : '');
     }
 }

--- a/src/DocBlock/Tags/PropertyWrite.php
+++ b/src/DocBlock/Tags/PropertyWrite.php
@@ -68,7 +68,7 @@ final class PropertyWrite extends TagWithType implements Factory\StaticMethod
             array_unshift($parts, $firstPart);
         }
 
-        // if the next item starts with a $ or ...$ it must be the variable name
+        // if the next item starts with a $ it must be the variable name
         if (isset($parts[0]) && strpos($parts[0], '$') === 0) {
             $variableName = array_shift($parts);
             if ($type) {

--- a/src/DocBlock/Tags/PropertyWrite.php
+++ b/src/DocBlock/Tags/PropertyWrite.php
@@ -71,7 +71,9 @@ final class PropertyWrite extends TagWithType implements Factory\StaticMethod
         // if the next item starts with a $ or ...$ it must be the variable name
         if (isset($parts[0]) && strpos($parts[0], '$') === 0) {
             $variableName = array_shift($parts);
-            array_shift($parts);
+            if ($type) {
+                array_shift($parts);
+            }
 
             Assert::notNull($variableName);
 
@@ -98,6 +100,6 @@ final class PropertyWrite extends TagWithType implements Factory\StaticMethod
     {
         return ($this->type ? $this->type . ' ' : '')
             . ($this->variableName ? '$' . $this->variableName : '')
-            . ($this->description ? ' ' . $this->description : '');
+            . ($this->description ? ($this->variableName ? ' ' : '') . $this->description : '');
     }
 }

--- a/src/DocBlock/Tags/PropertyWrite.php
+++ b/src/DocBlock/Tags/PropertyWrite.php
@@ -98,8 +98,22 @@ final class PropertyWrite extends TagWithType implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return ($this->type ? $this->type . ($this->variableName ? ' ' : '') : '')
-            . ($this->variableName ? '$' . $this->variableName : '')
-            . (('' . $this->description) ? ' ' . $this->description : '');
+        if ($this->description) {
+            $description = $this->description->render();
+        } else {
+            $description = '';
+        }
+
+        if ($this->variableName) {
+            $variableName = ($this->variableName ? '$' . $this->variableName : '');
+        } else {
+            $variableName = '';
+        }
+
+        $type = (string) $this->type;
+
+        return $type
+            . ($variableName !== '' ? ($type !== '' ? ' ' : '') . $variableName : '')
+            . ($description !== '' ? ($type !== '' || $variableName !== '' ? ' ' : '') . $description : '');
     }
 }

--- a/src/DocBlock/Tags/PropertyWrite.php
+++ b/src/DocBlock/Tags/PropertyWrite.php
@@ -105,7 +105,7 @@ final class PropertyWrite extends TagWithType implements Factory\StaticMethod
         }
 
         if ($this->variableName) {
-            $variableName = ($this->variableName ? '$' . $this->variableName : '');
+            $variableName = '$' . $this->variableName;
         } else {
             $variableName = '';
         }

--- a/src/DocBlock/Tags/Return_.php
+++ b/src/DocBlock/Tags/Return_.php
@@ -51,6 +51,14 @@ final class Return_ extends TagWithType implements Factory\StaticMethod
 
     public function __toString() : string
     {
-        return ($this->type ?: 'mixed') . ' ' . (string) $this->description;
+        if ($this->description) {
+            $description = $this->description->render();
+        } else {
+            $description = '';
+        }
+
+        $type = $this->type ? '' . $this->type : 'mixed';
+
+        return $type . ($description !== '' ? ($type !== '' ? ' ' : '') . $description : '');
     }
 }

--- a/src/DocBlock/Tags/See.php
+++ b/src/DocBlock/Tags/See.php
@@ -77,6 +77,14 @@ final class See extends BaseTag implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return $this->refers . ($this->description ? ' ' . $this->description->render() : '');
+        if ($this->description) {
+            $description = $this->description->render();
+        } else {
+            $description = '';
+        }
+
+        $refers = (string) $this->refers;
+
+        return $refers . ($description !== '' ? ($refers !== '' ? ' ' : '') . $description : '');
     }
 }

--- a/src/DocBlock/Tags/Since.php
+++ b/src/DocBlock/Tags/Since.php
@@ -89,6 +89,14 @@ final class Since extends BaseTag implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return (string) $this->version . ($this->description ? ' ' . (string) $this->description : '');
+        if ($this->description) {
+            $description = $this->description->render();
+        } else {
+            $description = '';
+        }
+
+        $version = (string) $this->version;
+
+        return $version . ($description !== '' ? ($version !== '' ? ' ' : '') . $description : '');
     }
 }

--- a/src/DocBlock/Tags/Source.php
+++ b/src/DocBlock/Tags/Source.php
@@ -107,7 +107,11 @@ final class Source extends BaseTag implements Factory\StaticMethod
         $lineCount = $this->lineCount !== null ? '' . $this->lineCount : '';
 
         return $startingLine
-            . ($lineCount !== '' ? ($startingLine || $startingLine === '0' ? ' ' : '') . $lineCount : '')
-            . ($description !== '' ? ($startingLine || $startingLine === '0' || $lineCount !== '' ? ' ' : '') . $description : '');
+            . ($lineCount !== ''
+                ? ($startingLine || $startingLine === '0' ? ' ' : '') . $lineCount
+                : '')
+            . ($description !== ''
+                ? ($startingLine || $startingLine === '0' || $lineCount !== '' ? ' ' : '') . $description
+                : '');
     }
 }

--- a/src/DocBlock/Tags/Source.php
+++ b/src/DocBlock/Tags/Source.php
@@ -107,7 +107,7 @@ final class Source extends BaseTag implements Factory\StaticMethod
         $lineCount = $this->lineCount !== null ? '' . $this->lineCount : '';
 
         return $startingLine
-            . ($lineCount !== '' ? ($startingLine !== '' ? ' ' : '') . $lineCount : '')
-            . ($description !== '' ? ($startingLine !== '' || $lineCount !== '' ? ' ' : '') . $description : '');
+            . ($lineCount !== '' ? ($startingLine || $startingLine === '0' ? ' ' : '') . $lineCount : '')
+            . ($description !== '' ? ($startingLine || $startingLine === '0' || $lineCount !== '' ? ' ' : '') . $description : '');
     }
 }

--- a/src/DocBlock/Tags/Source.php
+++ b/src/DocBlock/Tags/Source.php
@@ -96,8 +96,18 @@ final class Source extends BaseTag implements Factory\StaticMethod
 
     public function __toString() : string
     {
-        return $this->startingLine
-            . ($this->lineCount !== null ? ' ' . $this->lineCount : '')
-            . ($this->description ? ' ' . (string) $this->description : '');
+        if ($this->description) {
+            $description = $this->description->render();
+        } else {
+            $description = '';
+        }
+
+        $startingLine = (string) $this->startingLine;
+
+        $lineCount = $this->lineCount !== null ? '' . $this->lineCount : '';
+
+        return $startingLine
+            . ($lineCount !== '' ? ($startingLine !== '' ? ' ' : '') . $lineCount : '')
+            . ($description !== '' ? ($startingLine !== '' || $lineCount !== '' ? ' ' : '') . $description : '');
     }
 }

--- a/src/DocBlock/Tags/Throws.php
+++ b/src/DocBlock/Tags/Throws.php
@@ -51,6 +51,14 @@ final class Throws extends TagWithType implements Factory\StaticMethod
 
     public function __toString() : string
     {
-        return (string) $this->type . ' ' . (string) $this->description;
+        if ($this->description) {
+            $description = $this->description->render();
+        } else {
+            $description = '';
+        }
+
+        $type = (string) $this->type;
+
+        return $type . ($description !== '' ? ($type !== '' ? ' ' : '') . $description : '');
     }
 }

--- a/src/DocBlock/Tags/Uses.php
+++ b/src/DocBlock/Tags/Uses.php
@@ -71,6 +71,14 @@ final class Uses extends BaseTag implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return $this->refers . ' ' . (string) $this->description;
+        if ($this->description) {
+            $description = $this->description->render();
+        } else {
+            $description = '';
+        }
+
+        $refers = (string) $this->refers;
+
+        return $refers . ($description !== '' ? ($refers !== '' ? ' ' : '') . $description : '');
     }
 }

--- a/src/DocBlock/Tags/Var_.php
+++ b/src/DocBlock/Tags/Var_.php
@@ -72,7 +72,9 @@ final class Var_ extends TagWithType implements Factory\StaticMethod
         // if the next item starts with a $ or ...$ it must be the variable name
         if (isset($parts[0]) && strpos($parts[0], '$') === 0) {
             $variableName = array_shift($parts);
-            array_shift($parts);
+            if ($type) {
+                array_shift($parts);
+            }
 
             Assert::notNull($variableName);
 
@@ -98,7 +100,7 @@ final class Var_ extends TagWithType implements Factory\StaticMethod
     public function __toString() : string
     {
         return ($this->type ? $this->type . ' ' : '')
-            . (empty($this->variableName) ? '' : '$' . $this->variableName)
-            . ($this->description ? ' ' . $this->description : '');
+            . ($this->variableName ? '$' . $this->variableName : '')
+            . ($this->description ? ($this->variableName ? ' ' : '') . $this->description : '');
     }
 }

--- a/src/DocBlock/Tags/Var_.php
+++ b/src/DocBlock/Tags/Var_.php
@@ -99,8 +99,8 @@ final class Var_ extends TagWithType implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return ($this->type ? $this->type . ' ' : '')
+        return ($this->type ? $this->type . ($this->variableName ? ' ' : '') : '')
             . ($this->variableName ? '$' . $this->variableName : '')
-            . ($this->description ? ($this->variableName ? ' ' : '') . $this->description : '');
+            . (('' . $this->description) ? ' ' . $this->description : '');
     }
 }

--- a/src/DocBlock/Tags/Var_.php
+++ b/src/DocBlock/Tags/Var_.php
@@ -69,7 +69,7 @@ final class Var_ extends TagWithType implements Factory\StaticMethod
             array_unshift($parts, $firstPart);
         }
 
-        // if the next item starts with a $ or ...$ it must be the variable name
+        // if the next item starts with a $ it must be the variable name
         if (isset($parts[0]) && strpos($parts[0], '$') === 0) {
             $variableName = array_shift($parts);
             if ($type) {

--- a/src/DocBlock/Tags/Var_.php
+++ b/src/DocBlock/Tags/Var_.php
@@ -99,8 +99,22 @@ final class Var_ extends TagWithType implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return ($this->type ? $this->type . ($this->variableName ? ' ' : '') : '')
-            . ($this->variableName ? '$' . $this->variableName : '')
-            . (('' . $this->description) ? ' ' . $this->description : '');
+        if ($this->description) {
+            $description = $this->description->render();
+        } else {
+            $description = '';
+        }
+
+        if ($this->variableName) {
+            $variableName = ($this->variableName ? '$' . $this->variableName : '');
+        } else {
+            $variableName = '';
+        }
+
+        $type = (string) $this->type;
+
+        return $type
+            . ($variableName !== '' ? ($type !== '' ? ' ' : '') . $variableName : '')
+            . ($description !== '' ? ($type !== '' || $variableName !== '' ? ' ' : '') . $description : '');
     }
 }

--- a/src/DocBlock/Tags/Var_.php
+++ b/src/DocBlock/Tags/Var_.php
@@ -106,7 +106,7 @@ final class Var_ extends TagWithType implements Factory\StaticMethod
         }
 
         if ($this->variableName) {
-            $variableName = ($this->variableName ? '$' . $this->variableName : '');
+            $variableName = '$' . $this->variableName;
         } else {
             $variableName = '';
         }

--- a/src/DocBlock/Tags/Version.php
+++ b/src/DocBlock/Tags/Version.php
@@ -92,7 +92,14 @@ final class Version extends BaseTag implements Factory\StaticMethod
      */
     public function __toString() : string
     {
-        return ((string) $this->version) .
-            ($this->description instanceof Description ? ' ' . $this->description->render() : '');
+        if ($this->description) {
+            $description = $this->description->render();
+        } else {
+            $description = '';
+        }
+
+        $version = (string) $this->version;
+
+        return $version . ($description !== '' ? ($version !== '' ? ' ' : '') . $description : '');
     }
 }

--- a/tests/unit/DocBlock/Tags/AuthorTest.php
+++ b/tests/unit/DocBlock/Tags/AuthorTest.php
@@ -116,6 +116,23 @@ class AuthorTest extends TestCase
         $fixture = new Author('Mike van Riel', 'mike@phpdoc.org');
 
         $this->assertSame('Mike van Riel <mike@phpdoc.org>', (string) $fixture);
+
+        // ---
+
+        $fixture = new Author('0', 'zero@foo.bar');
+
+        $this->assertSame('0 <zero@foo.bar>', (string) $fixture);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function testStringRepresentationIsReturnedWithoutName() : void
+    {
+        $fixture = new Author('', 'mike@phpdoc.org');
+
+        $this->assertSame('<mike@phpdoc.org>', (string) $fixture);
     }
 
     /**

--- a/tests/unit/DocBlock/Tags/CoversTest.php
+++ b/tests/unit/DocBlock/Tags/CoversTest.php
@@ -152,6 +152,40 @@ class CoversTest extends TestCase
     }
 
     /**
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    {
+        $fixture = new Covers(new Fqsen('\\'));
+
+        $this->assertSame('\\', (string) $fixture);
+
+        // ---
+
+        $fixture = new Covers(new Fqsen('\DateTime'));
+
+        $this->assertSame('\DateTime', (string) $fixture);
+
+        // ---
+
+        $fixture = new Covers(new Fqsen('\DateTime'), new Description(''));
+
+        $this->assertSame('\DateTime', (string) $fixture);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function testStringRepresentationIsReturnedWithDescription() : void
+    {
+        $fixture = new Covers(new Fqsen('\DateTime'), new Description('My Description'));
+
+        $this->assertSame('\DateTime My Description', (string) $fixture);
+    }
+
+    /**
      * @covers ::create
      */
     public function testFactoryMethodFailsIfBodyIsNotEmpty() : void

--- a/tests/unit/DocBlock/Tags/DeprecatedTest.php
+++ b/tests/unit/DocBlock/Tags/DeprecatedTest.php
@@ -117,6 +117,37 @@ class DeprecatedTest extends TestCase
         $fixture = new Deprecated('1.0', new Description('Description'));
 
         $this->assertSame('1.0 Description', (string) $fixture);
+
+        // ---
+
+        $fixture = new Deprecated(null, new Description('My Description'));
+
+        $this->assertSame('My Description', (string) $fixture);
+    }
+
+    /**
+     * @uses   \phpDocumentor\Reflection\DocBlock\Description
+     *
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    {
+        $fixture = new Deprecated(null, new Description(''));
+
+        $this->assertSame('', (string) $fixture);
+
+        // ---
+
+        $fixture = new Deprecated('1.0', new Description(''));
+
+        $this->assertSame('1.0', (string) $fixture);
+
+        // ---
+
+        $fixture = new Deprecated('1.0');
+
+        $this->assertSame('1.0', (string) $fixture);
     }
 
     /**

--- a/tests/unit/DocBlock/Tags/ExampleTest.php
+++ b/tests/unit/DocBlock/Tags/ExampleTest.php
@@ -94,6 +94,52 @@ class ExampleTest extends TestCase
     }
 
     /**
+     * @covers ::create
+     * @covers ::__toString
+     */
+    public function testStringRepresentationIsReturned() : void
+    {
+        $tag = Example::create('"example1.php" 10 5 test text');
+
+        $this->assertSame('"example1.php" 10 5 test text', (string) $tag);
+
+        // ---
+
+        $tag = Example::create('file://example1.php');
+
+        $this->assertSame('file://example1.php', (string) $tag);
+
+        // ---
+
+        $tag = Example::create('0 foo bar');
+
+        $this->assertSame('0 foo bar', (string) $tag);
+
+        // ---
+
+        $tag = Example::create('$redisCluster->pttl(\'key\');');
+
+        $this->assertSame('$redisCluster->pttl(\'key\');', (string) $tag);
+
+        // ---
+
+        $tag = Example::create(' "example1.php" 10 5 test text ');
+
+        $this->assertSame('"example1.php" 10 5 test text', (string) $tag);
+    }
+
+    /**
+     * @covers ::create
+     * @covers ::__toString
+     */
+    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    {
+        $tag = Example::create('');
+
+        $this->assertSame('', (string) $tag);
+    }
+
+    /**
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      *
      * @dataProvider tagContentProvider

--- a/tests/unit/DocBlock/Tags/ExampleTest.php
+++ b/tests/unit/DocBlock/Tags/ExampleTest.php
@@ -22,7 +22,7 @@ class ExampleTest extends TestCase
     }
 
     /**
-     * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      *
      * @covers ::create
      * @covers ::__construct
@@ -37,7 +37,7 @@ class ExampleTest extends TestCase
     }
 
     /**
-     * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      *
      * @covers ::create
      * @covers ::__construct
@@ -52,7 +52,7 @@ class ExampleTest extends TestCase
     }
 
     /**
-     * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      *
      * @covers ::create
      * @covers ::__construct
@@ -67,7 +67,7 @@ class ExampleTest extends TestCase
     }
 
     /**
-     * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      *
      * @covers ::create
      * @covers ::__construct
@@ -84,7 +84,7 @@ class ExampleTest extends TestCase
     }
 
     /**
-     * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      *
      * @covers ::create
      * @covers ::__construct
@@ -101,7 +101,7 @@ class ExampleTest extends TestCase
     }
 
     /**
-     * @uses phpDocumentor\Reflection\DocBlock\Tags\BaseTag
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
      *
      * @covers ::create
      * @covers ::__construct

--- a/tests/unit/DocBlock/Tags/GenericTest.php
+++ b/tests/unit/DocBlock/Tags/GenericTest.php
@@ -108,6 +108,26 @@ class GenericTest extends TestCase
     }
 
     /**
+     * @uses   \phpDocumentor\Reflection\DocBlock\Description
+     * @uses   \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
+     *
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    {
+        $fixture = new Generic('generic');
+
+        $this->assertSame('', (string) $fixture);
+
+        // ---
+
+        $fixture = new Generic('generic', new Description(''));
+
+        $this->assertSame('', (string) $fixture);
+    }
+
+    /**
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Generic::<public>
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @uses \phpDocumentor\Reflection\DocBlock\Description

--- a/tests/unit/DocBlock/Tags/LinkTest.php
+++ b/tests/unit/DocBlock/Tags/LinkTest.php
@@ -120,6 +120,25 @@ class LinkTest extends TestCase
     }
 
     /**
+     * @uses   \phpDocumentor\Reflection\DocBlock\Description
+     *
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    {
+        $fixture = new Link('http://this.is.my/link');
+
+        $this->assertSame('http://this.is.my/link', (string) $fixture);
+
+        // ---
+
+        $fixture = new Link('http://this.is.my/link', new Description(''));
+
+        $this->assertSame('http://this.is.my/link', (string) $fixture);
+    }
+
+    /**
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Link::<public>
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @uses \phpDocumentor\Reflection\DocBlock\Description

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -277,7 +277,7 @@ class MethodTest extends TestCase
      */
     public function testStringRepresentationIsReturnedWithoutDescription() : void
     {
-        $fixture   = new Method('myMethod', [], null, false, new Description(''));
+        $fixture = new Method('myMethod', [], null, false, new Description(''));
 
         $this->assertSame(
             'void myMethod()',

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -269,6 +269,36 @@ class MethodTest extends TestCase
     }
 
     /**
+     * @uses   \phpDocumentor\Reflection\DocBlock\Description
+     * @uses   \phpDocumentor\Reflection\DocBlock\Tags\Method::isStatic
+     *
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    {
+        $fixture   = new Method('myMethod', [], null, false, new Description(''));
+
+        $this->assertSame(
+            'void myMethod()',
+            (string) $fixture
+        );
+
+        // ---
+
+        $arguments = [
+            ['name' => 'argument1', 'type' => new String_()],
+            ['name' => 'argument2', 'type' => new Object_()],
+        ];
+        $fixture   = new Method('myMethod', $arguments, new Void_(), true);
+
+        $this->assertSame(
+            'static void myMethod(string $argument1, object $argument2)',
+            (string) $fixture
+        );
+    }
+
+    /**
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Method::<public>
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @uses \phpDocumentor\Reflection\TypeResolver

--- a/tests/unit/DocBlock/Tags/ParamTest.php
+++ b/tests/unit/DocBlock/Tags/ParamTest.php
@@ -16,8 +16,11 @@ namespace phpDocumentor\Reflection\DocBlock\Tags;
 use Mockery as m;
 use phpDocumentor\Reflection\DocBlock\Description;
 use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
+use phpDocumentor\Reflection\DocBlock\StandardTagFactory;
+use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context;
+use phpDocumentor\Reflection\Types\Integer;
 use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\TestCase;
 
@@ -268,6 +271,128 @@ class ParamTest extends TestCase
         $this->assertTrue($fixture->isVariadic());
         $this->assertTrue($fixture->isReference());
         $this->assertSame($description, $fixture->getDescription());
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Param::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::create
+     */
+    public function testFactoryMethodWithReferenceWithoutType() : void
+    {
+        $typeResolver       = new TypeResolver();
+        $fqsenResolver      = new FqsenResolver();
+        $tagFactory         = new StandardTagFactory($fqsenResolver);
+        $descriptionFactory = new DescriptionFactory($tagFactory);
+        $context            = new Context('');
+
+        $fixture = Param::create(
+            '&$myParameter My Description',
+            $typeResolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertSame('&$myParameter My Description', (string) $fixture);
+        $this->assertSame('myParameter', $fixture->getVariableName());
+        $this->assertNull($fixture->getType());
+        $this->assertFalse($fixture->isVariadic());
+        $this->assertTrue($fixture->isReference());
+        $this->assertSame('My Description', $fixture->getDescription() . '');
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Param::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::create
+     */
+    public function testFactoryMethodWithVariadicReferenceWithoutType() : void
+    {
+        $typeResolver       = new TypeResolver();
+        $fqsenResolver      = new FqsenResolver();
+        $tagFactory         = new StandardTagFactory($fqsenResolver);
+        $descriptionFactory = new DescriptionFactory($tagFactory);
+        $context            = new Context('');
+
+        $fixture = Param::create(
+            '&...$myParameter My Description',
+            $typeResolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertSame('&...$myParameter My Description', (string) $fixture);
+        $this->assertSame('myParameter', $fixture->getVariableName());
+        $this->assertNull($fixture->getType());
+        $this->assertTrue($fixture->isVariadic());
+        $this->assertTrue($fixture->isReference());
+        $this->assertSame('My Description', $fixture->getDescription() . '');
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Param::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::create
+     */
+    public function testFactoryMethodWithoutType() : void
+    {
+        $typeResolver       = new TypeResolver();
+        $fqsenResolver      = new FqsenResolver();
+        $tagFactory         = new StandardTagFactory($fqsenResolver);
+        $descriptionFactory = new DescriptionFactory($tagFactory);
+        $context            = new Context('');
+
+        $fixture = Param::create(
+            '$myParameter My Description',
+            $typeResolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertSame('$myParameter My Description', (string) $fixture);
+        $this->assertSame('myParameter', $fixture->getVariableName());
+        $this->assertNull($fixture->getType());
+        $this->assertFalse($fixture->isVariadic());
+        $this->assertFalse($fixture->isReference());
+        $this->assertSame('My Description', $fixture->getDescription() . '');
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Param::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::create
+     */
+    public function testFactoryMethodWithType() : void
+    {
+        $typeResolver       = new TypeResolver();
+        $fqsenResolver      = new FqsenResolver();
+        $tagFactory         = new StandardTagFactory($fqsenResolver);
+        $descriptionFactory = new DescriptionFactory($tagFactory);
+        $context            = new Context('');
+
+        $fixture = Param::create(
+            'int My Description',
+            $typeResolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertSame('int My Description', (string) $fixture);
+        $this->assertSame('', $fixture->getVariableName());
+        $this->assertInstanceOf(Integer::class, $fixture->getType());
+        $this->assertSame('My Description', $fixture->getDescription() . '');
     }
 
     /**

--- a/tests/unit/DocBlock/Tags/PropertyReadTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyReadTest.php
@@ -16,8 +16,11 @@ namespace phpDocumentor\Reflection\DocBlock\Tags;
 use Mockery as m;
 use phpDocumentor\Reflection\DocBlock\Description;
 use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
+use phpDocumentor\Reflection\DocBlock\StandardTagFactory;
+use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context;
+use phpDocumentor\Reflection\Types\Integer;
 use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\TestCase;
 
@@ -167,6 +170,64 @@ class PropertyReadTest extends TestCase
         $this->assertSame('myProperty', $fixture->getVariableName());
         $this->assertInstanceOf(String_::class, $fixture->getType());
         $this->assertSame($description, $fixture->getDescription());
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Param::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::create
+     */
+    public function testFactoryMethodWithoutType() : void
+    {
+        $typeResolver       = new TypeResolver();
+        $fqsenResolver      = new FqsenResolver();
+        $tagFactory         = new StandardTagFactory($fqsenResolver);
+        $descriptionFactory = new DescriptionFactory($tagFactory);
+        $context            = new Context('');
+
+        $fixture = PropertyRead::create(
+            '$myParameter My Description',
+            $typeResolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertSame('$myParameter My Description', (string) $fixture);
+        $this->assertSame('myParameter', $fixture->getVariableName());
+        $this->assertNull($fixture->getType());
+        $this->assertSame('My Description', $fixture->getDescription() . '');
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Param::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::create
+     */
+    public function testFactoryMethodWithType() : void
+    {
+        $typeResolver       = new TypeResolver();
+        $fqsenResolver      = new FqsenResolver();
+        $tagFactory         = new StandardTagFactory($fqsenResolver);
+        $descriptionFactory = new DescriptionFactory($tagFactory);
+        $context            = new Context('');
+
+        $fixture = PropertyRead::create(
+            'int My Description',
+            $typeResolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertSame('int My Description', (string) $fixture);
+        $this->assertSame('', $fixture->getVariableName());
+        $this->assertInstanceOf(Integer::class, $fixture->getType());
+        $this->assertSame('My Description', $fixture->getDescription() . '');
     }
 
     /**

--- a/tests/unit/DocBlock/Tags/PropertyTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyTest.php
@@ -16,8 +16,11 @@ namespace phpDocumentor\Reflection\DocBlock\Tags;
 use Mockery as m;
 use phpDocumentor\Reflection\DocBlock\Description;
 use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
+use phpDocumentor\Reflection\DocBlock\StandardTagFactory;
+use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context;
+use phpDocumentor\Reflection\Types\Integer;
 use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\TestCase;
 
@@ -162,6 +165,64 @@ class PropertyTest extends TestCase
         $this->assertSame('myProperty', $fixture->getVariableName());
         $this->assertInstanceOf(String_::class, $fixture->getType());
         $this->assertSame($description, $fixture->getDescription());
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Param::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::create
+     */
+    public function testFactoryMethodWithoutType() : void
+    {
+        $typeResolver       = new TypeResolver();
+        $fqsenResolver      = new FqsenResolver();
+        $tagFactory         = new StandardTagFactory($fqsenResolver);
+        $descriptionFactory = new DescriptionFactory($tagFactory);
+        $context            = new Context('');
+
+        $fixture = Property::create(
+            '$myParameter My Description',
+            $typeResolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertSame('$myParameter My Description', (string) $fixture);
+        $this->assertSame('myParameter', $fixture->getVariableName());
+        $this->assertNull($fixture->getType());
+        $this->assertSame('My Description', $fixture->getDescription() . '');
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Param::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::create
+     */
+    public function testFactoryMethodWithType() : void
+    {
+        $typeResolver       = new TypeResolver();
+        $fqsenResolver      = new FqsenResolver();
+        $tagFactory         = new StandardTagFactory($fqsenResolver);
+        $descriptionFactory = new DescriptionFactory($tagFactory);
+        $context            = new Context('');
+
+        $fixture = Property::create(
+            'int My Description',
+            $typeResolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertSame('int My Description', (string) $fixture);
+        $this->assertSame('', $fixture->getVariableName());
+        $this->assertInstanceOf(Integer::class, $fixture->getType());
+        $this->assertSame('My Description', $fixture->getDescription() . '');
     }
 
     /**

--- a/tests/unit/DocBlock/Tags/PropertyWriteTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyWriteTest.php
@@ -16,8 +16,11 @@ namespace phpDocumentor\Reflection\DocBlock\Tags;
 use Mockery as m;
 use phpDocumentor\Reflection\DocBlock\Description;
 use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
+use phpDocumentor\Reflection\DocBlock\StandardTagFactory;
+use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context;
+use phpDocumentor\Reflection\Types\Integer;
 use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\TestCase;
 
@@ -167,6 +170,64 @@ class PropertyWriteTest extends TestCase
         $this->assertSame('myProperty', $fixture->getVariableName());
         $this->assertInstanceOf(String_::class, $fixture->getType());
         $this->assertSame($description, $fixture->getDescription());
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Param::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::create
+     */
+    public function testFactoryMethodWithoutType() : void
+    {
+        $typeResolver       = new TypeResolver();
+        $fqsenResolver      = new FqsenResolver();
+        $tagFactory         = new StandardTagFactory($fqsenResolver);
+        $descriptionFactory = new DescriptionFactory($tagFactory);
+        $context            = new Context('');
+
+        $fixture = PropertyWrite::create(
+            '$myParameter My Description',
+            $typeResolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertSame('$myParameter My Description', (string) $fixture);
+        $this->assertSame('myParameter', $fixture->getVariableName());
+        $this->assertNull($fixture->getType());
+        $this->assertSame('My Description', $fixture->getDescription() . '');
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Param::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::create
+     */
+    public function testFactoryMethodWithType() : void
+    {
+        $typeResolver       = new TypeResolver();
+        $fqsenResolver      = new FqsenResolver();
+        $tagFactory         = new StandardTagFactory($fqsenResolver);
+        $descriptionFactory = new DescriptionFactory($tagFactory);
+        $context            = new Context('');
+
+        $fixture = PropertyWrite::create(
+            'int My Description',
+            $typeResolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertSame('int My Description', (string) $fixture);
+        $this->assertSame('', $fixture->getVariableName());
+        $this->assertInstanceOf(Integer::class, $fixture->getType());
+        $this->assertSame('My Description', $fixture->getDescription() . '');
     }
 
     /**

--- a/tests/unit/DocBlock/Tags/ReturnTest.php
+++ b/tests/unit/DocBlock/Tags/ReturnTest.php
@@ -123,6 +123,25 @@ class ReturnTest extends TestCase
     }
 
     /**
+     * @uses   \phpDocumentor\Reflection\DocBlock\Description
+     *
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    {
+        $fixture = new Return_(new String_());
+
+        $this->assertSame('string', (string) $fixture);
+
+        // ---
+
+        $fixture = new Return_(new String_(), new Description(''));
+
+        $this->assertSame('string', (string) $fixture);
+    }
+
+    /**
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Return_::<public>
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @uses \phpDocumentor\Reflection\TypeResolver

--- a/tests/unit/DocBlock/Tags/SeeTest.php
+++ b/tests/unit/DocBlock/Tags/SeeTest.php
@@ -136,6 +136,27 @@ class SeeTest extends TestCase
     }
 
     /**
+     * @uses   \phpDocumentor\Reflection\DocBlock\Description
+     * @uses   \phpDocumentor\Reflection\DocBlock\Tags\Reference\Fqsen
+     * @uses   \phpDocumentor\Reflection\Fqsen
+     *
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    {
+        $fixture = new See(new FqsenRef(new Fqsen('\DateTime::format()')));
+
+        $this->assertSame('\DateTime::format()', (string) $fixture);
+
+        // ---
+
+        $fixture = new See(new FqsenRef(new Fqsen('\DateTime::format()')), new Description(''));
+
+        $this->assertSame('\DateTime::format()', (string) $fixture);
+    }
+
+    /**
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\See::<public>
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @uses \phpDocumentor\Reflection\FqsenResolver

--- a/tests/unit/DocBlock/Tags/SinceTest.php
+++ b/tests/unit/DocBlock/Tags/SinceTest.php
@@ -120,6 +120,25 @@ class SinceTest extends TestCase
     }
 
     /**
+     * @uses   \phpDocumentor\Reflection\DocBlock\Description
+     *
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    {
+        $fixture = new Since('1.0');
+
+        $this->assertSame('1.0', (string) $fixture);
+
+        // ---
+
+        $fixture = new Since('1.0', new Description(''));
+
+        $this->assertSame('1.0', (string) $fixture);
+    }
+
+    /**
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Since::<public>
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @uses \phpDocumentor\Reflection\DocBlock\Description

--- a/tests/unit/DocBlock/Tags/SourceTest.php
+++ b/tests/unit/DocBlock/Tags/SourceTest.php
@@ -138,6 +138,32 @@ class SourceTest extends TestCase
     }
 
     /**
+     * @uses   \phpDocumentor\Reflection\DocBlock\Description
+     * @uses   \phpDocumentor\Reflection\Types\String_
+     *
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    {
+        $fixture = new Source(1);
+
+        $this->assertSame('1', (string) $fixture);
+
+        // ---
+
+        $fixture = new Source(1, 0);
+
+        $this->assertSame('1 0', (string) $fixture);
+
+        // ---
+
+        $fixture = new Source(1, 10, new Description(''));
+
+        $this->assertSame('1 10', (string) $fixture);
+    }
+
+    /**
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Source::<public>
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @uses \phpDocumentor\Reflection\DocBlock\Description

--- a/tests/unit/DocBlock/Tags/ThrowsTest.php
+++ b/tests/unit/DocBlock/Tags/ThrowsTest.php
@@ -120,6 +120,31 @@ class ThrowsTest extends TestCase
         $fixture = new Throws(new String_(), new Description('Description'));
 
         $this->assertSame('string Description', (string) $fixture);
+
+        // ---
+
+        $fixture = new Throws(new String_(), new Description('My Description'));
+
+        $this->assertSame('string My Description', (string) $fixture);
+    }
+
+    /**
+     * @uses   \phpDocumentor\Reflection\DocBlock\Description
+     *
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    {
+        $fixture = new Throws(new String_());
+
+        $this->assertSame('string', (string) $fixture);
+
+        // ---
+
+        $fixture = new Throws(new String_(), new Description(''));
+
+        $this->assertSame('string', (string) $fixture);
     }
 
     /**

--- a/tests/unit/DocBlock/Tags/UsesTest.php
+++ b/tests/unit/DocBlock/Tags/UsesTest.php
@@ -122,6 +122,25 @@ class UsesTest extends TestCase
     }
 
     /**
+     * @uses   \phpDocumentor\Reflection\DocBlock\Description
+     *
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    {
+        $fixture = new Uses(new Fqsen('\DateTime'));
+
+        $this->assertSame('\DateTime', (string) $fixture);
+
+        // ---
+
+        $fixture = new Uses(new Fqsen('\DateTime'), new Description(''));
+
+        $this->assertSame('\DateTime', (string) $fixture);
+    }
+
+    /**
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Uses::<public>
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @uses \phpDocumentor\Reflection\FqsenResolver

--- a/tests/unit/DocBlock/Tags/VarTest.php
+++ b/tests/unit/DocBlock/Tags/VarTest.php
@@ -238,6 +238,35 @@ class VarTest extends TestCase
     }
 
     /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Param::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::create
+     */
+    public function testFactoryMethodWithTypeWithoutComment() : void
+    {
+        $typeResolver       = new TypeResolver();
+        $fqsenResolver      = new FqsenResolver();
+        $tagFactory         = new StandardTagFactory($fqsenResolver);
+        $descriptionFactory = new DescriptionFactory($tagFactory);
+        $context            = new Context('');
+
+        $fixture = Var_::create(
+            'int',
+            $typeResolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertSame('int', (string) $fixture);
+        $this->assertSame('', $fixture->getVariableName());
+        $this->assertInstanceOf(Integer::class, $fixture->getType());
+        $this->assertSame('', $fixture->getDescription() . '');
+    }
+
+    /**
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Var_::<public>
      * @uses \phpDocumentor\Reflection\TypeResolver
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory

--- a/tests/unit/DocBlock/Tags/VarTest.php
+++ b/tests/unit/DocBlock/Tags/VarTest.php
@@ -155,6 +155,32 @@ class VarTest extends TestCase
     }
 
     /**
+     * @uses   \phpDocumentor\Reflection\DocBlock\Description
+     * @uses   \phpDocumentor\Reflection\Types\String_
+     *
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    {
+        $fixture = new Var_('myVariable');
+
+        $this->assertSame('$myVariable', (string) $fixture);
+
+        // ---
+
+        $fixture = new Var_('myVariable', new String_());
+
+        $this->assertSame('string $myVariable', (string) $fixture);
+
+        // ---
+
+        $fixture = new Var_('myVariable', new String_(), new Description(''));
+
+        $this->assertSame('string $myVariable', (string) $fixture);
+    }
+
+    /**
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Var_::<public>
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @uses \phpDocumentor\Reflection\DocBlock\Description

--- a/tests/unit/DocBlock/Tags/VarTest.php
+++ b/tests/unit/DocBlock/Tags/VarTest.php
@@ -16,8 +16,11 @@ namespace phpDocumentor\Reflection\DocBlock\Tags;
 use Mockery as m;
 use phpDocumentor\Reflection\DocBlock\Description;
 use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
+use phpDocumentor\Reflection\DocBlock\StandardTagFactory;
+use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context;
+use phpDocumentor\Reflection\Types\Integer;
 use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\TestCase;
 
@@ -174,6 +177,64 @@ class VarTest extends TestCase
         $this->assertSame('myVariable', $fixture->getVariableName());
         $this->assertInstanceOf(String_::class, $fixture->getType());
         $this->assertSame($description, $fixture->getDescription());
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Param::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::create
+     */
+    public function testFactoryMethodWithoutType() : void
+    {
+        $typeResolver       = new TypeResolver();
+        $fqsenResolver      = new FqsenResolver();
+        $tagFactory         = new StandardTagFactory($fqsenResolver);
+        $descriptionFactory = new DescriptionFactory($tagFactory);
+        $context            = new Context('');
+
+        $fixture = Var_::create(
+            '$myParameter My Description',
+            $typeResolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertSame('$myParameter My Description', (string) $fixture);
+        $this->assertSame('myParameter', $fixture->getVariableName());
+        $this->assertNull($fixture->getType());
+        $this->assertSame('My Description', $fixture->getDescription() . '');
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Param::<public>
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::create
+     */
+    public function testFactoryMethodWithType() : void
+    {
+        $typeResolver       = new TypeResolver();
+        $fqsenResolver      = new FqsenResolver();
+        $tagFactory         = new StandardTagFactory($fqsenResolver);
+        $descriptionFactory = new DescriptionFactory($tagFactory);
+        $context            = new Context('');
+
+        $fixture = Var_::create(
+            'int My Description',
+            $typeResolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertSame('int My Description', (string) $fixture);
+        $this->assertSame('', $fixture->getVariableName());
+        $this->assertInstanceOf(Integer::class, $fixture->getType());
+        $this->assertSame('My Description', $fixture->getDescription() . '');
     }
 
     /**

--- a/tests/unit/DocBlock/Tags/VersionTest.php
+++ b/tests/unit/DocBlock/Tags/VersionTest.php
@@ -120,6 +120,25 @@ class VersionTest extends TestCase
     }
 
     /**
+     * @uses   \phpDocumentor\Reflection\DocBlock\Description
+     *
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    {
+        $fixture = new Version('1.0');
+
+        $this->assertSame('1.0', (string) $fixture);
+
+        // ---
+
+        $fixture = new Version('1.0', new Description(''));
+
+        $this->assertSame('1.0', (string) $fixture);
+    }
+
+    /**
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Version::<public>
      * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
      * @uses \phpDocumentor\Reflection\DocBlock\Description


### PR DESCRIPTION
Build errors:
⇾ https://travis-ci.org/github/JetBrains/phpstorm-stubs/builds/723069982

Pull request where I try to add "&" and "..." in the docs:
⇾ https://github.com/JetBrains/phpstorm-stubs/pull/892

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phpdocumentor/reflectiondocblock/254)
<!-- Reviewable:end -->
