### PR TITLE
Candidate fix for issue #255 : loosen up inline tag splitting regexp

### DIFF
--- a/src/DocBlock/DescriptionFactory.php
+++ b/src/DocBlock/DescriptionFactory.php
@@ -117,7 +117,7 @@ class DescriptionFactory
                             \{
                         )
                         # Match content after the nested inline tag.
-                        [^{}]*
+                        [^{]*
                     )* # If there are more inline tags, match them as well. We use "*" since there may not be any
                        # nested inline tags.
                 )

--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -44,9 +44,10 @@ use function array_slice;
 use function call_user_func_array;
 use function count;
 use function get_class;
+use function ltrim;
 use function preg_match;
 use function strpos;
-use function ltrim;
+
 
 /**
  * Creates a Tag object given the contents of a tag.

--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -145,7 +145,7 @@ final class StandardTagFactory implements TagFactory
 
         [$tagName, $tagBody] = $this->extractTagParts($tagLine);
 
-        return $this->createTag(trim($tagBody), $tagName, $context);
+        return $this->createTag(ltrim($tagBody), $tagName, $context);
     }
 
     /**

--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -48,7 +48,6 @@ use function ltrim;
 use function preg_match;
 use function strpos;
 
-
 /**
  * Creates a Tag object given the contents of a tag.
  *

--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -46,7 +46,7 @@ use function count;
 use function get_class;
 use function preg_match;
 use function strpos;
-use function trim;
+use function ltrim;
 
 /**
  * Creates a Tag object given the contents of a tag.

--- a/src/DocBlock/Tags/Formatter/AsisFormatter.php
+++ b/src/DocBlock/Tags/Formatter/AsisFormatter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\DocBlock\Tags\Formatter;
+
+use phpDocumentor\Reflection\DocBlock\Tag;
+use phpDocumentor\Reflection\DocBlock\Tags\Formatter;
+
+class AsisFormatter implements Formatter
+{
+    /**
+     * Formats the given tag to return a simple untrimmed plain text version.
+     */
+    public function format(Tag $tag) : string
+    {
+        return '@' . $tag->getName() . ' ' . $tag;
+    }
+}

--- a/tests/unit/DocBlock/DescriptionFactoryTest.php
+++ b/tests/unit/DocBlock/DescriptionFactoryTest.php
@@ -17,6 +17,7 @@ use Exception;
 use Mockery as m;
 use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
 use phpDocumentor\Reflection\DocBlock\Tags\Link as LinkTag;
+use phpDocumentor\Reflection\DocBlock\Tags\Formatter\AsisFormatter;
 use phpDocumentor\Reflection\Types\Context;
 use PHPUnit\Framework\TestCase;
 
@@ -224,7 +225,7 @@ DESCRIPTION;
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Link
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
-     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Formatter\PassthroughFormatter
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Formatter\AsisFormatter
      * @uses \phpDocumentor\Reflection\Types\Context
      *
      * @covers ::__construct
@@ -236,17 +237,17 @@ DESCRIPTION;
         $context    = new Context('');
         $tagFactory = m::mock(TagFactory::class);
         $tagFactory->shouldReceive('create')
-            ->twice()
             ->andReturnValues(
                 [
-                    new LinkTag('http://phpdoc.org/', new Description('This contains {braces}')),
+                    new LinkTag('http://phpdoc.org/', new Description('This contains {braces} ')),
                 ]
             );
 
         $factory     = new DescriptionFactory($tagFactory);
         $description = $factory->create($contents, $context);
+        $formatter = new AsisFormatter;
 
-        $this->assertSame($contents, $description->render());
+        $this->assertSame($contents, $description->render($formatter));
         $this->assertSame('This description has a %1$s', $description->getBodyTemplate());
     }
 

