### PR TITLE
GH Actions: fail the build if a test run fails

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -54,6 +54,7 @@ jobs:
     name: Unit tests for PHP version ${{ matrix.php-versions }} on ${{ matrix.operating-system }}
     runs-on: ${{ matrix.operating-system }}
     strategy:
+      fail-fast: false
       matrix:
         operating-system:
           - ubuntu-latest
@@ -110,7 +111,6 @@ jobs:
           composer-options: --optimize-autoloader
 
       - name: Run PHPUnit
-        continue-on-error: true
         run: php tools/phpunit
 
   codestyle:


### PR DESCRIPTION
The way things were set up now in the `phpunit` job, no matter whether tests passed or failed, the workflow would always continue.

I suspect this may have been set-up this way to make sure that all variations of test runs will actually be run ?
The downside is that, while you will see a :x: for the individual build in the workflow summary, the workflow will not be marked as failed, nor will the individual test builds be marked as failed.

If we look back at the last time the workflow was run completely, this can be seen in the annotations below the summary, which show that the Windows test runs all failed.
https://github.com/phpDocumentor/ReflectionDocBlock/actions/runs/370378454

I'm proposing to change this now by:
* Removing the `continue-on-error` for the test run.
* Adding the `fail-fast` key and setting it to `false`.
    By default this key is set to `true`, which means that if any individual build within the job fails, all other builds within the job will be cancelled.
    By setting it to `false`, all builds in the matrix will still be run, but if any of them fail, the workflow will be marked as "failed".

Opening as draft to expose issue #287 properly.