### PR TITLE
Composer: fix `autoload-dev` directive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "phpDocumentor\\Reflection\\": "tests/unit"
+            "phpDocumentor\\Reflection\\": ["tests/unit", "tests/integration"]
         }
     },
     "extra": {


### PR DESCRIPTION
This only allowed for the tests in the `tests/unit` directory, while there are also tests in the `tests/integration` directory.