### PR TITLE
Tests: fix missing `@covers` tag

### DIFF
--- a/tests/integration/DocblockSeeTagResolvingTest.php
+++ b/tests/integration/DocblockSeeTagResolvingTest.php
@@ -8,6 +8,9 @@ use phpDocumentor\Reflection\DocBlock\Tags\See;
 use phpDocumentor\Reflection\Types\Context;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversNothing
+ */
 class DocblockSeeTagResolvingTest extends TestCase
 {
     public function testResolvesSeeFQSENOfInlineTags()


### PR DESCRIPTION
... or rather add the missing `@coversNothing` as this is an integration test.

This prevents the test from being marked as "risky" due to the missing tag on PHPUnit 9.x:
```
There was 1 risky test:

1) phpDocumentor\Reflection\DocblockSeeTagResolvingTest::testResolvesSeeFQSENOfInlineTags
This test does not have a @covers annotation but is expected to have one
```