### PR TITLE
Include default argument value when argument has no type

### DIFF
--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -155,7 +155,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
             foreach ($argumentsExploded as $argument) {
                 $argument = explode(' ', self::stripRestArg(trim($argument)), 2);
                 if (strpos($argument[0], '$') === 0) {
-                    $argumentName = substr($argument[0], 1);
+                    $argumentName = substr(implode(' ', $argument), 1);
                     $argumentType = new Mixed_();
                 } else {
                     $argumentType = $typeResolver->resolve($argument[0], $context);

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -193,6 +193,31 @@ class MethodTest extends TestCase
         $this->assertEquals($expected, $fixture->getArguments());
     }
 
+    public function testArgumentHasDefaultValue() : void
+    {
+        $expected = [
+            ['name' => "arg1 = ''", 'type' => new Mixed_()],
+            ['name' => "arg2 = ['value']", 'type' => new Mixed_()],
+            ['name' => "arg3 = 'test'", 'type' => new String_()],
+            ['name' => "arg4 = ['value']", 'type' => new Array_()],
+        ];
+
+        $descriptionFactory = m::mock(DescriptionFactory::class);
+        $resolver           = new TypeResolver();
+        $context            = new Context('');
+        $description        = new Description('');
+        $descriptionFactory->shouldReceive('create')->with('', $context)->andReturn($description);
+
+        $fixture = Method::create(
+            'void myMethod($arg1 = \'\', $arg2 = [\'value\'], string $arg3 = \'test\', array $arg4 = [\'value\'])',
+            $resolver,
+            $descriptionFactory,
+            $context
+        );
+
+        $this->assertEquals($expected, $fixture->getArguments());
+    }
+
     /**
      * @covers ::__construct
      * @covers ::getReturnType


### PR DESCRIPTION
This PR fixes handling default argument values when the argument has no type specified. In that case the default value is currently omitted.

This notation was already working as expected:

`@method void myMethod(string $arg = '')`

With this PR this is also correctly handled:

`@method void myMethod($arg = '')`