### PR TITLE
Psalm: switch from Phive to Composer + fix (most) issues

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -195,7 +195,6 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: ${{ env.extensions }}
-          tools: psalm
           ini-values: memory_limit=2G, display_errors=On, error_reporting=-1
 
       - name: Get composer cache directory
@@ -213,7 +212,7 @@ jobs:
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
       - name: Run psalm
-        run: psalm --output-format=github
+        run: vendor/bin/psalm.phar --output-format=github
 
 
   bc_check:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ phpstan:
 
 .PHONY: psalm
 psalm:
-	docker run -it --rm -v${PWD}:/opt/project -w /opt/project php:7.2 tools/psalm
+	docker run -it --rm -v${PWD}:/opt/project -w /opt/project php:7.3 vendor/bin/psalm.phar
 
 .PHONY: test
 test:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "ext-filter": "*"
     },
     "require-dev": {
-        "mockery/mockery": "~1.3.2"
+        "mockery/mockery": "~1.3.2",
+        "psalm/phar": "^4.8"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8a52bc233d90a2f83a3d5ac697d9ccdc",
+    "content-hash": "f1e7818879f1626c05926f50c2c96f44",
     "packages": [
         {
             "name": "phpdocumentor/reflection-common",
@@ -53,6 +53,10 @@
                 "reflection",
                 "static analysis"
             ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
             "time": "2020-06-27T09:03:43+00:00"
         },
         {
@@ -98,6 +102,10 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+            },
             "time": "2020-09-17T18:55:26+00:00"
         },
         {
@@ -160,6 +168,9 @@
                 "polyfill",
                 "portable"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.17.1"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -223,6 +234,10 @@
                 "check",
                 "validate"
             ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
+            },
             "time": "2020-07-08T17:02:28+00:00"
         }
     ],
@@ -272,6 +287,10 @@
             "keywords": [
                 "test"
             ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
+            },
             "time": "2020-07-09T08:09:16+00:00"
         },
         {
@@ -337,7 +356,46 @@
                 "test double",
                 "testing"
             ],
+            "support": {
+                "issues": "https://github.com/mockery/mockery/issues",
+                "source": "https://github.com/mockery/mockery/tree/1.3.4"
+            },
             "time": "2021-02-24T09:51:00+00:00"
+        },
+        {
+            "name": "psalm/phar",
+            "version": "4.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/psalm/phar.git",
+                "reference": "ce0856e5c28a78382d1fa4e1a11cf9aac6292231"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/psalm/phar/zipball/ce0856e5c28a78382d1fa4e1a11cf9aac6292231",
+                "reference": "ce0856e5c28a78382d1fa4e1a11cf9aac6292231",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "vimeo/psalm": "*"
+            },
+            "bin": [
+                "psalm.phar"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer-based Psalm Phar",
+            "support": {
+                "issues": "https://github.com/psalm/phar/issues",
+                "source": "https://github.com/psalm/phar/tree/4.8.1"
+            },
+            "time": "2021-06-21T02:02:58+00:00"
         }
     ],
     "aliases": [],
@@ -350,5 +408,5 @@
         "ext-filter": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/phive.xml
+++ b/phive.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
   <phar name="phpunit" version="^9.2" installed="9.3.7" location="./tools/phpunit" copy="true"/>
-  <phar name="psalm" version="^3.12.1" installed="3.12.1" location="./tools/psalm" copy="true"/>
 </phive>

--- a/psalm.xml
+++ b/psalm.xml
@@ -41,5 +41,17 @@
                 <directory name="src/DocBlock/Tags/"/>
             </errorLevel>
         </RedundantConditionGivenDocblockType>
+
+        <InvalidReturnType>
+            <errorLevel type="info">
+                <file name="src/Utils.php"/>
+            </errorLevel>
+        </InvalidReturnType>
+
+        <InvalidReturnStatement>
+            <errorLevel type="info">
+                <file name="src/Utils.php"/>
+            </errorLevel>
+        </InvalidReturnStatement>
     </issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -53,5 +53,12 @@
                 <file name="src/Utils.php"/>
             </errorLevel>
         </InvalidReturnStatement>
