### PR TITLE
DocBlock/Tags/Source: remove redundant code

### DIFF
--- a/src/DocBlock/Tags/Source.php
+++ b/src/DocBlock/Tags/Source.php
@@ -104,14 +104,12 @@ final class Source extends BaseTag implements Factory\StaticMethod
 
         $startingLine = (string) $this->startingLine;
 
-        $lineCount = $this->lineCount !== null ? '' . $this->lineCount : '';
+        $lineCount = $this->lineCount !== null ? ' ' . $this->lineCount : '';
 
         return $startingLine
-            . ($lineCount !== ''
-                ? ($startingLine || $startingLine === '0' ? ' ' : '') . $lineCount
-                : '')
+            . $lineCount
             . ($description !== ''
-                ? ($startingLine || $startingLine === '0' || $lineCount !== '' ? ' ' : '') . $description
+                ? ' ' . $description
                 : '');
     }
 }


### PR DESCRIPTION
PHPStan flags the code within the `Source::__toString()` method:
```
 ------ -------------------------------------------------------------------------------------------
  Line   DocBlock\Tags\Source.php
 ------ -------------------------------------------------------------------------------------------
  111    Result of || is always true.
  114    Result of || is always true.
  114    Result of || is always true.
 ------ -------------------------------------------------------------------------------------------
```

I have investigated this and can confirm that these flags are correct.

1. `$this->startingLine` is cast to an integer in the `__construct()` method (line 45) and subsequently cast to a string in `__toString()` (line 105).
    This means that it can only ever be a non-empty ("truthy") string or the string '0', so the `$startingLine || $startingLine === '0'` condition used in two places is redundant.
2. `$this->lineCount` is either an integer or `null` after the `__construct()` method (line 46).
    In the `__toString()` method, if the `lineCount` is an integer, it is effectively cast to a string by the concatenation with an empty string on line 107, while if the `lineCount` was `null`, it is turned into an empty string.
    By changing the concatenation from concatenating with an empty string to concatenating with a one-space string, we can remove the ternary in the `return` statement checking for `$lineCount` being empty.

The existing unit tests already cover this code and still pass after this change.