### PR TITLE
Get tags with type by name

### DIFF
--- a/src/DocBlock.php
+++ b/src/DocBlock.php
@@ -175,9 +175,11 @@ final class DocBlock
         $result = [];
 
         foreach ($this->getTagsByName($name) as $tag) {
-            if ($tag instanceof TagWithType) {
-                $result[] = $tag;
+            if (!$tag instanceof TagWithType) {
+                continue;
             }
+
+            $result[] = $tag;
         }
 
         return $result;

--- a/src/DocBlock.php
+++ b/src/DocBlock.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection;
 
 use phpDocumentor\Reflection\DocBlock\Tag;
+use phpDocumentor\Reflection\DocBlock\Tags\TagWithType;
 use Webmozart\Assert\Assert;
 
 final class DocBlock
@@ -156,6 +157,27 @@ final class DocBlock
             }
 
             $result[] = $tag;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns an array of tags with type matching the given name. If no tags are found
+     * an empty array is returned.
+     *
+     * @param string $name String to search by.
+     *
+     * @return TagWithType[]
+     */
+    public function getTagsWithTypeByName(string $name) : array
+    {
+        $result = [];
+
+        foreach ($this->getTagsByName($name) as $tag) {
+            if ($tag instanceof TagWithType) {
+                $result[] = $tag;
+            }
         }
 
         return $result;

--- a/tests/unit/DocBlockTest.php
+++ b/tests/unit/DocBlockTest.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection;
 
 use Mockery as m;
+use phpDocumentor\Reflection\DocBlock\Tags\Author;
 use phpDocumentor\Reflection\DocBlock\Tags\Deprecated;
 use phpDocumentor\Reflection\Types\Context;
+use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -136,6 +138,28 @@ class DocBlockTest extends TestCase
 
         $this->assertSame([$tag2, $tag4], $fixture->getTagsByName('abcd'));
         $this->assertSame([], $fixture->getTagsByName('Ebcd'));
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\DocBlock::getTags
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\DocBlock\Tag
+     *
+     * @covers ::__construct
+     * @covers ::getTagsWithTypeByName
+     */
+    public function testFindTagsWithTypeInDocBlockByName() : void
+    {
+        $tag1 = new DocBlock\Tags\Var_('foo', new String_());
+        $tag2 = new DocBlock\Tags\Var_('bar', new String_());
+        $tag3 = new DocBlock\Tags\Return_(new String_());
+        $tag4 = new DocBlock\Tags\Author('lall', '');
+
+        $fixture = new DocBlock('', null, [$tag1, $tag2, $tag3, $tag4]);
+
+        $this->assertSame([$tag1, $tag2], $fixture->getTagsWithTypeByName('var'));
+        $this->assertSame([$tag3], $fixture->getTagsWithTypeByName('return'));
+        $this->assertSame([], $fixture->getTagsWithTypeByName('author'));
     }
 
     /**

--- a/tests/unit/DocBlockTest.php
+++ b/tests/unit/DocBlockTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection;
 
 use Mockery as m;
-use phpDocumentor\Reflection\DocBlock\Tags\Author;
 use phpDocumentor\Reflection\DocBlock\Tags\Deprecated;
 use phpDocumentor\Reflection\Types\Context;
 use phpDocumentor\Reflection\Types\String_;
@@ -23,7 +22,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @uses \Webmozart\Assert\Assert
  *
- * @coversDefaultClass phpDocumentor\Reflection\DocBlock
+ * @coversDefaultClass \phpDocumentor\Reflection\DocBlock
  * @covers ::<private>
  */
 class DocBlockTest extends TestCase


### PR DESCRIPTION
-> because I saw errors like this ```Call to undefined method phpDocumentor\Reflection\DocBlock\Tags\InvalidTag::getType()```

-> https://github.com/Roave/BetterReflection/blob/5b4d1c53768e2a3bc32ab348752663733fd70546/src/TypesFinder/FindReturnType.php#L53

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phpdocumentor/reflectiondocblock/260)
<!-- Reviewable:end -->