+
+        <ArgumentTypeCoercion>
+            <errorLevel type="info">
+                <!-- PHP handles invalid preg_split flags just fine. -->
+                <file name="src/Utils.php"/>
+            </errorLevel>
+        </ArgumentTypeCoercion>
     </issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -42,18 +42,6 @@
             </errorLevel>
         </RedundantConditionGivenDocblockType>
 
-        <InvalidReturnType>
-            <errorLevel type="info">
-                <file name="src/Utils.php"/>
-            </errorLevel>
-        </InvalidReturnType>
-
-        <InvalidReturnStatement>
-            <errorLevel type="info">
-                <file name="src/Utils.php"/>
-            </errorLevel>
-        </InvalidReturnStatement>
-
         <ArgumentTypeCoercion>
             <errorLevel type="info">
                 <!-- PHP handles invalid preg_split flags just fine. -->

--- a/src/DocBlock/Tags/Author.php
+++ b/src/DocBlock/Tags/Author.php
@@ -77,7 +77,7 @@ final class Author extends BaseTag implements Factory\StaticMethod
             $authorEmail = '';
         }
 
-        $authorName = (string) $this->authorName;
+        $authorName = $this->authorName;
 
         return $authorName . ($authorEmail !== '' ? ($authorName !== '' ? ' ' : '') . $authorEmail : '');
     }

--- a/src/DocBlock/Tags/Example.php
+++ b/src/DocBlock/Tags/Example.php
@@ -147,7 +147,7 @@ final class Example implements Tag, Factory\StaticMethod
      */
     public function __toString() : string
     {
-        $filePath = (string) $this->filePath;
+        $filePath = $this->filePath;
         $isDefaultLine = $this->startingLine === 1 && $this->lineCount === 0;
         $startingLine = !$isDefaultLine ? (string) $this->startingLine : '';
         $lineCount = !$isDefaultLine ? (string) $this->lineCount : '';

--- a/src/DocBlock/Tags/Link.php
+++ b/src/DocBlock/Tags/Link.php
@@ -71,7 +71,7 @@ final class Link extends BaseTag implements Factory\StaticMethod
             $description = '';
         }
 
-        $link = (string) $this->link;
+        $link = $this->link;
 
         return $link . ($description !== '' ? ($link !== '' ? ' ' : '') . $description : '');
     }

--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -225,7 +225,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
 
         $returnType = (string) $this->returnType;
 
-        $methodName = (string) $this->methodName;
+        $methodName = $this->methodName;
 
         return $static
             . ($returnType !== '' ? ($static !== '' ? ' ' : '') . $returnType : '')

--- a/src/DocBlock/Tags/Return_.php
+++ b/src/DocBlock/Tags/Return_.php
@@ -59,6 +59,6 @@ final class Return_ extends TagWithType implements Factory\StaticMethod
 
         $type = $this->type ? '' . $this->type : 'mixed';
 
-        return $type . ($description !== '' ? ($type !== '' ? ' ' : '') . $description : '');
+        return $type . ($description !== '' ? ' ' . $description : '');
     }
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -28,7 +28,7 @@ abstract class Utils
      *
      * @param string $pattern The pattern to search for, as a string.
      * @param string $subject The input string.
-     * @param int|null $limit If specified, then only substrings up to limit are returned with the
+     * @param int $limit If specified, then only substrings up to limit are returned with the
      *      rest of the string being placed in the last substring. A limit of -1 or 0 means "no limit".
      * @param int $flags flags can be any combination of the following flags (combined with the | bitwise operator):
      * *PREG_SPLIT_NO_EMPTY*
@@ -45,7 +45,7 @@ abstract class Utils
      *
      * @throws PcreException
      */
