### PR TITLE
Tests: mark test without assertions as such

### DIFF
--- a/tests/integration/ModifyBackTraceSafeTest.php
+++ b/tests/integration/ModifyBackTraceSafeTest.php
@@ -12,6 +12,9 @@ use PHPUnit\Framework\TestCase;
  */
 class ModifyBackTraceSafeTest extends TestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testBackTraceModificationDoesNotImpactFunctionArguments()
     {
         $traverser = new Traverser();


### PR DESCRIPTION
... to prevent it from being considered "risky" and being listed as "risky" below each test run.

```
There was 1 risky test:

1) phpDocumentor\Reflection\ModifyBackTraceSafeTest::testBackTraceModificationDoesNotImpactFunctionArguments
This test did not perform any assertions

/home/runner/work/ReflectionDocBlock/ReflectionDocBlock/tests/integration/ModifyBackTraceSafeTest.php:15
```