### PR TITLE
Docblock/Tags/Author: fix typo in method docblock

### DIFF
--- a/src/DocBlock/Tags/Author.php
+++ b/src/DocBlock/Tags/Author.php
@@ -83,7 +83,7 @@ final class Author extends BaseTag implements Factory\StaticMethod
     }
 
     /**
-     * Attempts to create a new Author object based on †he tag body.
+     * Attempts to create a new Author object based on the tag body.
      */
     public static function create(string $body) : ?self
     {


### PR DESCRIPTION
Non-latin UTF8 character was used.