--- a/tests/unit/DocBlock/DescriptionFactoryTest.php
+++ b/tests/unit/DocBlock/DescriptionFactoryTest.php
@@ -221,6 +221,36 @@ DESCRIPTION;
     }
 
     /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Link
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Formatter\PassthroughFormatter
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::__construct
+     * @covers ::create
+     */
+    public function testDescriptionCanParseStringWithInlineTagAndBraces() : void
+    {
+        $contents   = 'This description has a {@link http://phpdoc.org/ This contains {braces} }';
+        $context    = new Context('');
+        $tagFactory = m::mock(TagFactory::class);
+        $tagFactory->shouldReceive('create')
+            ->twice()
+            ->andReturnValues(
+                [
+                    new LinkTag('http://phpdoc.org/', new Description('This contains {braces}')),
+                ]
+            );
+
+        $factory     = new DescriptionFactory($tagFactory);
+        $description = $factory->create($contents, $context);
+
+        $this->assertSame($contents, $description->render());
+        $this->assertSame('This description has a %1$s', $description->getBodyTemplate());
+    }
+
+    /**
      * Provides a series of example strings that the parser should correctly interpret and return.
      *
      * @return string[][]

--- a/tests/unit/DocBlock/DescriptionFactoryTest.php
+++ b/tests/unit/DocBlock/DescriptionFactoryTest.php
@@ -15,9 +15,9 @@ namespace phpDocumentor\Reflection\DocBlock;
 
 use Exception;
 use Mockery as m;
+use phpDocumentor\Reflection\DocBlock\Tags\Formatter\AsisFormatter;
 use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
 use phpDocumentor\Reflection\DocBlock\Tags\Link as LinkTag;
-use phpDocumentor\Reflection\DocBlock\Tags\Formatter\AsisFormatter;
 use phpDocumentor\Reflection\Types\Context;
 use PHPUnit\Framework\TestCase;
 
@@ -245,7 +245,7 @@ DESCRIPTION;
 
         $factory     = new DescriptionFactory($tagFactory);
         $description = $factory->create($contents, $context);
-        $formatter = new AsisFormatter;
+        $formatter = new AsisFormatter();
 
         $this->assertSame($contents, $description->render($formatter));
         $this->assertSame('This description has a %1$s', $description->getBodyTemplate());

--- a/tests/unit/DocBlock/Tags/LinkTest.php
+++ b/tests/unit/DocBlock/Tags/LinkTest.php
@@ -125,6 +125,19 @@ class LinkTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
+    public function testStringRepresentationIsReturnedWithBracesAndTrailingSpace() : void
+    {
+        $fixture = new Link('http://this.is.my/link', new Description('Description with {braces} and {trailing space} '));
+
+        $this->assertSame('http://this.is.my/link Description with {braces} and {trailing space} ', (string) $fixture);
+    }
+
+    /**
+     * @uses   \phpDocumentor\Reflection\DocBlock\Description
+     *
+     * @covers ::__construct
+     * @covers ::__toString
+     */
     public function testStringRepresentationIsReturnedWithoutDescription() : void
     {
         $fixture = new Link('http://this.is.my/link');

--- a/tests/unit/DocBlock/Tags/LinkTest.php
+++ b/tests/unit/DocBlock/Tags/LinkTest.php
@@ -127,9 +127,9 @@ class LinkTest extends TestCase
      */
     public function testStringRepresentationIsReturnedWithBracesAndTrailingSpace() : void
     {
-        $fixture = new Link('http://this.is.my/link', new Description('Description with {braces} and {trailing space} '));
+        $fixture = new Link('http://this.is.my/link', new Description('Description has {braces} and trailing space '));
 
-        $this->assertSame('http://this.is.my/link Description with {braces} and {trailing space} ', (string) $fixture);
+        $this->assertSame('http://this.is.my/link Description has {braces} and trailing space ', (string) $fixture);
     }
 
     /**


### PR DESCRIPTION
Test output before : 
```
There was 1 failure:

1) phpDocumentor\Reflection\DocBlock\DescriptionFactoryTest::testDescriptionCanParseStringWithInlineTagAndBraces
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'This description has a {@link http://phpdoc.org/ This contains {braces} }'
+'This description has a {@link http://phpdoc.org/ This contains {braces}} }'

```
Test output after : 
```
There was 1 failure:

1) phpDocumentor\Reflection\DocBlock\DescriptionFactoryTest::testDescriptionCanParseStringWithInlineTagAndBraces
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'This description has a {@link http://phpdoc.org/ This contains {braces} }'
+'This description has a {@link http://phpdoc.org/ This contains {braces}}

```
The new test case still doesn't pass because the trailing space at the end of the inline tag got cleared in `StandardTagFactory::create()` which seems to be intended behavior (removing it solves the issue but also breaks two other tests). Discussion / guidance needed in order to move forward.