-    public static function pregSplit(string $pattern, string $subject, ?int $limit = -1, int $flags = 0) : array
+    public static function pregSplit(string $pattern, string $subject, int $limit = -1, int $flags = 0) : array
     {
         $parts = php_preg_split($pattern, $subject, $limit, $flags);
         if ($parts === false) {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -41,7 +41,8 @@ abstract class Utils
      *      Note that this changes the return value in an array where every element is an array consisting of the
      *      matched string at offset 0 and its string offset into subject at offset 1.
      *
-     * @return string[] Returns an array containing substrings of subject split along boundaries matched by pattern
+     * @return array<int|string, array<int|string, string>> Returns an array containing substrings of subject
+     *                                                      split along boundaries matched by pattern
      *
      * @throws PcreException
      */


### PR DESCRIPTION
### Psalm: switch from Phive to Composer

This switches the installation method for Psalm from Phive to Composer, while still using a Phar file for running Psalm.

Includes:
* Removing Psalm from the Phive configuration.
* Adding Psalm to the Composer configuration. Includes upgrading from version `3.11.2` to version `4.8.1`.
* Adjusting the script used in the `Makefile`.
    👉 Please verify and test this as things work differently on different OS-es and this should work for you.
* Adjusting the GH Actions script to use the Composer installed version of Psalm.

Note: due to the committed `composer.lock` file, Psalm will not automatically upgrade when newer versions are available.

Refs:
* https://github.com/vimeo/psalm/releases
* https://github.com/psalm/phar/releases

### Utils::pregSplit: limit is not nullable

Correctly flagged by Psalm:
```
ERROR: PossiblyNullArgument - src\Utils.php:50:53 - Argument 3 of preg_split cannot be null, possibly null value provided (see https://psalm.dev/078)
        $parts = php_preg_split($pattern, $subject, $limit, $flags);
```

The `$limit` argument of the PHP native `preg_split()` function is not nullable.

Ref: https://www.php.net/manual/en/function.preg-split

### Tags::__toString(): remove redundant type casts

Psalm flags these type casts as redundant:
```
ERROR: RedundantCastGivenDocblockType - src/DocBlock/Tags/Author.php:80:23 - Redundant cast to string given docblock-provided type (see https://psalm.dev/263)
        $authorName = (string) $this->authorName;

ERROR: RedundantCastGivenDocblockType - src/DocBlock/Tags/Example.php:150:21 - Redundant cast to string given docblock-provided type (see https://psalm.dev/263)
        $filePath = (string) $this->filePath;

ERROR: RedundantCastGivenDocblockType - src/DocBlock/Tags/Link.php:74:17 - Redundant cast to string given docblock-provided type (see https://psalm.dev/263)
        $link = (string) $this->link;

ERROR: RedundantCastGivenDocblockType - src/DocBlock/Tags/Method.php:228:23 - Redundant cast to string given docblock-provided type (see https://psalm.dev/263)
        $methodName = (string) $this->methodName;
```

I have verified each and can confirm that these are redundant. They are probably a left-over from the time when the `__construct()` method in these classes did not yet have type declarations.

### Tags/Return: remove redundant condition

Psalm flags this condition as redundant:
```
ERROR: RedundantCondition - src/DocBlock/Tags/Return_.php:62:48 - "" can never contain non-empty-lowercase-string (see https://psalm.dev/122)
        return $type . ($description !== '' ? ($type !== '' ? ' ' : '') . $description : '');
```

Based on the statement in the line above - `$type = $this->type ? '' . $this->type : 'mixed';` -, Psalm is correct and the `$type` variable can never be an empty string.

### Psalm: suppress two notices

The current version of Psalm flags the following issues:
```
ERROR: InvalidReturnType - src\Utils.php:44:16 - The declared return type 'array<array-key, string>' for phpDocumentor\Reflection\Utils::pregSplit is incorrect, got 'list<list<int|string>|string>' (see https://psalm.dev/011)
     * @return string[] Returns an array containing substrings of subject split along boundaries matched by pattern

ERROR: InvalidReturnStatement - src\Utils.php:55:16 - The inferred type 'list<list<int|string>|string>' does not match the declared return type 'array<array-key, string>' for phpDocumentor\Reflection\Utils::pregSplit (see https://psalm.dev/128)
        return $parts;
```

I'm suggest ignoring this as `list` isn't an officially supported type.

---

After this PR, there is still one issue remaining.
```
Argument 4 of preg_split expects 0|1|2|3|4|5|6|7, parent type int provided (see https://psalm.dev/193)
```

I believe this issue is for the `phpDocumentor\Reflection\Utils` class and expects the `pregSplit()` method to apply input validation to the value received for `$flags` before passing it off to the PHP native `preg_split()` function.

IMO that's taking things a little too far as PHP will handle this internally without errors. Want me to add it to the list of issues to be ignored ?
See: https://3v4l.org/NdDRK

Side-note: the weird thing is that this issue _does_ show up in CI, but with the same PHP + Psalm Phar version, I cannot reproduce this locally.