### PR TITLE
CS update after upstream changes

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,22 +1,29 @@
 <?xml version="1.0"?>
-<ruleset name="phpDocumentor">
- <description>The coding standard for phpDocumentor.</description>
+<ruleset name="ReflectionDocBlock">
+ <description>The coding standard for this library.</description>
 
     <file>src</file>
     <file>tests/unit</file>
-    <exclude-pattern>*/tests/unit/Types/ContextFactoryTest.php</exclude-pattern>
+    <exclude-pattern>*/tests/unit/Types/ContextFactoryTest\.php</exclude-pattern>
     <exclude-pattern>*/tests/unit/Assets/*</exclude-pattern>
     <arg value="p"/>
 
+    <!-- Set the minimum PHP version for PHPCompatibility.
+         This should be kept in sync with the requirements in the composer.json file. -->
+    <config name="testVersion" value="7.2-"/>
+
     <rule ref="phpDocumentor">
         <exclude name="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly.ReferencedGeneralException" />
+
+        <!-- Property type declarations are a PHP 7.4 feature. -->
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix">
-        <exclude-pattern>*/src/*/Abstract*.php</exclude-pattern>
+        <exclude-pattern>*/src/*/Abstract*\.php</exclude-pattern>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod">
-        <exclude-pattern>*/src/DocBlock/Tags/InvalidTag.php</exclude-pattern>
+        <exclude-pattern>*/src/DocBlock/Tags/InvalidTag\.php</exclude-pattern>
     </rule>
 </ruleset>

--- a/src/DocBlock.php
+++ b/src/DocBlock.php
@@ -69,12 +69,12 @@ final class DocBlock
         $this->isTemplateStart = $isTemplateStart;
     }
 
-    public function getSummary() : string
+    public function getSummary(): string
     {
         return $this->summary;
     }
 
-    public function getDescription() : DocBlock\Description
+    public function getDescription(): DocBlock\Description
     {
         return $this->description;
     }
@@ -82,7 +82,7 @@ final class DocBlock
     /**
      * Returns the current context.
      */
-    public function getContext() : ?Types\Context
+    public function getContext(): ?Types\Context
     {
         return $this->context;
     }
@@ -90,7 +90,7 @@ final class DocBlock
     /**
      * Returns the current location.
      */
-    public function getLocation() : ?Location
+    public function getLocation(): ?Location
     {
         return $this->location;
     }
@@ -114,7 +114,7 @@ final class DocBlock
      *
      * @see self::isTemplateEnd() for the check whether a closing marker was provided.
      */
-    public function isTemplateStart() : bool
+    public function isTemplateStart(): bool
     {
         return $this->isTemplateStart;
     }
@@ -124,7 +124,7 @@ final class DocBlock
      *
      * @see self::isTemplateStart() for a more complete description of the Docblock Template functionality.
      */
-    public function isTemplateEnd() : bool
+    public function isTemplateEnd(): bool
     {
         return $this->isTemplateEnd;
     }
@@ -134,7 +134,7 @@ final class DocBlock
      *
      * @return Tag[]
      */
-    public function getTags() : array
+    public function getTags(): array
     {
         return $this->tags;
     }
@@ -147,7 +147,7 @@ final class DocBlock
      *
      * @return Tag[]
      */
-    public function getTagsByName(string $name) : array
+    public function getTagsByName(string $name): array
     {
         $result = [];
 
@@ -170,7 +170,7 @@ final class DocBlock
      *
      * @return TagWithType[]
      */
-    public function getTagsWithTypeByName(string $name) : array
+    public function getTagsWithTypeByName(string $name): array
     {
         $result = [];
 
@@ -190,7 +190,7 @@ final class DocBlock
      *
      * @param string $name Tag name to check for.
      */
-    public function hasTag(string $name) : bool
+    public function hasTag(string $name): bool
     {
         foreach ($this->getTags() as $tag) {
             if ($tag->getName() === $name) {
@@ -206,7 +206,7 @@ final class DocBlock
      *
      * @param Tag $tagToRemove The tag to remove.
      */
-    public function removeTag(Tag $tagToRemove) : void
+    public function removeTag(Tag $tagToRemove): void
     {
         foreach ($this->tags as $key => $tag) {
             if ($tag === $tagToRemove) {
@@ -221,7 +221,7 @@ final class DocBlock
      *
      * @param Tag $tag The tag to add.
      */
-    private function addTag(Tag $tag) : void
+    private function addTag(Tag $tag): void
     {
         $this->tags[] = $tag;
     }

--- a/src/DocBlock/Description.php
+++ b/src/DocBlock/Description.php
@@ -71,7 +71,7 @@ class Description
     /**
      * Returns the body template.
      */
-    public function getBodyTemplate() : string
+    public function getBodyTemplate(): string
     {
         return $this->bodyTemplate;
     }
@@ -81,7 +81,7 @@ class Description
      *
      * @return Tag[]
      */
-    public function getTags() : array
+    public function getTags(): array
     {
         return $this->tags;
     }
@@ -90,7 +90,7 @@ class Description
      * Renders this description as a string where the provided formatter will format the tags in the expected string
      * format.
      */
-    public function render(?Formatter $formatter = null) : string
+    public function render(?Formatter $formatter = null): string
     {
         if ($formatter === null) {
             $formatter = new PassthroughFormatter();
@@ -107,7 +107,7 @@ class Description
     /**
      * Returns a plain string representation of this description.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return $this->render();
     }

--- a/src/DocBlock/Description.php
+++ b/src/DocBlock/Description.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Reflection\DocBlock;
 
 use phpDocumentor\Reflection\DocBlock\Tags\Formatter;
 use phpDocumentor\Reflection\DocBlock\Tags\Formatter\PassthroughFormatter;
+
 use function vsprintf;
 
 /**

--- a/src/DocBlock/DescriptionFactory.php
+++ b/src/DocBlock/DescriptionFactory.php
@@ -60,7 +60,7 @@ class DescriptionFactory
     /**
      * Returns the parsed text of this description.
      */
-    public function create(string $contents, ?TypeContext $context = null) : Description
+    public function create(string $contents, ?TypeContext $context = null): Description
     {
         $tokens   = $this->lex($contents);
         $count    = count($tokens);
@@ -88,7 +88,7 @@ class DescriptionFactory
      *
      * @return string[] A series of tokens of which the description text is composed.
      */
-    private function lex(string $contents) : array
+    private function lex(string $contents): array
     {
         $contents = $this->removeSuperfluousStartingWhitespace($contents);
 
@@ -142,7 +142,7 @@ class DescriptionFactory
      * If we do not normalize the indentation then we have superfluous whitespace on the second and subsequent
      * lines and this may cause rendering issues when, for example, using a Markdown converter.
      */
-    private function removeSuperfluousStartingWhitespace(string $contents) : string
+    private function removeSuperfluousStartingWhitespace(string $contents): string
     {
         $lines = explode("\n", $contents);
 

--- a/src/DocBlock/DescriptionFactory.php
+++ b/src/DocBlock/DescriptionFactory.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Reflection\DocBlock;
 
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use phpDocumentor\Reflection\Utils;
+
 use function count;
 use function explode;
 use function implode;
@@ -25,6 +26,7 @@ use function strlen;
 use function strpos;
 use function substr;
 use function trim;
+
 use const PREG_SPLIT_DELIM_CAPTURE;
 
 /**

--- a/src/DocBlock/ExampleFinder.php
+++ b/src/DocBlock/ExampleFinder.php
@@ -38,7 +38,7 @@ class ExampleFinder
     /**
      * Attempts to find the example contents for the given descriptor.
      */
-    public function find(Example $example) : string
+    public function find(Example $example): string
     {
         $filename = $example->getFilePath();
 
@@ -53,7 +53,7 @@ class ExampleFinder
     /**
      * Registers the project's root directory where an 'examples' folder can be expected.
      */
-    public function setSourceDirectory(string $directory = '') : void
+    public function setSourceDirectory(string $directory = ''): void
     {
         $this->sourceDirectory = $directory;
     }
@@ -61,7 +61,7 @@ class ExampleFinder
     /**
      * Returns the project's root directory where an 'examples' folder can be expected.
      */
-    public function getSourceDirectory() : string
+    public function getSourceDirectory(): string
     {
         return $this->sourceDirectory;
     }
@@ -71,7 +71,7 @@ class ExampleFinder
      *
      * @param string[] $directories
      */
-    public function setExampleDirectories(array $directories) : void
+    public function setExampleDirectories(array $directories): void
     {
         $this->exampleDirectories = $directories;
     }
@@ -81,7 +81,7 @@ class ExampleFinder
      *
      * @return string[]
      */
-    public function getExampleDirectories() : array
+    public function getExampleDirectories(): array
     {
         return $this->exampleDirectories;
     }
@@ -99,7 +99,7 @@ class ExampleFinder
      *
      * @return string[] all lines of the example file
      */
-    private function getExampleFileContents(string $filename) : ?array
+    private function getExampleFileContents(string $filename): ?array
     {
         $normalizedPath = null;
 
@@ -129,7 +129,7 @@ class ExampleFinder
     /**
      * Get example filepath based on the example directory inside your project.
      */
-    private function getExamplePathFromExampleDirectory(string $file) : string
+    private function getExamplePathFromExampleDirectory(string $file): string
     {
         return getcwd() . DIRECTORY_SEPARATOR . 'examples' . DIRECTORY_SEPARATOR . $file;
     }
@@ -137,7 +137,7 @@ class ExampleFinder
     /**
      * Returns a path to the example file in the given directory..
      */
-    private function constructExamplePath(string $directory, string $file) : string
+    private function constructExamplePath(string $directory, string $file): string
     {
         return rtrim($directory, '\\/') . DIRECTORY_SEPARATOR . $file;
     }
@@ -145,7 +145,7 @@ class ExampleFinder
     /**
      * Get example filepath based on sourcecode.
      */
-    private function getExamplePathFromSource(string $file) : string
+    private function getExamplePathFromSource(string $file): string
     {
         return sprintf(
             '%s%s%s',

--- a/src/DocBlock/ExampleFinder.php
+++ b/src/DocBlock/ExampleFinder.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\DocBlock;
 
 use phpDocumentor\Reflection\DocBlock\Tags\Example;
+
 use function array_slice;
 use function file;
 use function getcwd;
@@ -22,6 +23,7 @@ use function is_readable;
 use function rtrim;
 use function sprintf;
 use function trim;
+
 use const DIRECTORY_SEPARATOR;
 
 /**

--- a/src/DocBlock/Serializer.php
+++ b/src/DocBlock/Serializer.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\DocBlock\Tags\Formatter;
 use phpDocumentor\Reflection\DocBlock\Tags\Formatter\PassthroughFormatter;
+
 use function sprintf;
 use function str_repeat;
 use function str_replace;

--- a/src/DocBlock/Serializer.php
+++ b/src/DocBlock/Serializer.php
@@ -72,7 +72,7 @@ class Serializer
      *
      * @return string The serialized doc block.
      */
-    public function getDocComment(DocBlock $docblock) : string
+    public function getDocComment(DocBlock $docblock): string
     {
         $indent      = str_repeat($this->indentString, $this->indent);
         $firstIndent = $this->isFirstLineIndented ? $indent : '';
@@ -98,7 +98,7 @@ class Serializer
         return $comment . $indent . ' */';
     }
 
-    private function removeTrailingSpaces(string $indent, string $text) : string
+    private function removeTrailingSpaces(string $indent, string $text): string
     {
         return str_replace(
             sprintf("\n%s * \n", $indent),
@@ -107,7 +107,7 @@ class Serializer
         );
     }
 
-    private function addAsterisksForEachLine(string $indent, string $text) : string
+    private function addAsterisksForEachLine(string $indent, string $text): string
     {
         return str_replace(
             "\n",
@@ -116,7 +116,7 @@ class Serializer
         );
     }
 
-    private function getSummaryAndDescriptionTextBlock(DocBlock $docblock, ?int $wrapLength) : string
+    private function getSummaryAndDescriptionTextBlock(DocBlock $docblock, ?int $wrapLength): string
     {
         $text = $docblock->getSummary() . ((string) $docblock->getDescription() ? "\n\n" . $docblock->getDescription()
                 : '');
@@ -129,7 +129,7 @@ class Serializer
         return $text;
     }
 
-    private function addTagBlock(DocBlock $docblock, ?int $wrapLength, string $indent, string $comment) : string
+    private function addTagBlock(DocBlock $docblock, ?int $wrapLength, string $indent, string $comment): string
     {
         foreach ($docblock->getTags() as $tag) {
             $tagText = $this->tagFormatter->format($tag);

--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -137,7 +137,7 @@ final class StandardTagFactory implements TagFactory
         $this->addService($fqsenResolver, FqsenResolver::class);
     }
 
-    public function create(string $tagLine, ?TypeContext $context = null) : Tag
+    public function create(string $tagLine, ?TypeContext $context = null): Tag
     {
         if (!$context) {
             $context = new TypeContext('');
@@ -151,17 +151,17 @@ final class StandardTagFactory implements TagFactory
     /**
      * @param mixed $value
      */
-    public function addParameter(string $name, $value) : void
+    public function addParameter(string $name, $value): void
     {
         $this->serviceLocator[$name] = $value;
     }
 
-    public function addService(object $service, ?string $alias = null) : void
+    public function addService(object $service, ?string $alias = null): void
     {
         $this->serviceLocator[$alias ?: get_class($service)] = $service;
     }
 
-    public function registerTagHandler(string $tagName, string $handler) : void
+    public function registerTagHandler(string $tagName, string $handler): void
     {
         Assert::stringNotEmpty($tagName);
         Assert::classExists($handler);
@@ -181,7 +181,7 @@ final class StandardTagFactory implements TagFactory
      *
      * @return string[]
      */
-    private function extractTagParts(string $tagLine) : array
+    private function extractTagParts(string $tagLine): array
     {
         $matches = [];
         if (!preg_match('/^@(' . self::REGEX_TAGNAME . ')((?:[\s\(\{])\s*([^\s].*)|$)/us', $tagLine, $matches)) {
@@ -201,7 +201,7 @@ final class StandardTagFactory implements TagFactory
      * Creates a new tag object with the given name and body or returns null if the tag name was recognized but the
      * body was invalid.
      */
-    private function createTag(string $body, string $name, TypeContext $context) : Tag
+    private function createTag(string $body, string $name, TypeContext $context): Tag
     {
         $handlerClassName = $this->findHandlerClassName($name, $context);
         $arguments        = $this->getArgumentsForParametersFromWiring(
@@ -226,7 +226,7 @@ final class StandardTagFactory implements TagFactory
      *
      * @return class-string<Tag>
      */
-    private function findHandlerClassName(string $tagName, TypeContext $context) : string
+    private function findHandlerClassName(string $tagName, TypeContext $context): string
     {
         $handlerClassName = Generic::class;
         if (isset($this->tagHandlerMappings[$tagName])) {
@@ -251,7 +251,7 @@ final class StandardTagFactory implements TagFactory
      * @return mixed[] A series of values that can be passed to the Factory Method of the tag whose parameters
      *     is provided with this method.
      */
-    private function getArgumentsForParametersFromWiring(array $parameters, array $locator) : array
+    private function getArgumentsForParametersFromWiring(array $parameters, array $locator): array
     {
         $arguments = [];
         foreach ($parameters as $parameter) {
@@ -292,7 +292,7 @@ final class StandardTagFactory implements TagFactory
      *
      * @return ReflectionParameter[]
      */
-    private function fetchParametersForHandlerFactoryMethod(string $handlerClassName) : array
+    private function fetchParametersForHandlerFactoryMethod(string $handlerClassName): array
     {
         if (!isset($this->tagHandlerParameterCache[$handlerClassName])) {
             $methodReflection                                  = new ReflectionMethod($handlerClassName, 'create');
@@ -319,7 +319,7 @@ final class StandardTagFactory implements TagFactory
         TypeContext $context,
         string $tagName,
         string $tagBody
-    ) : array {
+    ): array {
         return array_merge(
             $this->serviceLocator,
             [
@@ -335,7 +335,7 @@ final class StandardTagFactory implements TagFactory
      *
      * @todo this method should be populated once we implement Annotation notation support.
      */
-    private function isAnnotation(string $tagContent) : bool
+    private function isAnnotation(string $tagContent): bool
     {
         // 1. Contains a namespace separator
         // 2. Contains parenthesis

--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -39,6 +39,7 @@ use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionParameter;
 use Webmozart\Assert\Assert;
+
 use function array_merge;
 use function array_slice;
 use function call_user_func_array;

--- a/src/DocBlock/Tag.php
+++ b/src/DocBlock/Tag.php
@@ -17,7 +17,7 @@ use phpDocumentor\Reflection\DocBlock\Tags\Formatter;
 
 interface Tag
 {
-    public function getName() : string;
+    public function getName(): string;
 
     /**
      * @return Tag|mixed Class that implements Tag
@@ -26,7 +26,7 @@ interface Tag
      */
     public static function create(string $body);
 
-    public function render(?Formatter $formatter = null) : string;
+    public function render(?Formatter $formatter = null): string;
 
-    public function __toString() : string;
+    public function __toString(): string;
 }

--- a/src/DocBlock/TagFactory.php
+++ b/src/DocBlock/TagFactory.php
@@ -38,7 +38,7 @@ interface TagFactory
      *
      * @param mixed $value
      */
-    public function addParameter(string $name, $value) : void;
+    public function addParameter(string $name, $value): void;
 
     /**
      * Factory method responsible for instantiating the correct sub type.
@@ -49,7 +49,7 @@ interface TagFactory
      *
      * @throws InvalidArgumentException If an invalid tag line was presented.
      */
-    public function create(string $tagLine, ?TypeContext $context = null) : Tag;
+    public function create(string $tagLine, ?TypeContext $context = null): Tag;
 
     /**
      * Registers a service with the Service Locator using the FQCN of the class or the alias, if provided.
@@ -60,7 +60,7 @@ interface TagFactory
      * Because interfaces are regularly used as type-hints this method provides an alias parameter; if the FQCN of the
      * interface is passed as alias then every time that interface is requested the provided service will be returned.
      */
-    public function addService(object $service) : void;
+    public function addService(object $service): void;
 
     /**
      * Registers a handler for tags.
@@ -80,5 +80,5 @@ interface TagFactory
      * @throws InvalidArgumentException If the handler is not an existing class.
      * @throws InvalidArgumentException If the handler does not implement the {@see Tag} interface.
      */
-    public function registerTagHandler(string $tagName, string $handler) : void;
+    public function registerTagHandler(string $tagName, string $handler): void;
 }

--- a/src/DocBlock/Tags/Author.php
+++ b/src/DocBlock/Tags/Author.php
@@ -51,7 +51,7 @@ final class Author extends BaseTag implements Factory\StaticMethod
      *
      * @return string The author's name.
      */
-    public function getAuthorName() : string
+    public function getAuthorName(): string
     {
         return $this->authorName;
     }
@@ -61,7 +61,7 @@ final class Author extends BaseTag implements Factory\StaticMethod
      *
      * @return string The author's email.
      */
-    public function getEmail() : string
+    public function getEmail(): string
     {
         return $this->authorEmail;
     }
@@ -69,7 +69,7 @@ final class Author extends BaseTag implements Factory\StaticMethod
     /**
      * Returns this tag in string form.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->authorEmail) {
             $authorEmail = '<' . $this->authorEmail . '>';
@@ -85,7 +85,7 @@ final class Author extends BaseTag implements Factory\StaticMethod
     /**
      * Attempts to create a new Author object based on the tag body.
      */
-    public static function create(string $body) : ?self
+    public static function create(string $body): ?self
     {
         $splitTagContent = preg_match('/^([^\<]*)(?:\<([^\>]*)\>)?$/u', $body, $matches);
         if (!$splitTagContent) {

--- a/src/DocBlock/Tags/Author.php
+++ b/src/DocBlock/Tags/Author.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\DocBlock\Tags;
 
 use InvalidArgumentException;
+
 use function filter_var;
 use function preg_match;
 use function trim;
+
 use const FILTER_VALIDATE_EMAIL;
 
 /**

--- a/src/DocBlock/Tags/BaseTag.php
+++ b/src/DocBlock/Tags/BaseTag.php
@@ -32,17 +32,17 @@ abstract class BaseTag implements DocBlock\Tag
      *
      * @return string The name of this tag.
      */
-    public function getName() : string
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function getDescription() : ?Description
+    public function getDescription(): ?Description
     {
         return $this->description;
     }
 
-    public function render(?Formatter $formatter = null) : string
+    public function render(?Formatter $formatter = null): string
     {
         if ($formatter === null) {
             $formatter = new Formatter\PassthroughFormatter();

--- a/src/DocBlock/Tags/Covers.php
+++ b/src/DocBlock/Tags/Covers.php
@@ -48,7 +48,7 @@ final class Covers extends BaseTag implements Factory\StaticMethod
         ?DescriptionFactory $descriptionFactory = null,
         ?FqsenResolver $resolver = null,
         ?TypeContext $context = null
-    ) : self {
+    ): self {
         Assert::stringNotEmpty($body);
         Assert::notNull($descriptionFactory);
         Assert::notNull($resolver);
@@ -61,7 +61,7 @@ final class Covers extends BaseTag implements Factory\StaticMethod
         );
     }
 
-    private static function resolveFqsen(string $parts, ?FqsenResolver $fqsenResolver, ?TypeContext $context) : Fqsen
+    private static function resolveFqsen(string $parts, ?FqsenResolver $fqsenResolver, ?TypeContext $context): Fqsen
     {
         Assert::notNull($fqsenResolver);
         $fqsenParts = explode('::', $parts);
@@ -77,7 +77,7 @@ final class Covers extends BaseTag implements Factory\StaticMethod
     /**
      * Returns the structural element this tag refers to.
      */
-    public function getReference() : Fqsen
+    public function getReference(): Fqsen
     {
         return $this->refers;
     }
@@ -85,7 +85,7 @@ final class Covers extends BaseTag implements Factory\StaticMethod
     /**
      * Returns a string representation of this tag.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->description) {
             $description = $this->description->render();

--- a/src/DocBlock/Tags/Covers.php
+++ b/src/DocBlock/Tags/Covers.php
@@ -20,6 +20,7 @@ use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use phpDocumentor\Reflection\Utils;
 use Webmozart\Assert\Assert;
+
 use function array_key_exists;
 use function explode;
 

--- a/src/DocBlock/Tags/Deprecated.php
+++ b/src/DocBlock/Tags/Deprecated.php
@@ -61,7 +61,7 @@ final class Deprecated extends BaseTag implements Factory\StaticMethod
         ?string $body,
         ?DescriptionFactory $descriptionFactory = null,
         ?TypeContext $context = null
-    ) : self {
+    ): self {
         if (empty($body)) {
             return new static();
         }
@@ -85,7 +85,7 @@ final class Deprecated extends BaseTag implements Factory\StaticMethod
     /**
      * Gets the version section of the tag.
      */
-    public function getVersion() : ?string
+    public function getVersion(): ?string
     {
         return $this->version;
     }
@@ -93,7 +93,7 @@ final class Deprecated extends BaseTag implements Factory\StaticMethod
     /**
      * Returns a string representation for this tag.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->description) {
             $description = $this->description->render();

--- a/src/DocBlock/Tags/Deprecated.php
+++ b/src/DocBlock/Tags/Deprecated.php
@@ -17,6 +17,7 @@ use phpDocumentor\Reflection\DocBlock\Description;
 use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use Webmozart\Assert\Assert;
+
 use function preg_match;
 
 /**

--- a/src/DocBlock/Tags/Example.php
+++ b/src/DocBlock/Tags/Example.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Reflection\DocBlock\Tags;
 
 use phpDocumentor\Reflection\DocBlock\Tag;
 use Webmozart\Assert\Assert;
+
 use function array_key_exists;
 use function preg_match;
 use function rawurlencode;

--- a/src/DocBlock/Tags/Example.php
+++ b/src/DocBlock/Tags/Example.php
@@ -66,7 +66,7 @@ final class Example implements Tag, Factory\StaticMethod
         $this->isURI = $isURI;
     }
 
-    public function getContent() : string
+    public function getContent(): string
     {
         if ($this->content === null || $this->content === '') {
             $filePath = $this->filePath;
@@ -82,12 +82,12 @@ final class Example implements Tag, Factory\StaticMethod
         return $this->content;
     }
 
-    public function getDescription() : ?string
+    public function getDescription(): ?string
     {
         return $this->content;
     }
 
-    public static function create(string $body) : ?Tag
+    public static function create(string $body): ?Tag
     {
         // File component: File path in quotes or File URI / Source information
         if (!preg_match('/^\s*(?:(\"[^\"]+\")|(\S+))(?:\s+(.*))?$/sux', $body, $matches)) {
@@ -137,7 +137,7 @@ final class Example implements Tag, Factory\StaticMethod
      * @return string Path to a file to use as an example.
      *     May also be an absolute URI.
      */
-    public function getFilePath() : string
+    public function getFilePath(): string
     {
         return trim($this->filePath, '"');
     }
@@ -145,7 +145,7 @@ final class Example implements Tag, Factory\StaticMethod
     /**
      * Returns a string representation for this tag.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         $filePath = (string) $this->filePath;
         $isDefaultLine = $this->startingLine === 1 && $this->lineCount === 0;
@@ -168,27 +168,27 @@ final class Example implements Tag, Factory\StaticMethod
     /**
      * Returns true if the provided URI is relative or contains a complete scheme (and thus is absolute).
      */
-    private function isUriRelative(string $uri) : bool
+    private function isUriRelative(string $uri): bool
     {
         return strpos($uri, ':') === false;
     }
 
-    public function getStartingLine() : int
+    public function getStartingLine(): int
     {
         return $this->startingLine;
     }
 
-    public function getLineCount() : int
+    public function getLineCount(): int
     {
         return $this->lineCount;
     }
 
-    public function getName() : string
+    public function getName(): string
     {
         return 'example';
     }
 
-    public function render(?Formatter $formatter = null) : string
+    public function render(?Formatter $formatter = null): string
     {
         if ($formatter === null) {
             $formatter = new Formatter\PassthroughFormatter();

--- a/src/DocBlock/Tags/Formatter.php
+++ b/src/DocBlock/Tags/Formatter.php
@@ -20,5 +20,5 @@ interface Formatter
     /**
      * Formats a tag into a string representation according to a specific format, such as Markdown.
      */
-    public function format(Tag $tag) : string;
+    public function format(Tag $tag): string;
 }

--- a/src/DocBlock/Tags/Formatter/AlignFormatter.php
+++ b/src/DocBlock/Tags/Formatter/AlignFormatter.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Reflection\DocBlock\Tags\Formatter;
 
 use phpDocumentor\Reflection\DocBlock\Tag;
 use phpDocumentor\Reflection\DocBlock\Tags\Formatter;
+
 use function max;
 use function str_repeat;
 use function strlen;

--- a/src/DocBlock/Tags/Formatter/AlignFormatter.php
+++ b/src/DocBlock/Tags/Formatter/AlignFormatter.php
@@ -37,7 +37,7 @@ class AlignFormatter implements Formatter
     /**
      * Formats the given tag to return a simple plain text version.
      */
-    public function format(Tag $tag) : string
+    public function format(Tag $tag): string
     {
         return '@' . $tag->getName() .
             str_repeat(

--- a/src/DocBlock/Tags/Formatter/PassthroughFormatter.php
+++ b/src/DocBlock/Tags/Formatter/PassthroughFormatter.php
@@ -22,7 +22,7 @@ class PassthroughFormatter implements Formatter
     /**
      * Formats the given tag to return a simple plain text version.
      */
-    public function format(Tag $tag) : string
+    public function format(Tag $tag): string
     {
         return trim('@' . $tag->getName() . ' ' . $tag);
     }

--- a/src/DocBlock/Tags/Formatter/PassthroughFormatter.php
+++ b/src/DocBlock/Tags/Formatter/PassthroughFormatter.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Reflection\DocBlock\Tags\Formatter;
 
 use phpDocumentor\Reflection\DocBlock\Tag;
 use phpDocumentor\Reflection\DocBlock\Tags\Formatter;
+
 use function trim;
 
 class PassthroughFormatter implements Formatter

--- a/src/DocBlock/Tags/Generic.php
+++ b/src/DocBlock/Tags/Generic.php
@@ -50,7 +50,7 @@ final class Generic extends BaseTag implements Factory\StaticMethod
         string $name = '',
         ?DescriptionFactory $descriptionFactory = null,
         ?TypeContext $context = null
-    ) : self {
+    ): self {
         Assert::stringNotEmpty($name);
         Assert::notNull($descriptionFactory);
 
@@ -62,7 +62,7 @@ final class Generic extends BaseTag implements Factory\StaticMethod
     /**
      * Returns the tag as a serialized string
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->description) {
             $description = $this->description->render();
@@ -76,7 +76,7 @@ final class Generic extends BaseTag implements Factory\StaticMethod
     /**
      * Validates if the tag name matches the expected format, otherwise throws an exception.
      */
-    private function validateTagName(string $name) : void
+    private function validateTagName(string $name): void
     {
         if (!preg_match('/^' . StandardTagFactory::REGEX_TAGNAME . '$/u', $name)) {
             throw new InvalidArgumentException(

--- a/src/DocBlock/Tags/Generic.php
+++ b/src/DocBlock/Tags/Generic.php
@@ -19,6 +19,7 @@ use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
 use phpDocumentor\Reflection\DocBlock\StandardTagFactory;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use Webmozart\Assert\Assert;
+
 use function preg_match;
 
 /**

--- a/src/DocBlock/Tags/InvalidTag.php
+++ b/src/DocBlock/Tags/InvalidTag.php
@@ -46,22 +46,22 @@ final class InvalidTag implements Tag
         $this->body = $body;
     }
 
-    public function getException() : ?Throwable
+    public function getException(): ?Throwable
     {
         return $this->throwable;
     }
 
-    public function getName() : string
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public static function create(string $body, string $name = '') : self
+    public static function create(string $body, string $name = ''): self
     {
         return new self($name, $body);
     }
 
-    public function withError(Throwable $exception) : self
+    public function withError(Throwable $exception): self
     {
         $this->flattenExceptionBacktrace($exception);
         $tag            = new self($this->name, $this->body);
@@ -76,7 +76,7 @@ final class InvalidTag implements Tag
      * Not all objects are serializable. So we need to remove them from the
      * stored exception to be sure that we do not break existing library usage.
      */
-    private function flattenExceptionBacktrace(Throwable $exception) : void
+    private function flattenExceptionBacktrace(Throwable $exception): void
     {
         $traceProperty = (new ReflectionClass(Exception::class))->getProperty('trace');
         $traceProperty->setAccessible(true);
@@ -85,7 +85,7 @@ final class InvalidTag implements Tag
             $trace = $exception->getTrace();
             if (isset($trace[0]['args'])) {
                 $trace = array_map(
-                    function (array $call) : array {
+                    function (array $call): array {
                         $call['args'] = array_map([$this, 'flattenArguments'], $call['args']);
 
                         return $call;
@@ -128,7 +128,7 @@ final class InvalidTag implements Tag
         return $value;
     }
 
-    public function render(?Formatter $formatter = null) : string
+    public function render(?Formatter $formatter = null): string
     {
         if ($formatter === null) {
             $formatter = new Formatter\PassthroughFormatter();
@@ -137,7 +137,7 @@ final class InvalidTag implements Tag
         return $formatter->format($this);
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         return $this->body;
     }

--- a/src/DocBlock/Tags/InvalidTag.php
+++ b/src/DocBlock/Tags/InvalidTag.php
@@ -11,6 +11,7 @@ use ReflectionClass;
 use ReflectionException;
 use ReflectionFunction;
 use Throwable;
+
 use function array_map;
 use function get_class;
 use function get_resource_type;

--- a/src/DocBlock/Tags/Link.php
+++ b/src/DocBlock/Tags/Link.php
@@ -43,7 +43,7 @@ final class Link extends BaseTag implements Factory\StaticMethod
         string $body,
         ?DescriptionFactory $descriptionFactory = null,
         ?TypeContext $context = null
-    ) : self {
+    ): self {
         Assert::notNull($descriptionFactory);
 
         $parts = Utils::pregSplit('/\s+/Su', $body, 2);
@@ -55,7 +55,7 @@ final class Link extends BaseTag implements Factory\StaticMethod
     /**
      * Gets the link
      */
-    public function getLink() : string
+    public function getLink(): string
     {
         return $this->link;
     }
@@ -63,7 +63,7 @@ final class Link extends BaseTag implements Factory\StaticMethod
     /**
      * Returns a string representation for this tag.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->description) {
             $description = $this->description->render();

--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -86,7 +86,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
         ?TypeResolver $typeResolver = null,
         ?DescriptionFactory $descriptionFactory = null,
         ?TypeContext $context = null
-    ) : ?self {
+    ): ?self {
         Assert::stringNotEmpty($body);
         Assert::notNull($typeResolver);
         Assert::notNull($descriptionFactory);
@@ -176,7 +176,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
     /**
      * Retrieves the method name.
      */
-    public function getMethodName() : string
+    public function getMethodName(): string
     {
         return $this->methodName;
     }
@@ -186,7 +186,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
      *
      * @phpstan-return array<int, array{name: string, type: Type}>
      */
-    public function getArguments() : array
+    public function getArguments(): array
     {
         return $this->arguments;
     }
@@ -196,17 +196,17 @@ final class Method extends BaseTag implements Factory\StaticMethod
      *
      * @return bool TRUE if the method declaration is for a static method, FALSE otherwise.
      */
-    public function isStatic() : bool
+    public function isStatic(): bool
     {
         return $this->isStatic;
     }
 
-    public function getReturnType() : Type
+    public function getReturnType(): Type
     {
         return $this->returnType;
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         $arguments = [];
         foreach ($this->arguments as $argument) {
@@ -242,7 +242,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
      * @phpstan-param array<int, array{name: string, type: Type}|string> $arguments
      * @phpstan-return array<int, array{name: string, type: Type}>
      */
-    private function filterArguments(array $arguments = []) : array
+    private function filterArguments(array $arguments = []): array
     {
         $result = [];
         foreach ($arguments as $argument) {
@@ -268,7 +268,7 @@ final class Method extends BaseTag implements Factory\StaticMethod
         return $result;
     }
 
-    private static function stripRestArg(string $argument) : string
+    private static function stripRestArg(string $argument): string
     {
         if (strpos($argument, '...') === 0) {
             $argument = trim(substr($argument, 3));

--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -22,6 +22,7 @@ use phpDocumentor\Reflection\Types\Context as TypeContext;
 use phpDocumentor\Reflection\Types\Mixed_;
 use phpDocumentor\Reflection\Types\Void_;
 use Webmozart\Assert\Assert;
+
 use function array_keys;
 use function explode;
 use function implode;

--- a/src/DocBlock/Tags/Method.php
+++ b/src/DocBlock/Tags/Method.php
@@ -101,8 +101,9 @@ final class Method extends BaseTag implements Factory\StaticMethod
         // 5. then a word with underscores, followed by ( and any character
         //    until a ) and whitespace : as method name with signature
         // 6. any remaining text : as description
-        if (!preg_match(
-            '/^
+        if (
+            !preg_match(
+                '/^
                 # Static keyword
                 # Declares a static method ONLY if type is also present
                 (?:
@@ -132,9 +133,10 @@ final class Method extends BaseTag implements Factory\StaticMethod
                 # Description
                 (.*)
             $/sux',
-            $body,
-            $matches
-        )) {
+                $body,
+                $matches
+            )
+        ) {
             return null;
         }
 

--- a/src/DocBlock/Tags/Param.php
+++ b/src/DocBlock/Tags/Param.php
@@ -61,7 +61,7 @@ final class Param extends TagWithType implements Factory\StaticMethod
         ?TypeResolver $typeResolver = null,
         ?DescriptionFactory $descriptionFactory = null,
         ?TypeContext $context = null
-    ) : self {
+    ): self {
         Assert::stringNotEmpty($body);
         Assert::notNull($typeResolver);
         Assert::notNull($descriptionFactory);
@@ -114,7 +114,7 @@ final class Param extends TagWithType implements Factory\StaticMethod
     /**
      * Returns the variable's name.
      */
-    public function getVariableName() : ?string
+    public function getVariableName(): ?string
     {
         return $this->variableName;
     }
@@ -122,7 +122,7 @@ final class Param extends TagWithType implements Factory\StaticMethod
     /**
      * Returns whether this tag is variadic.
      */
-    public function isVariadic() : bool
+    public function isVariadic(): bool
     {
         return $this->isVariadic;
     }
@@ -130,7 +130,7 @@ final class Param extends TagWithType implements Factory\StaticMethod
     /**
      * Returns whether this tag is passed by reference.
      */
-    public function isReference() : bool
+    public function isReference(): bool
     {
         return $this->isReference;
     }
@@ -138,7 +138,7 @@ final class Param extends TagWithType implements Factory\StaticMethod
     /**
      * Returns a string representation for this tag.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->description) {
             $description = $this->description->render();
@@ -159,7 +159,7 @@ final class Param extends TagWithType implements Factory\StaticMethod
             . ($description !== '' ? ($type !== '' || $variableName !== '' ? ' ' : '') . $description : '');
     }
 
-    private static function strStartsWithVariable(string $str) : bool
+    private static function strStartsWithVariable(string $str): bool
     {
         return strpos($str, '$') === 0
                ||

--- a/src/DocBlock/Tags/Param.php
+++ b/src/DocBlock/Tags/Param.php
@@ -20,11 +20,13 @@ use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use phpDocumentor\Reflection\Utils;
 use Webmozart\Assert\Assert;
+
 use function array_shift;
 use function array_unshift;
 use function implode;
 use function strpos;
 use function substr;
+
 use const PREG_SPLIT_DELIM_CAPTURE;
 
 /**

--- a/src/DocBlock/Tags/Property.php
+++ b/src/DocBlock/Tags/Property.php
@@ -50,7 +50,7 @@ final class Property extends TagWithType implements Factory\StaticMethod
         ?TypeResolver $typeResolver = null,
         ?DescriptionFactory $descriptionFactory = null,
         ?TypeContext $context = null
-    ) : self {
+    ): self {
         Assert::stringNotEmpty($body);
         Assert::notNull($typeResolver);
         Assert::notNull($descriptionFactory);
@@ -88,7 +88,7 @@ final class Property extends TagWithType implements Factory\StaticMethod
     /**
      * Returns the variable's name.
      */
-    public function getVariableName() : ?string
+    public function getVariableName(): ?string
     {
         return $this->variableName;
     }
@@ -96,7 +96,7 @@ final class Property extends TagWithType implements Factory\StaticMethod
     /**
      * Returns a string representation for this tag.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->description) {
             $description = $this->description->render();

--- a/src/DocBlock/Tags/Property.php
+++ b/src/DocBlock/Tags/Property.php
@@ -20,11 +20,13 @@ use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use phpDocumentor\Reflection\Utils;
 use Webmozart\Assert\Assert;
+
 use function array_shift;
 use function array_unshift;
 use function implode;
 use function strpos;
 use function substr;
+
 use const PREG_SPLIT_DELIM_CAPTURE;
 
 /**

--- a/src/DocBlock/Tags/PropertyRead.php
+++ b/src/DocBlock/Tags/PropertyRead.php
@@ -50,7 +50,7 @@ final class PropertyRead extends TagWithType implements Factory\StaticMethod
         ?TypeResolver $typeResolver = null,
         ?DescriptionFactory $descriptionFactory = null,
         ?TypeContext $context = null
-    ) : self {
+    ): self {
         Assert::stringNotEmpty($body);
         Assert::notNull($typeResolver);
         Assert::notNull($descriptionFactory);
@@ -88,7 +88,7 @@ final class PropertyRead extends TagWithType implements Factory\StaticMethod
     /**
      * Returns the variable's name.
      */
-    public function getVariableName() : ?string
+    public function getVariableName(): ?string
     {
         return $this->variableName;
     }
@@ -96,7 +96,7 @@ final class PropertyRead extends TagWithType implements Factory\StaticMethod
     /**
      * Returns a string representation for this tag.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->description) {
             $description = $this->description->render();

--- a/src/DocBlock/Tags/PropertyRead.php
+++ b/src/DocBlock/Tags/PropertyRead.php
@@ -20,11 +20,13 @@ use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use phpDocumentor\Reflection\Utils;
 use Webmozart\Assert\Assert;
+
 use function array_shift;
 use function array_unshift;
 use function implode;
 use function strpos;
 use function substr;
+
 use const PREG_SPLIT_DELIM_CAPTURE;
 
 /**

--- a/src/DocBlock/Tags/PropertyWrite.php
+++ b/src/DocBlock/Tags/PropertyWrite.php
@@ -50,7 +50,7 @@ final class PropertyWrite extends TagWithType implements Factory\StaticMethod
         ?TypeResolver $typeResolver = null,
         ?DescriptionFactory $descriptionFactory = null,
         ?TypeContext $context = null
-    ) : self {
+    ): self {
         Assert::stringNotEmpty($body);
         Assert::notNull($typeResolver);
         Assert::notNull($descriptionFactory);
@@ -88,7 +88,7 @@ final class PropertyWrite extends TagWithType implements Factory\StaticMethod
     /**
      * Returns the variable's name.
      */
-    public function getVariableName() : ?string
+    public function getVariableName(): ?string
     {
         return $this->variableName;
     }
@@ -96,7 +96,7 @@ final class PropertyWrite extends TagWithType implements Factory\StaticMethod
     /**
      * Returns a string representation for this tag.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->description) {
             $description = $this->description->render();

--- a/src/DocBlock/Tags/PropertyWrite.php
+++ b/src/DocBlock/Tags/PropertyWrite.php
@@ -20,11 +20,13 @@ use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use phpDocumentor\Reflection\Utils;
 use Webmozart\Assert\Assert;
+
 use function array_shift;
 use function array_unshift;
 use function implode;
 use function strpos;
 use function substr;
+
 use const PREG_SPLIT_DELIM_CAPTURE;
 
 /**

--- a/src/DocBlock/Tags/Reference/Fqsen.php
+++ b/src/DocBlock/Tags/Reference/Fqsen.php
@@ -31,7 +31,7 @@ final class Fqsen implements Reference
     /**
      * @return string string representation of the referenced fqsen
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return (string) $this->fqsen;
     }

--- a/src/DocBlock/Tags/Reference/Reference.php
+++ b/src/DocBlock/Tags/Reference/Reference.php
@@ -18,5 +18,5 @@ namespace phpDocumentor\Reflection\DocBlock\Tags\Reference;
  */
 interface Reference
 {
-    public function __toString() : string;
+    public function __toString(): string;
 }

--- a/src/DocBlock/Tags/Reference/Url.php
+++ b/src/DocBlock/Tags/Reference/Url.php
@@ -29,7 +29,7 @@ final class Url implements Reference
         $this->uri = $uri;
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         return $this->uri;
     }

--- a/src/DocBlock/Tags/Return_.php
+++ b/src/DocBlock/Tags/Return_.php
@@ -37,7 +37,7 @@ final class Return_ extends TagWithType implements Factory\StaticMethod
         ?TypeResolver $typeResolver = null,
         ?DescriptionFactory $descriptionFactory = null,
         ?TypeContext $context = null
-    ) : self {
+    ): self {
         Assert::notNull($typeResolver);
         Assert::notNull($descriptionFactory);
 
@@ -49,7 +49,7 @@ final class Return_ extends TagWithType implements Factory\StaticMethod
         return new static($type, $description);
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->description) {
             $description = $this->description->render();

--- a/src/DocBlock/Tags/See.php
+++ b/src/DocBlock/Tags/See.php
@@ -52,7 +52,7 @@ final class See extends BaseTag implements Factory\StaticMethod
         ?FqsenResolver $typeResolver = null,
         ?DescriptionFactory $descriptionFactory = null,
         ?TypeContext $context = null
-    ) : self {
+    ): self {
         Assert::notNull($descriptionFactory);
 
         $parts = Utils::pregSplit('/\s+/Su', $body, 2);
@@ -66,7 +66,7 @@ final class See extends BaseTag implements Factory\StaticMethod
         return new static(new FqsenRef(self::resolveFqsen($parts[0], $typeResolver, $context)), $description);
     }
 
-    private static function resolveFqsen(string $parts, ?FqsenResolver $fqsenResolver, ?TypeContext $context) : Fqsen
+    private static function resolveFqsen(string $parts, ?FqsenResolver $fqsenResolver, ?TypeContext $context): Fqsen
     {
         Assert::notNull($fqsenResolver);
         $fqsenParts = explode('::', $parts);
@@ -82,7 +82,7 @@ final class See extends BaseTag implements Factory\StaticMethod
     /**
      * Returns the ref of this tag.
      */
-    public function getReference() : Reference
+    public function getReference(): Reference
     {
         return $this->refers;
     }
@@ -90,7 +90,7 @@ final class See extends BaseTag implements Factory\StaticMethod
     /**
      * Returns a string representation of this tag.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->description) {
             $description = $this->description->render();

--- a/src/DocBlock/Tags/See.php
+++ b/src/DocBlock/Tags/See.php
@@ -23,6 +23,7 @@ use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use phpDocumentor\Reflection\Utils;
 use Webmozart\Assert\Assert;
+
 use function array_key_exists;
 use function explode;
 use function preg_match;

--- a/src/DocBlock/Tags/Since.php
+++ b/src/DocBlock/Tags/Since.php
@@ -58,7 +58,7 @@ final class Since extends BaseTag implements Factory\StaticMethod
         ?string $body,
         ?DescriptionFactory $descriptionFactory = null,
         ?TypeContext $context = null
-    ) : ?self {
+    ): ?self {
         if (empty($body)) {
             return new static();
         }
@@ -79,7 +79,7 @@ final class Since extends BaseTag implements Factory\StaticMethod
     /**
      * Gets the version section of the tag.
      */
-    public function getVersion() : ?string
+    public function getVersion(): ?string
     {
         return $this->version;
     }
@@ -87,7 +87,7 @@ final class Since extends BaseTag implements Factory\StaticMethod
     /**
      * Returns a string representation for this tag.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->description) {
             $description = $this->description->render();

--- a/src/DocBlock/Tags/Since.php
+++ b/src/DocBlock/Tags/Since.php
@@ -17,6 +17,7 @@ use phpDocumentor\Reflection\DocBlock\Description;
 use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use Webmozart\Assert\Assert;
+
 use function preg_match;
 
 /**

--- a/src/DocBlock/Tags/Source.php
+++ b/src/DocBlock/Tags/Source.php
@@ -51,7 +51,7 @@ final class Source extends BaseTag implements Factory\StaticMethod
         string $body,
         ?DescriptionFactory $descriptionFactory = null,
         ?TypeContext $context = null
-    ) : self {
+    ): self {
         Assert::stringNotEmpty($body);
         Assert::notNull($descriptionFactory);
 
@@ -78,7 +78,7 @@ final class Source extends BaseTag implements Factory\StaticMethod
      * @return int The starting line, relative to the structural element's
      *     location.
      */
-    public function getStartingLine() : int
+    public function getStartingLine(): int
     {
         return $this->startingLine;
     }
@@ -89,12 +89,12 @@ final class Source extends BaseTag implements Factory\StaticMethod
      * @return int|null The number of lines, relative to the starting line. NULL
      *     means "to the end".
      */
-    public function getLineCount() : ?int
+    public function getLineCount(): ?int
     {
         return $this->lineCount;
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->description) {
             $description = $this->description->render();

--- a/src/DocBlock/Tags/Source.php
+++ b/src/DocBlock/Tags/Source.php
@@ -17,6 +17,7 @@ use phpDocumentor\Reflection\DocBlock\Description;
 use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use Webmozart\Assert\Assert;
+
 use function preg_match;
 
 /**

--- a/src/DocBlock/Tags/Source.php
+++ b/src/DocBlock/Tags/Source.php
@@ -70,7 +70,7 @@ final class Source extends BaseTag implements Factory\StaticMethod
             $description = $matches[3];
         }
 
-        return new static($startingLine, $lineCount, $descriptionFactory->create($description??'', $context));
+        return new static($startingLine, $lineCount, $descriptionFactory->create($description ?? '', $context));
     }
 
     /**

--- a/src/DocBlock/Tags/TagWithType.php
+++ b/src/DocBlock/Tags/TagWithType.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\DocBlock\Tags;
 
 use phpDocumentor\Reflection\Type;
+
 use function in_array;
 use function strlen;
 use function substr;

--- a/src/DocBlock/Tags/TagWithType.php
+++ b/src/DocBlock/Tags/TagWithType.php
@@ -27,7 +27,7 @@ abstract class TagWithType extends BaseTag
     /**
      * Returns the type section of the variable.
      */
-    public function getType() : ?Type
+    public function getType(): ?Type
     {
         return $this->type;
     }
@@ -35,7 +35,7 @@ abstract class TagWithType extends BaseTag
     /**
      * @return string[]
      */
-    protected static function extractTypeFromBody(string $body) : array
+    protected static function extractTypeFromBody(string $body): array
     {
         $type         = '';
         $nestingLevel = 0;

--- a/src/DocBlock/Tags/Throws.php
+++ b/src/DocBlock/Tags/Throws.php
@@ -37,7 +37,7 @@ final class Throws extends TagWithType implements Factory\StaticMethod
         ?TypeResolver $typeResolver = null,
         ?DescriptionFactory $descriptionFactory = null,
         ?TypeContext $context = null
-    ) : self {
+    ): self {
         Assert::notNull($typeResolver);
         Assert::notNull($descriptionFactory);
 
@@ -49,7 +49,7 @@ final class Throws extends TagWithType implements Factory\StaticMethod
         return new static($type, $description);
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->description) {
             $description = $this->description->render();

--- a/src/DocBlock/Tags/Uses.php
+++ b/src/DocBlock/Tags/Uses.php
@@ -48,7 +48,7 @@ final class Uses extends BaseTag implements Factory\StaticMethod
         ?FqsenResolver $resolver = null,
         ?DescriptionFactory $descriptionFactory = null,
         ?TypeContext $context = null
-    ) : self {
+    ): self {
         Assert::notNull($resolver);
         Assert::notNull($descriptionFactory);
 
@@ -60,7 +60,7 @@ final class Uses extends BaseTag implements Factory\StaticMethod
         );
     }
 
-    private static function resolveFqsen(string $parts, ?FqsenResolver $fqsenResolver, ?TypeContext $context) : Fqsen
+    private static function resolveFqsen(string $parts, ?FqsenResolver $fqsenResolver, ?TypeContext $context): Fqsen
     {
         Assert::notNull($fqsenResolver);
         $fqsenParts = explode('::', $parts);
@@ -76,7 +76,7 @@ final class Uses extends BaseTag implements Factory\StaticMethod
     /**
      * Returns the structural element this tag refers to.
      */
-    public function getReference() : Fqsen
+    public function getReference(): Fqsen
     {
         return $this->refers;
     }
@@ -84,7 +84,7 @@ final class Uses extends BaseTag implements Factory\StaticMethod
     /**
      * Returns a string representation of this tag.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->description) {
             $description = $this->description->render();

--- a/src/DocBlock/Tags/Uses.php
+++ b/src/DocBlock/Tags/Uses.php
@@ -20,6 +20,7 @@ use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use phpDocumentor\Reflection\Utils;
 use Webmozart\Assert\Assert;
+
 use function array_key_exists;
 use function explode;
 

--- a/src/DocBlock/Tags/Var_.php
+++ b/src/DocBlock/Tags/Var_.php
@@ -50,7 +50,7 @@ final class Var_ extends TagWithType implements Factory\StaticMethod
         ?TypeResolver $typeResolver = null,
         ?DescriptionFactory $descriptionFactory = null,
         ?TypeContext $context = null
-    ) : self {
+    ): self {
         Assert::stringNotEmpty($body);
         Assert::notNull($typeResolver);
         Assert::notNull($descriptionFactory);
@@ -89,7 +89,7 @@ final class Var_ extends TagWithType implements Factory\StaticMethod
     /**
      * Returns the variable's name.
      */
-    public function getVariableName() : ?string
+    public function getVariableName(): ?string
     {
         return $this->variableName;
     }
@@ -97,7 +97,7 @@ final class Var_ extends TagWithType implements Factory\StaticMethod
     /**
      * Returns a string representation for this tag.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->description) {
             $description = $this->description->render();

--- a/src/DocBlock/Tags/Var_.php
+++ b/src/DocBlock/Tags/Var_.php
@@ -20,11 +20,13 @@ use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use phpDocumentor\Reflection\Utils;
 use Webmozart\Assert\Assert;
+
 use function array_shift;
 use function array_unshift;
 use function implode;
 use function strpos;
 use function substr;
+
 use const PREG_SPLIT_DELIM_CAPTURE;
 
 /**

--- a/src/DocBlock/Tags/Version.php
+++ b/src/DocBlock/Tags/Version.php
@@ -17,6 +17,7 @@ use phpDocumentor\Reflection\DocBlock\Description;
 use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
 use phpDocumentor\Reflection\Types\Context as TypeContext;
 use Webmozart\Assert\Assert;
+
 use function preg_match;
 
 /**

--- a/src/DocBlock/Tags/Version.php
+++ b/src/DocBlock/Tags/Version.php
@@ -58,7 +58,7 @@ final class Version extends BaseTag implements Factory\StaticMethod
         ?string $body,
         ?DescriptionFactory $descriptionFactory = null,
         ?TypeContext $context = null
-    ) : ?self {
+    ): ?self {
         if (empty($body)) {
             return new static();
         }
@@ -82,7 +82,7 @@ final class Version extends BaseTag implements Factory\StaticMethod
     /**
      * Gets the version section of the tag.
      */
-    public function getVersion() : ?string
+    public function getVersion(): ?string
     {
         return $this->version;
     }
@@ -90,7 +90,7 @@ final class Version extends BaseTag implements Factory\StaticMethod
     /**
      * Returns a string representation for this tag.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->description) {
             $description = $this->description->render();

--- a/src/DocBlockFactory.php
+++ b/src/DocBlockFactory.php
@@ -20,6 +20,7 @@ use phpDocumentor\Reflection\DocBlock\StandardTagFactory;
 use phpDocumentor\Reflection\DocBlock\Tag;
 use phpDocumentor\Reflection\DocBlock\TagFactory;
 use Webmozart\Assert\Assert;
+
 use function array_shift;
 use function count;
 use function explode;

--- a/src/DocBlockFactory.php
+++ b/src/DocBlockFactory.php
@@ -54,7 +54,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
      *
      * @param array<string, class-string<Tag>> $additionalTags
      */
-    public static function createInstance(array $additionalTags = []) : self
+    public static function createInstance(array $additionalTags = []): self
     {
         $fqsenResolver      = new FqsenResolver();
         $tagFactory         = new StandardTagFactory($fqsenResolver);
@@ -75,7 +75,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
      * @param object|string $docblock A string containing the DocBlock to parse or an object supporting the
      *                                getDocComment method (such as a ReflectionClass object).
      */
-    public function create($docblock, ?Types\Context $context = null, ?Location $location = null) : DocBlock
+    public function create($docblock, ?Types\Context $context = null, ?Location $location = null): DocBlock
     {
         if (is_object($docblock)) {
             if (!method_exists($docblock, 'getDocComment')) {
@@ -112,7 +112,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
     /**
      * @param class-string<Tag> $handler
      */
-    public function registerTagHandler(string $tagName, string $handler) : void
+    public function registerTagHandler(string $tagName, string $handler): void
     {
         $this->tagFactory->registerTagHandler($tagName, $handler);
     }
@@ -122,7 +122,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
      *
      * @param string $comment String containing the comment text.
      */
-    private function stripDocComment(string $comment) : string
+    private function stripDocComment(string $comment): string
     {
         $comment = preg_replace('#[ \t]*(?:\/\*\*|\*\/|\*)?[ \t]?(.*)?#u', '$1', $comment);
         Assert::string($comment);
@@ -231,7 +231,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
      *
      * @return DocBlock\Tag[]
      */
-    private function parseTagBlock(string $tags, Types\Context $context) : array
+    private function parseTagBlock(string $tags, Types\Context $context): array
     {
         $tags = $this->filterTagBlock($tags);
         if ($tags === null) {
@@ -250,7 +250,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
     /**
      * @return string[]
      */
-    private function splitTagBlockIntoTagLines(string $tags) : array
+    private function splitTagBlockIntoTagLines(string $tags): array
     {
         $result = [];
         foreach (explode("\n", $tags) as $tagLine) {
@@ -264,7 +264,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
         return $result;
     }
 
-    private function filterTagBlock(string $tags) : ?string
+    private function filterTagBlock(string $tags): ?string
     {
         $tags = trim($tags);
         if (!$tags) {

--- a/src/DocBlockFactoryInterface.php
+++ b/src/DocBlockFactoryInterface.php
@@ -14,10 +14,10 @@ interface DocBlockFactoryInterface
      *
      * @param array<string, class-string<Tag>> $additionalTags
      */
-    public static function createInstance(array $additionalTags = []) : DocBlockFactory;
+    public static function createInstance(array $additionalTags = []): DocBlockFactory;
 
     /**
      * @param string|object $docblock
      */
-    public function create($docblock, ?Types\Context $context = null, ?Location $location = null) : DocBlock;
+    public function create($docblock, ?Types\Context $context = null, ?Location $location = null): DocBlock;
 }

--- a/src/Exception/PcreException.php
+++ b/src/Exception/PcreException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\Exception;
 
 use InvalidArgumentException;
+
 use const PREG_BACKTRACK_LIMIT_ERROR;
 use const PREG_BAD_UTF8_ERROR;
 use const PREG_BAD_UTF8_OFFSET_ERROR;

--- a/src/Exception/PcreException.php
+++ b/src/Exception/PcreException.php
@@ -15,7 +15,7 @@ use const PREG_RECURSION_LIMIT_ERROR;
 
 final class PcreException extends InvalidArgumentException
 {
-    public static function createFromPhpError(int $errorCode) : self
+    public static function createFromPhpError(int $errorCode): self
     {
         switch ($errorCode) {
             case PREG_BACKTRACK_LIMIT_ERROR:

--- a/src/Exception/PcreException.php
+++ b/src/Exception/PcreException.php
@@ -21,14 +21,19 @@ final class PcreException extends InvalidArgumentException
         switch ($errorCode) {
             case PREG_BACKTRACK_LIMIT_ERROR:
                 return new self('Backtrack limit error');
+
             case PREG_RECURSION_LIMIT_ERROR:
                 return new self('Recursion limit error');
+
             case PREG_BAD_UTF8_ERROR:
                 return new self('Bad UTF8 error');
+
             case PREG_BAD_UTF8_OFFSET_ERROR:
                 return new self('Bad UTF8 offset error');
+
             case PREG_JIT_STACKLIMIT_ERROR:
                 return new self('Jit stacklimit error');
+
             case PREG_NO_ERROR:
             case PREG_INTERNAL_ERROR:
             default:

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection;
 
 use phpDocumentor\Reflection\Exception\PcreException;
+
 use function preg_last_error;
 use function preg_split as php_preg_split;
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -45,7 +45,7 @@ abstract class Utils
      *
      * @throws PcreException
      */
-    public static function pregSplit(string $pattern, string $subject, ?int $limit = -1, int $flags = 0) : array
+    public static function pregSplit(string $pattern, string $subject, ?int $limit = -1, int $flags = 0): array
     {
         $parts = php_preg_split($pattern, $subject, $limit, $flags);
         if ($parts === false) {

--- a/tests/unit/DocBlock/DescriptionFactoryTest.php
+++ b/tests/unit/DocBlock/DescriptionFactoryTest.php
@@ -29,7 +29,7 @@ class DescriptionFactoryTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -41,7 +41,7 @@ class DescriptionFactoryTest extends TestCase
      * @covers ::create
      * @dataProvider provideSimpleExampleDescriptions
      */
-    public function testDescriptionCanParseASimpleString(string $contents) : void
+    public function testDescriptionCanParseASimpleString(string $contents): void
     {
         $tagFactory = m::mock(TagFactory::class);
         $tagFactory->shouldReceive('create')->never();
@@ -59,7 +59,7 @@ class DescriptionFactoryTest extends TestCase
      * @covers ::create
      * @dataProvider provideEscapeSequences
      */
-    public function testEscapeSequences(string $contents, string $expected) : void
+    public function testEscapeSequences(string $contents, string $expected): void
     {
         $tagFactory = m::mock(TagFactory::class);
         $tagFactory->shouldReceive('create')->never();
@@ -80,7 +80,7 @@ class DescriptionFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::create
      */
-    public function testDescriptionCanParseAStringWithInlineTag() : void
+    public function testDescriptionCanParseAStringWithInlineTag(): void
     {
         $contents   = 'This is text for a {@link http://phpdoc.org/ description} that uses an inline tag.';
         $context    = new Context('');
@@ -106,7 +106,7 @@ class DescriptionFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::create
      */
-    public function testDescriptionCanParseAStringStartingWithInlineTag() : void
+    public function testDescriptionCanParseAStringStartingWithInlineTag(): void
     {
         $contents   = '{@link http://phpdoc.org/ This} is text for a description that starts with an inline tag.';
         $context    = new Context('');
@@ -132,7 +132,7 @@ class DescriptionFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::create
      */
-    public function testDescriptionCanParseAStringContainingMultipleTags() : void
+    public function testDescriptionCanParseAStringContainingMultipleTags(): void
     {
         $contents   = 'This description has a {@link http://phpdoc.org/ This} another {@link http://phpdoc.org/ This2}';
         $context    = new Context('');
@@ -159,7 +159,7 @@ class DescriptionFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::create
      */
-    public function testIfSuperfluousStartingSpacesAreRemoved() : void
+    public function testIfSuperfluousStartingSpacesAreRemoved(): void
     {
         $factory         = new DescriptionFactory(m::mock(TagFactory::class));
         $descriptionText = <<<DESCRIPTION
@@ -204,7 +204,7 @@ DESCRIPTION;
      * @covers ::__construct
      * @covers ::create
      */
-    public function testDescriptionWithBrokenInlineTags() : void
+    public function testDescriptionWithBrokenInlineTags(): void
     {
         $contents   = 'This {@see $name} is a broken use case, but used in real life.';
         $context    = new Context('');
@@ -225,7 +225,7 @@ DESCRIPTION;
      *
      * @return string[][]
      */
-    public function provideSimpleExampleDescriptions() : array
+    public function provideSimpleExampleDescriptions(): array
     {
         return [
             ['This is text for a description.'],
@@ -238,7 +238,7 @@ DESCRIPTION;
     /**
      * @return string[][]
      */
-    public function provideEscapeSequences() : array
+    public function provideEscapeSequences(): array
     {
         return [
             ['This is text for a description with a {@}.', 'This is text for a description with a @.'],

--- a/tests/unit/DocBlock/DescriptionTest.php
+++ b/tests/unit/DocBlock/DescriptionTest.php
@@ -26,7 +26,7 @@ class DescriptionTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -39,7 +39,7 @@ class DescriptionTest extends TestCase
      * @covers ::__construct
      * @covers ::render
      */
-    public function testDescriptionCanRenderUsingABodyWithPlaceholdersAndTags() : void
+    public function testDescriptionCanRenderUsingABodyWithPlaceholdersAndTags(): void
     {
         $body     = 'This is a %1$s body.';
         $expected = 'This is a {@internal significant} body.';
@@ -65,7 +65,7 @@ class DescriptionTest extends TestCase
      * @covers ::render
      * @covers ::__toString
      */
-    public function testDescriptionCanBeCastToString() : void
+    public function testDescriptionCanBeCastToString(): void
     {
         $body     = 'This is a %1$s body.';
         $expected = 'This is a {@internal significant} body.';
@@ -82,7 +82,7 @@ class DescriptionTest extends TestCase
      *
      * @covers ::getTags
      */
-    public function testDescriptionTagsGetter() : void
+    public function testDescriptionTagsGetter(): void
     {
         $body = '@JoinTable(name="table", joinColumns=%1$s, inverseJoinColumns=%2$s)';
 
@@ -107,7 +107,7 @@ class DescriptionTest extends TestCase
     /**
      * @covers ::getBodyTemplate
      */
-    public function testDescriptionBodyTemplateGetter() : void
+    public function testDescriptionBodyTemplateGetter(): void
     {
         $body = 'See https://github.com/phpDocumentor/ReflectionDocBlock/pull/171 for more information';
 
@@ -125,7 +125,7 @@ class DescriptionTest extends TestCase
      * @covers ::render
      * @covers ::__toString
      */
-    public function testDescriptionMultipleTagsCanBeCastToString() : void
+    public function testDescriptionMultipleTagsCanBeCastToString(): void
     {
         $body = '@JoinTable(name="table", joinColumns=%1$s, inverseJoinColumns=%2$s)';
 

--- a/tests/unit/DocBlock/ExampleFinderTest.php
+++ b/tests/unit/DocBlock/ExampleFinderTest.php
@@ -20,12 +20,12 @@ class ExampleFinderTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
 
-    public function setUp() : void
+    public function setUp(): void
     {
         $this->fixture = new ExampleFinder();
     }
@@ -37,7 +37,7 @@ class ExampleFinderTest extends TestCase
      * @covers ::find
      * @covers ::getSourceDirectory
      */
-    public function testFileNotFound() : void
+    public function testFileNotFound(): void
     {
         $example = new Example('./example.php', false, 1, 0, 'Test');
         $this->assertSame('** File not found : ./example.php **', $this->fixture->find($example));

--- a/tests/unit/DocBlock/SerializerTest.php
+++ b/tests/unit/DocBlock/SerializerTest.php
@@ -26,7 +26,7 @@ class SerializerTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -41,7 +41,7 @@ class SerializerTest extends TestCase
      * @covers ::__construct
      * @covers ::getDocComment
      */
-    public function testReconstructsADocCommentFromADocBlock() : void
+    public function testReconstructsADocCommentFromADocBlock(): void
     {
         $expected = <<<'DOCCOMMENT'
 /**
@@ -76,7 +76,7 @@ DOCCOMMENT;
      * @covers ::__construct
      * @covers ::getDocComment
      */
-    public function testAddPrefixToDocBlock() : void
+    public function testAddPrefixToDocBlock(): void
     {
         $expected = <<<'DOCCOMMENT'
 aa/**
@@ -111,7 +111,7 @@ DOCCOMMENT;
      * @covers ::__construct
      * @covers ::getDocComment
      */
-    public function testAddPrefixToDocBlockExceptFirstLine() : void
+    public function testAddPrefixToDocBlockExceptFirstLine(): void
     {
         $expected = <<<'DOCCOMMENT'
 /**
@@ -146,7 +146,7 @@ DOCCOMMENT;
      * @covers ::__construct
      * @covers ::getDocComment
      */
-    public function testWordwrapsAroundTheGivenAmountOfCharacters() : void
+    public function testWordwrapsAroundTheGivenAmountOfCharacters(): void
     {
         $expected = <<<'DOCCOMMENT'
 /**
@@ -181,7 +181,7 @@ DOCCOMMENT;
      * @covers ::__construct
      * @covers ::getDocComment
      */
-    public function testNoExtraSpacesAfterTagRemoval() : void
+    public function testNoExtraSpacesAfterTagRemoval(): void
     {
         $expected = <<<'DOCCOMMENT'
 /**

--- a/tests/unit/DocBlock/StandardTagFactoryTest.php
+++ b/tests/unit/DocBlock/StandardTagFactoryTest.php
@@ -40,7 +40,7 @@ class StandardTagFactoryTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -54,7 +54,7 @@ class StandardTagFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::create
      */
-    public function testCreatingAGenericTag() : void
+    public function testCreatingAGenericTag(): void
     {
         $expectedTagName         = 'unknown-tag';
         $expectedDescriptionText = 'This is a description';
@@ -87,7 +87,7 @@ class StandardTagFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::create
      */
-    public function testCreatingAGenericTagWithDescriptionText() : void
+    public function testCreatingAGenericTagWithDescriptionText(): void
     {
         $expectedTagName         = 'unknown-tag';
         $expectedDescriptionText = ' foo Bar 123 ';
@@ -110,7 +110,7 @@ class StandardTagFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::create
      */
-    public function testCreatingASpecificTag() : void
+    public function testCreatingASpecificTag(): void
     {
         $context    = new Context('');
         $tagFactory = new StandardTagFactory(m::mock(FqsenResolver::class));
@@ -131,7 +131,7 @@ class StandardTagFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::create
      */
-    public function testAnEmptyContextIsCreatedIfNoneIsProvided() : void
+    public function testAnEmptyContextIsCreatedIfNoneIsProvided(): void
     {
         $fqsen              = '\Tag';
         $resolver           = m::mock(FqsenResolver::class)
@@ -159,7 +159,7 @@ class StandardTagFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::create
      */
-    public function testPassingYourOwnSetOfTagHandlers() : void
+    public function testPassingYourOwnSetOfTagHandlers(): void
     {
         $context    = new Context('');
         $tagFactory = new StandardTagFactory(m::mock(FqsenResolver::class), ['user' => Author::class]);
@@ -178,7 +178,7 @@ class StandardTagFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::create
      */
-    public function testPassingYourOwnSetOfTagHandlersWithGermanChars() : void
+    public function testPassingYourOwnSetOfTagHandlersWithGermanChars(): void
     {
         $typeResolver       = new TypeResolver();
         $fqsenResolver      = new FqsenResolver();
@@ -206,7 +206,7 @@ class StandardTagFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::create
      */
-    public function testPassingYourOwnSetOfTagHandlersWithoutComment() : void
+    public function testPassingYourOwnSetOfTagHandlersWithoutComment(): void
     {
         $typeResolver       = new TypeResolver();
         $fqsenResolver      = new FqsenResolver();
@@ -233,7 +233,7 @@ class StandardTagFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::create
      */
-    public function testPassingYourOwnSetOfTagHandlersWithEmptyComment() : void
+    public function testPassingYourOwnSetOfTagHandlersWithEmptyComment(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage(
@@ -260,7 +260,7 @@ class StandardTagFactoryTest extends TestCase
      *
      * @covers ::create
      */
-    public function testExceptionIsThrownIfProvidedTagIsNotWellformed() : void
+    public function testExceptionIsThrownIfProvidedTagIsNotWellformed(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage(
@@ -276,7 +276,7 @@ class StandardTagFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::addParameter
      */
-    public function testAddParameterToServiceLocator() : void
+    public function testAddParameterToServiceLocator(): void
     {
         $resolver   = m::mock(FqsenResolver::class);
         $tagFactory = new StandardTagFactory($resolver);
@@ -294,7 +294,7 @@ class StandardTagFactoryTest extends TestCase
      *
      * @covers ::addService
      */
-    public function testAddServiceToServiceLocator() : void
+    public function testAddServiceToServiceLocator(): void
     {
         $service = new PassthroughFormatter();
 
@@ -313,7 +313,7 @@ class StandardTagFactoryTest extends TestCase
      *
      * @covers ::addService
      */
-    public function testInjectConcreteServiceForInterfaceToServiceLocator() : void
+    public function testInjectConcreteServiceForInterfaceToServiceLocator(): void
     {
         $interfaceName = Formatter::class;
         $service       = new PassthroughFormatter();
@@ -336,7 +336,7 @@ class StandardTagFactoryTest extends TestCase
      *
      * @covers ::registerTagHandler
      */
-    public function testRegisteringAHandlerForANewTag() : void
+    public function testRegisteringAHandlerForANewTag(): void
     {
         $resolver   = m::mock(FqsenResolver::class);
         $tagFactory = new StandardTagFactory($resolver);
@@ -354,7 +354,7 @@ class StandardTagFactoryTest extends TestCase
      *
      * @covers ::registerTagHandler
      */
-    public function testHandlerRegistrationFailsIfProvidedTagNameIsNamespaceButNotFullyQualified() : void
+    public function testHandlerRegistrationFailsIfProvidedTagNameIsNamespaceButNotFullyQualified(): void
     {
         $this->expectException('InvalidArgumentException');
         $resolver   = m::mock(FqsenResolver::class);
@@ -369,7 +369,7 @@ class StandardTagFactoryTest extends TestCase
      *
      * @covers ::registerTagHandler
      */
-    public function testHandlerRegistrationFailsIfProvidedHandlerIsEmpty() : void
+    public function testHandlerRegistrationFailsIfProvidedHandlerIsEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         $resolver   = m::mock(FqsenResolver::class);
@@ -383,7 +383,7 @@ class StandardTagFactoryTest extends TestCase
      *
      * @covers ::registerTagHandler
      */
-    public function testHandlerRegistrationFailsIfProvidedHandlerIsNotAnExistingClassName() : void
+    public function testHandlerRegistrationFailsIfProvidedHandlerIsNotAnExistingClassName(): void
     {
         $this->expectException('InvalidArgumentException');
         $resolver   = m::mock(FqsenResolver::class);
@@ -397,7 +397,7 @@ class StandardTagFactoryTest extends TestCase
      *
      * @covers ::registerTagHandler
      */
-    public function testHandlerRegistrationFailsIfProvidedHandlerDoesNotImplementTheTagInterface() : void
+    public function testHandlerRegistrationFailsIfProvidedHandlerDoesNotImplementTheTagInterface(): void
     {
         $this->expectException('InvalidArgumentException');
         $resolver   = m::mock(FqsenResolver::class);
@@ -414,7 +414,7 @@ class StandardTagFactoryTest extends TestCase
      *
      * @covers ::create
      */
-    public function testReturnTagIsMappedCorrectly() : void
+    public function testReturnTagIsMappedCorrectly(): void
     {
         $context = new Context('');
 
@@ -437,7 +437,7 @@ class StandardTagFactoryTest extends TestCase
         $this->assertSame('return', $tag->getName());
     }
 
-    public function testInvalidTagIsReturnedOnFailure() : void
+    public function testInvalidTagIsReturnedOnFailure(): void
     {
         $tagFactory = new StandardTagFactory(m::mock(FqsenResolver::class));
 
@@ -449,7 +449,7 @@ class StandardTagFactoryTest extends TestCase
     /**
      * @dataProvider validTagProvider
      */
-    public function testValidFormattedTags(string $input, string $tagName, string $render) : void
+    public function testValidFormattedTags(string $input, string $tagName, string $render): void
     {
         $fqsenResolver = m::mock(FqsenResolver::class);
         $tagFactory = new StandardTagFactory($fqsenResolver);
@@ -465,7 +465,7 @@ class StandardTagFactoryTest extends TestCase
      *
      * @phpstan-return array<string, array<int, string>>
      */
-    public function validTagProvider() : array
+    public function validTagProvider(): array
     {
         //rendered result is adding a space, because the tags are not rendered properly.
         return [
@@ -515,7 +515,7 @@ class StandardTagFactoryTest extends TestCase
     /**
      * @dataProvider invalidTagProvider
      */
-    public function testInValidFormattedTags(string $input) : void
+    public function testInValidFormattedTags(string $input): void
     {
         $this->expectException(InvalidArgumentException::class);
         $fqsenResolver = m::mock(FqsenResolver::class);
@@ -529,7 +529,7 @@ class StandardTagFactoryTest extends TestCase
      *
      * @phpstan-return list<array<int, string>>
      */
-    public function invalidTagProvider() : array
+    public function invalidTagProvider(): array
     {
         return [
             ['@tag[invalid]'],

--- a/tests/unit/DocBlock/Tags/AuthorTest.php
+++ b/tests/unit/DocBlock/Tags/AuthorTest.php
@@ -25,7 +25,7 @@ class AuthorTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -35,7 +35,7 @@ class AuthorTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned() : void
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Author('Mike van Riel', 'mike@phpdoc.org');
 
@@ -50,7 +50,7 @@ class AuthorTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter() : void
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Author('Mike van Riel', 'mike@phpdoc.org');
 
@@ -62,7 +62,7 @@ class AuthorTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter() : void
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Author('Mike van Riel', 'mike@phpdoc.org');
 
@@ -76,7 +76,7 @@ class AuthorTest extends TestCase
      * @covers ::__construct
      * @covers ::getAuthorName
      */
-    public function testHasTheAuthorName() : void
+    public function testHasTheAuthorName(): void
     {
         $expected = 'Mike van Riel';
 
@@ -89,7 +89,7 @@ class AuthorTest extends TestCase
      * @covers ::__construct
      * @covers ::getEmail
      */
-    public function testHasTheAuthorMailAddress() : void
+    public function testHasTheAuthorMailAddress(): void
     {
         $expected = 'mike@phpdoc.org';
 
@@ -101,7 +101,7 @@ class AuthorTest extends TestCase
     /**
      * @covers ::__construct
      */
-    public function testInitializationFailsIfEmailIsNotValid() : void
+    public function testInitializationFailsIfEmailIsNotValid(): void
     {
         $this->expectException('InvalidArgumentException');
         new Author('Mike van Riel', 'mike');
@@ -111,7 +111,7 @@ class AuthorTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Author('Mike van Riel', 'mike@phpdoc.org');
 
@@ -128,7 +128,7 @@ class AuthorTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturnedWithoutName() : void
+    public function testStringRepresentationIsReturnedWithoutName(): void
     {
         $fixture = new Author('', 'mike@phpdoc.org');
 
@@ -139,7 +139,7 @@ class AuthorTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationWithEmtpyEmail() : void
+    public function testStringRepresentationWithEmtpyEmail(): void
     {
         $fixture = new Author('Mike van Riel', '');
 
@@ -152,7 +152,7 @@ class AuthorTest extends TestCase
      * @covers ::create
      * @dataProvider authorTagProvider
      */
-    public function testFactoryMethod(string $input, string $output, string $name, string $email) : void
+    public function testFactoryMethod(string $input, string $output, string $name, string $email): void
     {
         $fixture = Author::create($input);
 
@@ -162,7 +162,7 @@ class AuthorTest extends TestCase
     }
 
     /** @return mixed[][] */
-    public function authorTagProvider() : array
+    public function authorTagProvider(): array
     {
         return [
             [
@@ -191,7 +191,7 @@ class AuthorTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodReturnsNullIfItCouldNotReadBody() : void
+    public function testFactoryMethodReturnsNullIfItCouldNotReadBody(): void
     {
         $this->assertNull(Author::create('dfgr<'));
     }

--- a/tests/unit/DocBlock/Tags/CoversTest.php
+++ b/tests/unit/DocBlock/Tags/CoversTest.php
@@ -31,7 +31,7 @@ class CoversTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -42,7 +42,7 @@ class CoversTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned() : void
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Covers(new Fqsen('\DateTime'), new Description('Description'));
 
@@ -58,7 +58,7 @@ class CoversTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter() : void
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Covers(new Fqsen('\DateTime'), new Description('Description'));
 
@@ -71,7 +71,7 @@ class CoversTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter() : void
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Covers(new Fqsen('\DateTime'), new Description('Description'));
 
@@ -85,7 +85,7 @@ class CoversTest extends TestCase
      * @covers ::__construct
      * @covers ::getReference
      */
-    public function testHasReferenceToFqsen() : void
+    public function testHasReferenceToFqsen(): void
     {
         $expected = new Fqsen('\DateTime');
 
@@ -100,7 +100,7 @@ class CoversTest extends TestCase
      * @covers ::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      */
-    public function testHasDescription() : void
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -115,7 +115,7 @@ class CoversTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Covers(new Fqsen('\DateTime'), new Description('Description'));
 
@@ -132,7 +132,7 @@ class CoversTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethod() : void
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = m::mock(FqsenResolver::class);
@@ -156,7 +156,7 @@ class CoversTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    public function testStringRepresentationIsReturnedWithoutDescription(): void
     {
         $fixture = new Covers(new Fqsen('\\'));
 
@@ -185,7 +185,7 @@ class CoversTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithSpaceBeforeClass() : void
+    public function testFactoryMethodWithSpaceBeforeClass(): void
     {
         $fqsenResolver      = new FqsenResolver();
         $tagFactory         = new StandardTagFactory($fqsenResolver);
@@ -208,7 +208,7 @@ class CoversTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturnedWithDescription() : void
+    public function testStringRepresentationIsReturnedWithDescription(): void
     {
         $fixture = new Covers(new Fqsen('\DateTime'), new Description('My Description'));
 
@@ -218,7 +218,7 @@ class CoversTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty() : void
+    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->assertNull(Covers::create(''));

--- a/tests/unit/DocBlock/Tags/DeprecatedTest.php
+++ b/tests/unit/DocBlock/Tags/DeprecatedTest.php
@@ -28,7 +28,7 @@ class DeprecatedTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -39,7 +39,7 @@ class DeprecatedTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned() : void
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Deprecated('1.0', new Description('Description'));
 
@@ -55,7 +55,7 @@ class DeprecatedTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter() : void
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Deprecated('1.0', new Description('Description'));
 
@@ -68,7 +68,7 @@ class DeprecatedTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter() : void
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Deprecated('1.0', new Description('Description'));
 
@@ -82,7 +82,7 @@ class DeprecatedTest extends TestCase
      * @covers ::__construct
      * @covers ::getVersion
      */
-    public function testHasVersionNumber() : void
+    public function testHasVersionNumber(): void
     {
         $expected = '1.0';
 
@@ -97,7 +97,7 @@ class DeprecatedTest extends TestCase
      * @covers ::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      */
-    public function testHasDescription() : void
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -112,7 +112,7 @@ class DeprecatedTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Deprecated('1.0', new Description('Description'));
 
@@ -131,7 +131,7 @@ class DeprecatedTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    public function testStringRepresentationIsReturnedWithoutDescription(): void
     {
         $fixture = new Deprecated(null, new Description(''));
 
@@ -158,7 +158,7 @@ class DeprecatedTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethod() : void
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $context            = new Context('');
@@ -183,7 +183,7 @@ class DeprecatedTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodCreatesEmptyDeprecatedTag() : void
+    public function testFactoryMethodCreatesEmptyDeprecatedTag(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $descriptionFactory->shouldReceive('create')->never();
@@ -200,7 +200,7 @@ class DeprecatedTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodReturnsNullIfBodyDoesNotMatchRegex() : void
+    public function testFactoryMethodReturnsNullIfBodyDoesNotMatchRegex(): void
     {
         $this->assertEquals(new Deprecated(), Deprecated::create('dkhf<'));
     }

--- a/tests/unit/DocBlock/Tags/ExampleTest.php
+++ b/tests/unit/DocBlock/Tags/ExampleTest.php
@@ -20,7 +20,7 @@ class ExampleTest extends TestCase
      * @covers ::__construct
      * @covers ::getContent
      */
-    public function testExampleWithoutContent() : void
+    public function testExampleWithoutContent(): void
     {
         $tag = Example::create('"example1.php"');
         $this->assertEquals('"example1.php"', $tag->getContent());
@@ -36,7 +36,7 @@ class ExampleTest extends TestCase
      * @covers ::getFilePath
      * @covers ::getDescription
      */
-    public function testWithDescription() : void
+    public function testWithDescription(): void
     {
         $tag = Example::create('"example1.php" some text');
         $this->assertEquals('example1.php', $tag->getFilePath());
@@ -51,7 +51,7 @@ class ExampleTest extends TestCase
      * @covers ::getFilePath
      * @covers ::getStartingLine
      */
-    public function testStartlineIsParsed() : void
+    public function testStartlineIsParsed(): void
     {
         $tag = Example::create('"example1.php" 10');
         $this->assertEquals('example1.php', $tag->getFilePath());
@@ -67,7 +67,7 @@ class ExampleTest extends TestCase
      * @covers ::getStartingLine
      * @covers ::getDescription
      */
-    public function testAllowOmitingLineCount() : void
+    public function testAllowOmitingLineCount(): void
     {
         $tag = Example::create('"example1.php" 10 some text');
         $this->assertEquals('example1.php', $tag->getFilePath());
@@ -84,7 +84,7 @@ class ExampleTest extends TestCase
      * @covers ::getStartingLine
      * @covers ::getLineCount
      */
-    public function testLengthIsParsed() : void
+    public function testLengthIsParsed(): void
     {
         $tag = Example::create('"example1.php" 10 5');
         $this->assertEquals('example1.php', $tag->getFilePath());
@@ -96,7 +96,7 @@ class ExampleTest extends TestCase
      * @covers ::create
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $tag = Example::create('"example1.php" 10 5 test text');
 
@@ -131,7 +131,7 @@ class ExampleTest extends TestCase
      * @covers ::create
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    public function testStringRepresentationIsReturnedWithoutDescription(): void
     {
         $tag = Example::create('');
 
@@ -157,7 +157,7 @@ class ExampleTest extends TestCase
         int $lineCount,
         ?string $description,
         string $content
-    ) : void {
+    ): void {
         $tag = Example::create($input);
         $this->assertSame($filePath, $tag->getFilePath());
         $this->assertSame($startLine, $tag->getStartingLine());
@@ -167,7 +167,7 @@ class ExampleTest extends TestCase
     }
 
     /** @return mixed[][] */
-    public function tagContentProvider() : array
+    public function tagContentProvider(): array
     {
         return [
             [
@@ -231,7 +231,7 @@ class ExampleTest extends TestCase
         int $startLine,
         int $lineCount,
         string $description
-    ) : void {
+    ): void {
         $this->expectException(InvalidArgumentException::class);
 
         new Example(
@@ -244,7 +244,7 @@ class ExampleTest extends TestCase
     }
 
     /** @return mixed[][] */
-    public function invalidExampleProvider() : array
+    public function invalidExampleProvider(): array
     {
         return [
             'invalid start' => [

--- a/tests/unit/DocBlock/Tags/Formatter/AlignFormatterTest.php
+++ b/tests/unit/DocBlock/Tags/Formatter/AlignFormatterTest.php
@@ -29,7 +29,7 @@ class AlignFormatterTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -45,7 +45,7 @@ class AlignFormatterTest extends TestCase
      * @covers ::format
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\Formatter\AlignFormatter::__construct
      */
-    public function testFormatterCallsToStringAndReturnsAStandardRepresentation() : void
+    public function testFormatterCallsToStringAndReturnsAStandardRepresentation(): void
     {
         $tags    = [
             new Param('foobar', new String_()),

--- a/tests/unit/DocBlock/Tags/Formatter/PassthroughFormatterTest.php
+++ b/tests/unit/DocBlock/Tags/Formatter/PassthroughFormatterTest.php
@@ -26,7 +26,7 @@ class PassthroughFormatterTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -38,7 +38,7 @@ class PassthroughFormatterTest extends TestCase
      *
      * @covers ::format
      */
-    public function testFormatterCallsToStringAndReturnsAStandardRepresentation() : void
+    public function testFormatterCallsToStringAndReturnsAStandardRepresentation(): void
     {
         $expected = '@unknown-tag This is a description';
 
@@ -57,7 +57,7 @@ class PassthroughFormatterTest extends TestCase
      *
      * @covers ::format
      */
-    public function testFormatterToStringWithoutDescription() : void
+    public function testFormatterToStringWithoutDescription(): void
     {
         $expected = '@unknown-tag';
         $fixture  = new PassthroughFormatter();

--- a/tests/unit/DocBlock/Tags/GenericTest.php
+++ b/tests/unit/DocBlock/Tags/GenericTest.php
@@ -28,7 +28,7 @@ class GenericTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -39,7 +39,7 @@ class GenericTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned() : void
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Generic('generic', new Description('Description'));
 
@@ -55,7 +55,7 @@ class GenericTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter() : void
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Generic('generic', new Description('Description'));
 
@@ -68,7 +68,7 @@ class GenericTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter() : void
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Generic('generic', new Description('Description'));
 
@@ -84,7 +84,7 @@ class GenericTest extends TestCase
      * @covers ::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      */
-    public function testHasDescription() : void
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -100,7 +100,7 @@ class GenericTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Generic('generic', new Description('Description'));
 
@@ -114,7 +114,7 @@ class GenericTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    public function testStringRepresentationIsReturnedWithoutDescription(): void
     {
         $fixture = new Generic('generic');
 
@@ -135,7 +135,7 @@ class GenericTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethod() : void
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $context            = new Context('');
@@ -155,7 +155,7 @@ class GenericTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfNameIsNotEmpty() : void
+    public function testFactoryMethodFailsIfNameIsNotEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         Generic::create('', '');
@@ -165,7 +165,7 @@ class GenericTest extends TestCase
      * @covers ::create
      * @covers ::__construct
      */
-    public function testFactoryMethodFailsIfNameContainsIllegalCharacters() : void
+    public function testFactoryMethodFailsIfNameContainsIllegalCharacters(): void
     {
         $this->expectException('InvalidArgumentException');
         Generic::create('', 'name/myname');

--- a/tests/unit/DocBlock/Tags/InvalidTagTest.php
+++ b/tests/unit/DocBlock/Tags/InvalidTagTest.php
@@ -22,7 +22,7 @@ use function unserialize;
  */
 final class InvalidTagTest extends TestCase
 {
-    public function testCreationWithoutError() : void
+    public function testCreationWithoutError(): void
     {
         $tag = InvalidTag::create('Body', 'name');
 
@@ -35,7 +35,7 @@ final class InvalidTagTest extends TestCase
      * @covers ::withError
      * @covers ::__toString
      */
-    public function testCreationWithError() : void
+    public function testCreationWithError(): void
     {
         $exception = new Exception();
         $tag       = InvalidTag::create('Body', 'name')->withError($exception);
@@ -46,7 +46,7 @@ final class InvalidTagTest extends TestCase
         self::assertSame($exception, $tag->getException());
     }
 
-    public function testCreationWithErrorContainingClosure() : void
+    public function testCreationWithErrorContainingClosure(): void
     {
         try {
             $this->throwExceptionFromClosureWithClosureArgument();
@@ -67,16 +67,16 @@ final class InvalidTagTest extends TestCase
         }
     }
 
-    private function throwExceptionFromClosureWithClosureArgument() : void
+    private function throwExceptionFromClosureWithClosureArgument(): void
     {
-        $function = static function () : void {
+        $function = static function (): void {
             throw new InvalidArgumentException();
         };
 
         $function($function);
     }
 
-    public function testCreationWithErrorContainingResource() : void
+    public function testCreationWithErrorContainingResource(): void
     {
         try {
             $this->throwExceptionWithResourceArgument();
@@ -99,9 +99,9 @@ final class InvalidTagTest extends TestCase
         }
     }
 
-    private function throwExceptionWithResourceArgument() : void
+    private function throwExceptionWithResourceArgument(): void
     {
-        $function = static function () : void {
+        $function = static function (): void {
             throw new InvalidArgumentException();
         };
 

--- a/tests/unit/DocBlock/Tags/InvalidTagTest.php
+++ b/tests/unit/DocBlock/Tags/InvalidTagTest.php
@@ -8,6 +8,7 @@ use Exception;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Throwable;
+
 use function fopen;
 use function serialize;
 use function unserialize;

--- a/tests/unit/DocBlock/Tags/LinkTest.php
+++ b/tests/unit/DocBlock/Tags/LinkTest.php
@@ -30,7 +30,7 @@ class LinkTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -41,7 +41,7 @@ class LinkTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned() : void
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Link('http://this.is.my/link', new Description('Description'));
 
@@ -57,7 +57,7 @@ class LinkTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter() : void
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Link('http://this.is.my/link', new Description('Description'));
 
@@ -70,7 +70,7 @@ class LinkTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter() : void
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Link('http://this.is.my/link', new Description('Description'));
 
@@ -84,7 +84,7 @@ class LinkTest extends TestCase
      * @covers ::__construct
      * @covers ::getLink
      */
-    public function testHasLinkUrl() : void
+    public function testHasLinkUrl(): void
     {
         $expected = 'http://this.is.my/link';
 
@@ -99,7 +99,7 @@ class LinkTest extends TestCase
      * @covers ::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      */
-    public function testHasDescription() : void
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -114,7 +114,7 @@ class LinkTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Link('http://this.is.my/link', new Description('Description'));
 
@@ -127,7 +127,7 @@ class LinkTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    public function testStringRepresentationIsReturnedWithoutDescription(): void
     {
         $fixture = new Link('http://this.is.my/link');
 
@@ -148,7 +148,7 @@ class LinkTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethod() : void
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $context            = new Context('');
@@ -175,7 +175,7 @@ class LinkTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithoutSpaceBeforeUrl() : void
+    public function testFactoryMethodWithoutSpaceBeforeUrl(): void
     {
         $fqsenResolver      = new FqsenResolver();
         $tagFactory         = new StandardTagFactory($fqsenResolver);
@@ -202,7 +202,7 @@ class LinkTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithSpaceBeforeUrl() : void
+    public function testFactoryMethodWithSpaceBeforeUrl(): void
     {
         $fqsenResolver      = new FqsenResolver();
         $tagFactory         = new StandardTagFactory($fqsenResolver);
@@ -227,7 +227,7 @@ class LinkTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodCreatesEmptyLinkTag() : void
+    public function testFactoryMethodCreatesEmptyLinkTag(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $descriptionFactory->shouldReceive('create')->never();

--- a/tests/unit/DocBlock/Tags/MethodTest.php
+++ b/tests/unit/DocBlock/Tags/MethodTest.php
@@ -38,7 +38,7 @@ class MethodTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -48,7 +48,7 @@ class MethodTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned() : void
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Method('myMethod');
 
@@ -65,7 +65,7 @@ class MethodTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter() : void
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $arguments = [
             ['name' => 'argument1', 'type' => new String_()],
@@ -92,7 +92,7 @@ class MethodTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter() : void
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Method('myMethod');
 
@@ -106,7 +106,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @covers ::getMethodName
      */
-    public function testHasMethodName() : void
+    public function testHasMethodName(): void
     {
         $expected = 'myMethod';
 
@@ -119,7 +119,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @covers ::getArguments
      */
-    public function testHasArguments() : void
+    public function testHasArguments(): void
     {
         $arguments = [
             ['name' => 'argument1', 'type' => new String_()],
@@ -134,7 +134,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @covers ::getArguments
      */
-    public function testArgumentsMayBePassedAsString() : void
+    public function testArgumentsMayBePassedAsString(): void
     {
         $arguments = ['argument1'];
         $expected  = [
@@ -150,7 +150,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @covers ::getArguments
      */
-    public function testArgumentTypeCanBeInferredAsMixed() : void
+    public function testArgumentTypeCanBeInferredAsMixed(): void
     {
         $arguments = [['name' => 'argument1']];
         $expected  = [
@@ -169,7 +169,7 @@ class MethodTest extends TestCase
      *
      * @covers ::create
      */
-    public function testRestArgumentIsParsedAsRegularArg() : void
+    public function testRestArgumentIsParsedAsRegularArg(): void
     {
         $expected = [
             ['name' => 'arg1', 'type' => new Mixed_()],
@@ -197,7 +197,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @covers ::getReturnType
      */
-    public function testHasReturnType() : void
+    public function testHasReturnType(): void
     {
         $expected = new String_();
 
@@ -210,7 +210,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @covers ::getReturnType
      */
-    public function testReturnTypeCanBeInferredAsVoid() : void
+    public function testReturnTypeCanBeInferredAsVoid(): void
     {
         $fixture = new Method('myMethod', []);
 
@@ -221,7 +221,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @covers ::isStatic
      */
-    public function testMethodCanBeStatic() : void
+    public function testMethodCanBeStatic(): void
     {
         $expected = false;
         $fixture  = new Method('myMethod', [], null, $expected);
@@ -238,7 +238,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      */
-    public function testHasDescription() : void
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -254,7 +254,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $arguments = [
             ['name' => 'argument1', 'type' => new String_()],
@@ -275,7 +275,7 @@ class MethodTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    public function testStringRepresentationIsReturnedWithoutDescription(): void
     {
         $fixture = new Method('myMethod', [], null, false, new Description(''));
 
@@ -308,7 +308,7 @@ class MethodTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethod() : void
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();
@@ -349,7 +349,7 @@ class MethodTest extends TestCase
      *
      * @covers ::create
      */
-    public function testReturnTypeThis() : void
+    public function testReturnTypeThis(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();
@@ -380,7 +380,7 @@ class MethodTest extends TestCase
      *
      * @covers ::create
      */
-    public function testReturnTypeNoneWithLongMethodName() : void
+    public function testReturnTypeNoneWithLongMethodName(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();
@@ -406,7 +406,7 @@ class MethodTest extends TestCase
     /**
      * @return string[][]
      */
-    public function collectionReturnTypesProvider() : array
+    public function collectionReturnTypesProvider(): array
     {
         return [
             ['int[]', Array_::class, Integer::class, Compound::class],
@@ -434,7 +434,7 @@ class MethodTest extends TestCase
         string $expectedType,
         ?string $expectedValueType = null,
         ?string $expectedKeyType = null
-    ) : void {
+    ): void {
         $resolver           = new TypeResolver();
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $descriptionFactory->shouldReceive('create')
@@ -456,7 +456,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfBodyIsEmpty() : void
+    public function testFactoryMethodFailsIfBodyIsEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         Method::create('');
@@ -465,7 +465,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodReturnsNullIfBodyIsIncorrect() : void
+    public function testFactoryMethodReturnsNullIfBodyIsIncorrect(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->assertNull(Method::create('body('));
@@ -474,7 +474,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Method::create('body');
@@ -483,7 +483,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Method::create('body', new TypeResolver());
@@ -492,7 +492,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::__construct
      */
-    public function testCreationFailsIfBodyIsEmpty() : void
+    public function testCreationFailsIfBodyIsEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         new Method('');
@@ -501,7 +501,7 @@ class MethodTest extends TestCase
     /**
      * @covers ::__construct
      */
-    public function testCreationFailsIfArgumentRecordContainsInvalidEntry() : void
+    public function testCreationFailsIfArgumentRecordContainsInvalidEntry(): void
     {
         $this->expectException('InvalidArgumentException');
         new Method('body', [['name' => 'myName', 'unknown' => 'nah']]);
@@ -517,7 +517,7 @@ class MethodTest extends TestCase
      *
      * @covers ::create
      */
-    public function testCreateMethodParenthesisMissing() : void
+    public function testCreateMethodParenthesisMissing(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();
@@ -554,7 +554,7 @@ class MethodTest extends TestCase
      *
      * @covers ::create
      */
-    public function testCreateMethodEmptyArguments() : void
+    public function testCreateMethodEmptyArguments(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();
@@ -591,7 +591,7 @@ class MethodTest extends TestCase
      *
      * @covers ::create
      */
-    public function testCreateWithoutReturnType() : void
+    public function testCreateWithoutReturnType(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();
@@ -629,7 +629,7 @@ class MethodTest extends TestCase
      *
      * @covers ::create
      */
-    public function testCreateWithMixedReturnTypes() : void
+    public function testCreateWithMixedReturnTypes(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();

--- a/tests/unit/DocBlock/Tags/ParamTest.php
+++ b/tests/unit/DocBlock/Tags/ParamTest.php
@@ -33,7 +33,7 @@ class ParamTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -44,7 +44,7 @@ class ParamTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned() : void
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Param('myParameter', null, false, new Description('Description'));
 
@@ -61,7 +61,7 @@ class ParamTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter() : void
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Param('myParameter', new String_(), true, new Description('Description'));
         $this->assertSame('@param string ...$myParameter Description', $fixture->render());
@@ -81,7 +81,7 @@ class ParamTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter() : void
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Param('myParameter');
 
@@ -95,7 +95,7 @@ class ParamTest extends TestCase
      * @covers ::__construct
      * @covers ::getVariableName
      */
-    public function testHasVariableName() : void
+    public function testHasVariableName(): void
     {
         $expected = 'myParameter';
 
@@ -108,7 +108,7 @@ class ParamTest extends TestCase
      * @covers ::__construct
      * @covers ::getType
      */
-    public function testHasType() : void
+    public function testHasType(): void
     {
         $expected = new String_();
 
@@ -121,7 +121,7 @@ class ParamTest extends TestCase
      * @covers ::__construct
      * @covers ::isVariadic
      */
-    public function testIfParameterIsVariadic() : void
+    public function testIfParameterIsVariadic(): void
     {
         $fixture = new Param('myParameter', new String_(), false);
         $this->assertFalse($fixture->isVariadic());
@@ -136,7 +136,7 @@ class ParamTest extends TestCase
      * @covers ::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      */
-    public function testHasDescription() : void
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -153,7 +153,7 @@ class ParamTest extends TestCase
      * @covers ::isVariadic
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Param('myParameter', new String_(), true, new Description('Description'));
 
@@ -168,7 +168,7 @@ class ParamTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethod() : void
+    public function testFactoryMethod(): void
     {
         $typeResolver       = new TypeResolver();
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -195,7 +195,7 @@ class ParamTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithVariadic() : void
+    public function testFactoryMethodWithVariadic(): void
     {
         $typeResolver       = new TypeResolver();
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -222,7 +222,7 @@ class ParamTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithReference() : void
+    public function testFactoryMethodWithReference(): void
     {
         $typeResolver       = new TypeResolver();
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -249,7 +249,7 @@ class ParamTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithVariadicReference() : void
+    public function testFactoryMethodWithVariadicReference(): void
     {
         $typeResolver       = new TypeResolver();
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -281,7 +281,7 @@ class ParamTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithReferenceWithoutType() : void
+    public function testFactoryMethodWithReferenceWithoutType(): void
     {
         $typeResolver       = new TypeResolver();
         $fqsenResolver      = new FqsenResolver();
@@ -312,7 +312,7 @@ class ParamTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithVariadicReferenceWithoutType() : void
+    public function testFactoryMethodWithVariadicReferenceWithoutType(): void
     {
         $typeResolver       = new TypeResolver();
         $fqsenResolver      = new FqsenResolver();
@@ -343,7 +343,7 @@ class ParamTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithoutType() : void
+    public function testFactoryMethodWithoutType(): void
     {
         $typeResolver       = new TypeResolver();
         $fqsenResolver      = new FqsenResolver();
@@ -374,7 +374,7 @@ class ParamTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithType() : void
+    public function testFactoryMethodWithType(): void
     {
         $typeResolver       = new TypeResolver();
         $fqsenResolver      = new FqsenResolver();
@@ -402,7 +402,7 @@ class ParamTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven() : void
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
     {
         $this->expectException('InvalidArgumentException');
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -412,7 +412,7 @@ class ParamTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Param::create('body');
@@ -423,7 +423,7 @@ class ParamTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Param::create('body', new TypeResolver());

--- a/tests/unit/DocBlock/Tags/PropertyReadTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyReadTest.php
@@ -33,7 +33,7 @@ class PropertyReadTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -44,7 +44,7 @@ class PropertyReadTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned() : void
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new PropertyRead('myProperty', null, new Description('Description'));
 
@@ -60,7 +60,7 @@ class PropertyReadTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter() : void
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new PropertyRead('myProperty', new String_(), new Description('Description'));
         $this->assertSame('@property-read string $myProperty Description', $fixture->render());
@@ -77,7 +77,7 @@ class PropertyReadTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter() : void
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new PropertyRead('myProperty');
 
@@ -91,7 +91,7 @@ class PropertyReadTest extends TestCase
      * @covers ::__construct
      * @covers ::getVariableName
      */
-    public function testHasVariableName() : void
+    public function testHasVariableName(): void
     {
         $expected = 'myProperty';
 
@@ -104,7 +104,7 @@ class PropertyReadTest extends TestCase
      * @covers ::__construct
      * @covers ::getType
      */
-    public function testHasType() : void
+    public function testHasType(): void
     {
         $expected = new String_();
 
@@ -119,7 +119,7 @@ class PropertyReadTest extends TestCase
      * @covers ::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      */
-    public function testHasDescription() : void
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -135,7 +135,7 @@ class PropertyReadTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new PropertyRead('myProperty', new String_(), new Description('Description'));
 
@@ -150,7 +150,7 @@ class PropertyReadTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethod() : void
+    public function testFactoryMethod(): void
     {
         $typeResolver       = new TypeResolver();
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -180,7 +180,7 @@ class PropertyReadTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithoutType() : void
+    public function testFactoryMethodWithoutType(): void
     {
         $typeResolver       = new TypeResolver();
         $fqsenResolver      = new FqsenResolver();
@@ -209,7 +209,7 @@ class PropertyReadTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithType() : void
+    public function testFactoryMethodWithType(): void
     {
         $typeResolver       = new TypeResolver();
         $fqsenResolver      = new FqsenResolver();
@@ -237,7 +237,7 @@ class PropertyReadTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven() : void
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
     {
         $this->expectException('InvalidArgumentException');
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -247,7 +247,7 @@ class PropertyReadTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         PropertyRead::create('body');
@@ -258,7 +258,7 @@ class PropertyReadTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         PropertyRead::create('body', new TypeResolver());

--- a/tests/unit/DocBlock/Tags/PropertyTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyTest.php
@@ -33,7 +33,7 @@ class PropertyTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -44,7 +44,7 @@ class PropertyTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned() : void
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Property('myProperty', null, new Description('Description'));
 
@@ -60,7 +60,7 @@ class PropertyTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter() : void
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Property('myProperty', new String_(), new Description('Description'));
         $this->assertSame('@property string $myProperty Description', $fixture->render());
@@ -77,7 +77,7 @@ class PropertyTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter() : void
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Property('myProperty');
 
@@ -91,7 +91,7 @@ class PropertyTest extends TestCase
      * @covers ::__construct
      * @covers ::getVariableName
      */
-    public function testHasVariableName() : void
+    public function testHasVariableName(): void
     {
         $expected = 'myProperty';
 
@@ -104,7 +104,7 @@ class PropertyTest extends TestCase
      * @covers ::__construct
      * @covers ::getType
      */
-    public function testHasType() : void
+    public function testHasType(): void
     {
         $expected = new String_();
 
@@ -119,7 +119,7 @@ class PropertyTest extends TestCase
      * @covers ::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      */
-    public function testHasDescription() : void
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -135,7 +135,7 @@ class PropertyTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Property('myProperty', new String_(), new Description('Description'));
 
@@ -150,7 +150,7 @@ class PropertyTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethod() : void
+    public function testFactoryMethod(): void
     {
         $typeResolver       = new TypeResolver();
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -175,7 +175,7 @@ class PropertyTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithoutType() : void
+    public function testFactoryMethodWithoutType(): void
     {
         $typeResolver       = new TypeResolver();
         $fqsenResolver      = new FqsenResolver();
@@ -204,7 +204,7 @@ class PropertyTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithType() : void
+    public function testFactoryMethodWithType(): void
     {
         $typeResolver       = new TypeResolver();
         $fqsenResolver      = new FqsenResolver();
@@ -232,7 +232,7 @@ class PropertyTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven() : void
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
     {
         $this->expectException('InvalidArgumentException');
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -242,7 +242,7 @@ class PropertyTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Property::create('body');
@@ -253,7 +253,7 @@ class PropertyTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Property::create('body', new TypeResolver());

--- a/tests/unit/DocBlock/Tags/PropertyWriteTest.php
+++ b/tests/unit/DocBlock/Tags/PropertyWriteTest.php
@@ -33,7 +33,7 @@ class PropertyWriteTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -44,7 +44,7 @@ class PropertyWriteTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned() : void
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new PropertyWrite('myProperty', null, new Description('Description'));
 
@@ -60,7 +60,7 @@ class PropertyWriteTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter() : void
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new PropertyWrite('myProperty', new String_(), new Description('Description'));
         $this->assertSame('@property-write string $myProperty Description', $fixture->render());
@@ -77,7 +77,7 @@ class PropertyWriteTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter() : void
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new PropertyWrite('myProperty');
 
@@ -91,7 +91,7 @@ class PropertyWriteTest extends TestCase
      * @covers ::__construct
      * @covers ::getVariableName
      */
-    public function testHasVariableName() : void
+    public function testHasVariableName(): void
     {
         $expected = 'myProperty';
 
@@ -104,7 +104,7 @@ class PropertyWriteTest extends TestCase
      * @covers ::__construct
      * @covers ::getType
      */
-    public function testHasType() : void
+    public function testHasType(): void
     {
         $expected = new String_();
 
@@ -119,7 +119,7 @@ class PropertyWriteTest extends TestCase
      * @covers ::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      */
-    public function testHasDescription() : void
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -135,7 +135,7 @@ class PropertyWriteTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new PropertyWrite('myProperty', new String_(), new Description('Description'));
 
@@ -150,7 +150,7 @@ class PropertyWriteTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethod() : void
+    public function testFactoryMethod(): void
     {
         $typeResolver       = new TypeResolver();
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -180,7 +180,7 @@ class PropertyWriteTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithoutType() : void
+    public function testFactoryMethodWithoutType(): void
     {
         $typeResolver       = new TypeResolver();
         $fqsenResolver      = new FqsenResolver();
@@ -209,7 +209,7 @@ class PropertyWriteTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithType() : void
+    public function testFactoryMethodWithType(): void
     {
         $typeResolver       = new TypeResolver();
         $fqsenResolver      = new FqsenResolver();
@@ -237,7 +237,7 @@ class PropertyWriteTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven() : void
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
     {
         $this->expectException('InvalidArgumentException');
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -247,7 +247,7 @@ class PropertyWriteTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         PropertyWrite::create('body');
@@ -258,7 +258,7 @@ class PropertyWriteTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         PropertyWrite::create('body', new TypeResolver());

--- a/tests/unit/DocBlock/Tags/ReturnTest.php
+++ b/tests/unit/DocBlock/Tags/ReturnTest.php
@@ -31,7 +31,7 @@ class ReturnTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -42,7 +42,7 @@ class ReturnTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned() : void
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Return_(new String_(), new Description('Description'));
 
@@ -58,7 +58,7 @@ class ReturnTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter() : void
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Return_(new String_(), new Description('Description'));
 
@@ -71,7 +71,7 @@ class ReturnTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter() : void
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Return_(new String_(), new Description('Description'));
 
@@ -85,7 +85,7 @@ class ReturnTest extends TestCase
      * @covers ::__construct
      * @covers ::getType
      */
-    public function testHasType() : void
+    public function testHasType(): void
     {
         $expected = new String_();
 
@@ -100,7 +100,7 @@ class ReturnTest extends TestCase
      * @covers ::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      */
-    public function testHasDescription() : void
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -115,7 +115,7 @@ class ReturnTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Return_(new String_(), new Description('Description'));
 
@@ -128,7 +128,7 @@ class ReturnTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    public function testStringRepresentationIsReturnedWithoutDescription(): void
     {
         $fixture = new Return_(new String_());
 
@@ -151,7 +151,7 @@ class ReturnTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethod() : void
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();
@@ -187,7 +187,7 @@ class ReturnTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithGenericWithSpace() : void
+    public function testFactoryMethodWithGenericWithSpace(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();
@@ -216,7 +216,7 @@ class ReturnTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithGenericWithSpaceAndAddedEmojisToVerifyMultiByteBehaviour() : void
+    public function testFactoryMethodWithGenericWithSpaceAndAddedEmojisToVerifyMultiByteBehaviour(): void
     {
         $this->markTestSkipped('A bug in the TypeResolver breaks this test');
         $this->expectException(InvalidArgumentException::class);
@@ -244,7 +244,7 @@ class ReturnTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithEmojisToVerifyMultiByteBehaviour() : void
+    public function testFactoryMethodWithEmojisToVerifyMultiByteBehaviour(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();
@@ -265,7 +265,7 @@ class ReturnTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty() : void
+    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->assertNull(Return_::create(''));
@@ -274,7 +274,7 @@ class ReturnTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Return_::create('body');
@@ -283,7 +283,7 @@ class ReturnTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Return_::create('body', new TypeResolver());

--- a/tests/unit/DocBlock/Tags/SeeTest.php
+++ b/tests/unit/DocBlock/Tags/SeeTest.php
@@ -34,7 +34,7 @@ class SeeTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -47,7 +47,7 @@ class SeeTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned() : void
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new See(new FqsenRef(new Fqsen('\DateTime')), new Description('Description'));
 
@@ -64,7 +64,7 @@ class SeeTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter() : void
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new See(new FqsenRef(new Fqsen('\DateTime')), new Description('Description'));
 
@@ -79,7 +79,7 @@ class SeeTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter() : void
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new See(new FqsenRef(new Fqsen('\DateTime')), new Description('Description'));
 
@@ -96,7 +96,7 @@ class SeeTest extends TestCase
      * @covers ::__construct
      * @covers ::getReference
      */
-    public function testHasReferenceToFqsen() : void
+    public function testHasReferenceToFqsen(): void
     {
         $expected = new FqsenRef(new Fqsen('\DateTime'));
 
@@ -113,7 +113,7 @@ class SeeTest extends TestCase
      * @covers ::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      */
-    public function testHasDescription() : void
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -130,7 +130,7 @@ class SeeTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new See(new FqsenRef(new Fqsen('\DateTime::format()')), new Description('Description'));
 
@@ -145,7 +145,7 @@ class SeeTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    public function testStringRepresentationIsReturnedWithoutDescription(): void
     {
         $fixture = new See(new FqsenRef(new Fqsen('\DateTime::format()')));
 
@@ -169,7 +169,7 @@ class SeeTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethod() : void
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = m::mock(FqsenResolver::class);
@@ -201,7 +201,7 @@ class SeeTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithNonClassFQSEN() : void
+    public function testFactoryMethodWithNonClassFQSEN(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = m::mock(FqsenResolver::class);
@@ -232,7 +232,7 @@ class SeeTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithUrl() : void
+    public function testFactoryMethodWithUrl(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = m::mock(FqsenResolver::class);
@@ -263,7 +263,7 @@ class SeeTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithoutUrl() : void
+    public function testFactoryMethodWithoutUrl(): void
     {
         $fqsenResolver      = new FqsenResolver();
         $tagFactory         = new StandardTagFactory($fqsenResolver);
@@ -286,7 +286,7 @@ class SeeTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty() : void
+    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->assertNull(See::create(''));
@@ -295,7 +295,7 @@ class SeeTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         See::create('body');
@@ -304,7 +304,7 @@ class SeeTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         See::create('body', new FqsenResolver());

--- a/tests/unit/DocBlock/Tags/SinceTest.php
+++ b/tests/unit/DocBlock/Tags/SinceTest.php
@@ -28,7 +28,7 @@ class SinceTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -39,7 +39,7 @@ class SinceTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned() : void
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Since('1.0', new Description('Description'));
 
@@ -55,7 +55,7 @@ class SinceTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter() : void
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Since('1.0', new Description('Description'));
 
@@ -68,7 +68,7 @@ class SinceTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter() : void
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Since('1.0', new Description('Description'));
 
@@ -82,7 +82,7 @@ class SinceTest extends TestCase
      * @covers ::__construct
      * @covers ::getVersion
      */
-    public function testHasVersionNumber() : void
+    public function testHasVersionNumber(): void
     {
         $expected = '1.0';
 
@@ -97,7 +97,7 @@ class SinceTest extends TestCase
      * @covers ::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      */
-    public function testHasDescription() : void
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -112,7 +112,7 @@ class SinceTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Since('1.0', new Description('Description'));
 
@@ -125,7 +125,7 @@ class SinceTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    public function testStringRepresentationIsReturnedWithoutDescription(): void
     {
         $fixture = new Since('1.0');
 
@@ -146,7 +146,7 @@ class SinceTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethod() : void
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $context            = new Context('');
@@ -171,7 +171,7 @@ class SinceTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodCreatesEmptySinceTag() : void
+    public function testFactoryMethodCreatesEmptySinceTag(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $descriptionFactory->shouldReceive('create')->never();
@@ -186,7 +186,7 @@ class SinceTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodReturnsNullIfBodyDoesNotMatchRegex() : void
+    public function testFactoryMethodReturnsNullIfBodyDoesNotMatchRegex(): void
     {
         $this->assertNull(Since::create('dkhf<'));
     }

--- a/tests/unit/DocBlock/Tags/SourceTest.php
+++ b/tests/unit/DocBlock/Tags/SourceTest.php
@@ -28,7 +28,7 @@ class SourceTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -39,7 +39,7 @@ class SourceTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned() : void
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Source(1, null, new Description('Description'));
 
@@ -55,7 +55,7 @@ class SourceTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter() : void
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Source(1, 10, new Description('Description'));
         $this->assertSame('@source 1 10 Description', $fixture->render());
@@ -72,7 +72,7 @@ class SourceTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter() : void
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Source(1);
 
@@ -86,7 +86,7 @@ class SourceTest extends TestCase
      * @covers ::__construct
      * @covers ::getStartingLine
      */
-    public function testHasStartingLine() : void
+    public function testHasStartingLine(): void
     {
         $expected = 1;
 
@@ -99,7 +99,7 @@ class SourceTest extends TestCase
      * @covers ::__construct
      * @covers ::getLineCount
      */
-    public function testHasLineCount() : void
+    public function testHasLineCount(): void
     {
         $expected = 2;
 
@@ -114,7 +114,7 @@ class SourceTest extends TestCase
      * @covers ::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      */
-    public function testHasDescription() : void
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -130,7 +130,7 @@ class SourceTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Source(1, 10, new Description('Description'));
 
@@ -144,7 +144,7 @@ class SourceTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    public function testStringRepresentationIsReturnedWithoutDescription(): void
     {
         $fixture = new Source(1);
 
@@ -171,7 +171,7 @@ class SourceTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethod() : void
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $context            = new Context('');
@@ -194,7 +194,7 @@ class SourceTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven() : void
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
     {
         $this->expectException('InvalidArgumentException');
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -206,7 +206,7 @@ class SourceTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Source::create('1');
@@ -215,7 +215,7 @@ class SourceTest extends TestCase
     /**
      * @covers ::__construct
      */
-    public function testExceptionIsThrownIfStartingLineIsNotInteger() : void
+    public function testExceptionIsThrownIfStartingLineIsNotInteger(): void
     {
         $this->expectException('InvalidArgumentException');
         new Source('blabla');
@@ -224,7 +224,7 @@ class SourceTest extends TestCase
     /**
      * @covers ::__construct
      */
-    public function testExceptionIsThrownIfLineCountIsNotIntegerOrNull() : void
+    public function testExceptionIsThrownIfLineCountIsNotIntegerOrNull(): void
     {
         $this->expectException('InvalidArgumentException');
         new Source('1', []);

--- a/tests/unit/DocBlock/Tags/ThrowsTest.php
+++ b/tests/unit/DocBlock/Tags/ThrowsTest.php
@@ -31,7 +31,7 @@ class ThrowsTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -42,7 +42,7 @@ class ThrowsTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned() : void
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Throws(new String_(), new Description('Description'));
 
@@ -58,7 +58,7 @@ class ThrowsTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter() : void
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Throws(new String_(), new Description('Description'));
 
@@ -71,7 +71,7 @@ class ThrowsTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter() : void
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Throws(new String_(), new Description('Description'));
 
@@ -85,7 +85,7 @@ class ThrowsTest extends TestCase
      * @covers ::__construct
      * @covers ::getType
      */
-    public function testHasType() : void
+    public function testHasType(): void
     {
         $expected = new String_();
 
@@ -100,7 +100,7 @@ class ThrowsTest extends TestCase
      * @covers ::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      */
-    public function testHasDescription() : void
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -115,7 +115,7 @@ class ThrowsTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Throws(new String_(), new Description('Description'));
 
@@ -134,7 +134,7 @@ class ThrowsTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    public function testStringRepresentationIsReturnedWithoutDescription(): void
     {
         $fixture = new Throws(new String_());
 
@@ -157,7 +157,7 @@ class ThrowsTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethod() : void
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();
@@ -193,7 +193,7 @@ class ThrowsTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithGenericWithSpace() : void
+    public function testFactoryMethodWithGenericWithSpace(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();
@@ -222,7 +222,7 @@ class ThrowsTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithGenericWithSpaceAndAddedEmojisToVerifyMultiByteBehaviour() : void
+    public function testFactoryMethodWithGenericWithSpaceAndAddedEmojisToVerifyMultiByteBehaviour(): void
     {
         $this->markTestSkipped('A bug in the TypeResolver breaks this test');
         $this->expectException(InvalidArgumentException::class);
@@ -250,7 +250,7 @@ class ThrowsTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithEmojisToVerifyMultiByteBehaviour() : void
+    public function testFactoryMethodWithEmojisToVerifyMultiByteBehaviour(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = new TypeResolver();
@@ -271,7 +271,7 @@ class ThrowsTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty() : void
+    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->assertNull(Throws::create(''));
@@ -280,7 +280,7 @@ class ThrowsTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Throws::create('body');
@@ -289,7 +289,7 @@ class ThrowsTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Throws::create('body', new TypeResolver());

--- a/tests/unit/DocBlock/Tags/UsesTest.php
+++ b/tests/unit/DocBlock/Tags/UsesTest.php
@@ -31,7 +31,7 @@ class UsesTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -42,7 +42,7 @@ class UsesTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned() : void
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Uses(new Fqsen('\DateTime'), new Description('Description'));
 
@@ -58,7 +58,7 @@ class UsesTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter() : void
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Uses(new Fqsen('\DateTime'), new Description('Description'));
 
@@ -71,7 +71,7 @@ class UsesTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter() : void
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Uses(new Fqsen('\DateTime'), new Description('Description'));
 
@@ -85,7 +85,7 @@ class UsesTest extends TestCase
      * @covers ::__construct
      * @covers ::getReference
      */
-    public function testHasReferenceToFqsen() : void
+    public function testHasReferenceToFqsen(): void
     {
         $expected = new Fqsen('\DateTime');
 
@@ -100,7 +100,7 @@ class UsesTest extends TestCase
      * @covers ::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      */
-    public function testHasDescription() : void
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -115,7 +115,7 @@ class UsesTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Uses(new Fqsen('\DateTime'), new Description('Description'));
 
@@ -128,7 +128,7 @@ class UsesTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    public function testStringRepresentationIsReturnedWithoutDescription(): void
     {
         $fixture = new Uses(new Fqsen('\\'));
 
@@ -157,7 +157,7 @@ class UsesTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethod() : void
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $resolver           = m::mock(FqsenResolver::class);
@@ -187,7 +187,7 @@ class UsesTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithoutSpaceBeforeClass() : void
+    public function testFactoryMethodWithoutSpaceBeforeClass(): void
     {
         $fqsenResolver      = new FqsenResolver();
         $tagFactory         = new StandardTagFactory($fqsenResolver);
@@ -217,7 +217,7 @@ class UsesTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithSpaceBeforeClass() : void
+    public function testFactoryMethodWithSpaceBeforeClass(): void
     {
         $fqsenResolver      = new FqsenResolver();
         $tagFactory         = new StandardTagFactory($fqsenResolver);
@@ -240,7 +240,7 @@ class UsesTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfBodyIsNotEmpty() : void
+    public function testFactoryMethodFailsIfBodyIsNotEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->assertNull(Uses::create(''));
@@ -249,7 +249,7 @@ class UsesTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Uses::create('body');
@@ -258,7 +258,7 @@ class UsesTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Uses::create('body', new FqsenResolver());

--- a/tests/unit/DocBlock/Tags/VarTest.php
+++ b/tests/unit/DocBlock/Tags/VarTest.php
@@ -33,7 +33,7 @@ class VarTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -44,7 +44,7 @@ class VarTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned() : void
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Var_('myVariable', null, new Description('Description'));
 
@@ -56,7 +56,7 @@ class VarTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfVariableNameIsOmmitedIfEmpty() : void
+    public function testIfVariableNameIsOmmitedIfEmpty(): void
     {
         $fixture = new Var_('', null, null);
 
@@ -72,7 +72,7 @@ class VarTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter() : void
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Var_('myVariable', new String_(), new Description('Description'));
         $this->assertSame('@var string $myVariable Description', $fixture->render());
@@ -89,7 +89,7 @@ class VarTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter() : void
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Var_('myVariable');
 
@@ -103,7 +103,7 @@ class VarTest extends TestCase
      * @covers ::__construct
      * @covers ::getVariableName
      */
-    public function testHasVariableName() : void
+    public function testHasVariableName(): void
     {
         $expected = 'myVariable';
 
@@ -116,7 +116,7 @@ class VarTest extends TestCase
      * @covers ::__construct
      * @covers ::getType
      */
-    public function testHasType() : void
+    public function testHasType(): void
     {
         $expected = new String_();
 
@@ -131,7 +131,7 @@ class VarTest extends TestCase
      * @covers ::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      */
-    public function testHasDescription() : void
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -147,7 +147,7 @@ class VarTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Var_('myVariable', new String_(), new Description('Description'));
 
@@ -161,7 +161,7 @@ class VarTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    public function testStringRepresentationIsReturnedWithoutDescription(): void
     {
         $fixture = new Var_('myVariable');
 
@@ -188,7 +188,7 @@ class VarTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethod() : void
+    public function testFactoryMethod(): void
     {
         $typeResolver       = new TypeResolver();
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -213,7 +213,7 @@ class VarTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithoutType() : void
+    public function testFactoryMethodWithoutType(): void
     {
         $typeResolver       = new TypeResolver();
         $fqsenResolver      = new FqsenResolver();
@@ -242,7 +242,7 @@ class VarTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithType() : void
+    public function testFactoryMethodWithType(): void
     {
         $typeResolver       = new TypeResolver();
         $fqsenResolver      = new FqsenResolver();
@@ -271,7 +271,7 @@ class VarTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodWithTypeWithoutComment() : void
+    public function testFactoryMethodWithTypeWithoutComment(): void
     {
         $typeResolver       = new TypeResolver();
         $fqsenResolver      = new FqsenResolver();
@@ -299,7 +299,7 @@ class VarTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfEmptyBodyIsGiven() : void
+    public function testFactoryMethodFailsIfEmptyBodyIsGiven(): void
     {
         $this->expectException('InvalidArgumentException');
         $descriptionFactory = m::mock(DescriptionFactory::class);
@@ -309,7 +309,7 @@ class VarTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfResolverIsNull() : void
+    public function testFactoryMethodFailsIfResolverIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Var_::create('body');
@@ -320,7 +320,7 @@ class VarTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodFailsIfDescriptionFactoryIsNull() : void
+    public function testFactoryMethodFailsIfDescriptionFactoryIsNull(): void
     {
         $this->expectException('InvalidArgumentException');
         Var_::create('body', new TypeResolver());

--- a/tests/unit/DocBlock/Tags/VersionTest.php
+++ b/tests/unit/DocBlock/Tags/VersionTest.php
@@ -28,7 +28,7 @@ class VersionTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -39,7 +39,7 @@ class VersionTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfCorrectTagNameIsReturned() : void
+    public function testIfCorrectTagNameIsReturned(): void
     {
         $fixture = new Version('1.0', new Description('Description'));
 
@@ -55,7 +55,7 @@ class VersionTest extends TestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getName
      */
-    public function testIfTagCanBeRenderedUsingDefaultFormatter() : void
+    public function testIfTagCanBeRenderedUsingDefaultFormatter(): void
     {
         $fixture = new Version('1.0', new Description('Description'));
 
@@ -68,7 +68,7 @@ class VersionTest extends TestCase
      *
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::render
      */
-    public function testIfTagCanBeRenderedUsingSpecificFormatter() : void
+    public function testIfTagCanBeRenderedUsingSpecificFormatter(): void
     {
         $fixture = new Version('1.0', new Description('Description'));
 
@@ -82,7 +82,7 @@ class VersionTest extends TestCase
      * @covers ::__construct
      * @covers ::getVersion
      */
-    public function testHasVersionNumber() : void
+    public function testHasVersionNumber(): void
     {
         $expected = '1.0';
 
@@ -97,7 +97,7 @@ class VersionTest extends TestCase
      * @covers ::__construct
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\BaseTag::getDescription
      */
-    public function testHasDescription() : void
+    public function testHasDescription(): void
     {
         $expected = new Description('Description');
 
@@ -112,7 +112,7 @@ class VersionTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturned() : void
+    public function testStringRepresentationIsReturned(): void
     {
         $fixture = new Version('1.0', new Description('Description'));
 
@@ -125,7 +125,7 @@ class VersionTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testStringRepresentationIsReturnedWithoutDescription() : void
+    public function testStringRepresentationIsReturnedWithoutDescription(): void
     {
         $fixture = new Version('1.0');
 
@@ -146,7 +146,7 @@ class VersionTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethod() : void
+    public function testFactoryMethod(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $context            = new Context('');
@@ -171,7 +171,7 @@ class VersionTest extends TestCase
      *
      * @covers ::create
      */
-    public function testFactoryMethodCreatesEmptyVersionTag() : void
+    public function testFactoryMethodCreatesEmptyVersionTag(): void
     {
         $descriptionFactory = m::mock(DescriptionFactory::class);
         $descriptionFactory->shouldReceive('create')->never();
@@ -186,7 +186,7 @@ class VersionTest extends TestCase
     /**
      * @covers ::create
      */
-    public function testFactoryMethodReturnsNullIfBodyDoesNotMatchRegex() : void
+    public function testFactoryMethodReturnsNullIfBodyDoesNotMatchRegex(): void
     {
         $this->assertNull(Version::create('dkhf<'));
     }

--- a/tests/unit/DocBlockFactoryTest.php
+++ b/tests/unit/DocBlockFactoryTest.php
@@ -35,7 +35,7 @@ class DocBlockFactoryTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -47,7 +47,7 @@ class DocBlockFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::createInstance
      */
-    public function testCreateFactoryUsingFactoryMethod() : void
+    public function testCreateFactoryUsingFactoryMethod(): void
     {
         $fixture = DocBlockFactory::createInstance();
 
@@ -60,7 +60,7 @@ class DocBlockFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::create
      */
-    public function testCreateDocBlockFromReflection() : void
+    public function testCreateDocBlockFromReflection(): void
     {
         $fixture = new DocBlockFactory(m::mock(DescriptionFactory::class), m::mock(TagFactory::class));
 
@@ -83,7 +83,7 @@ class DocBlockFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::create
      */
-    public function testCreateDocBlockFromStringWithDocComment() : void
+    public function testCreateDocBlockFromStringWithDocComment(): void
     {
         $fixture = new DocBlockFactory(m::mock(DescriptionFactory::class), m::mock(TagFactory::class));
 
@@ -103,7 +103,7 @@ class DocBlockFactoryTest extends TestCase
      * @covers ::create
      * @covers ::__construct
      */
-    public function testCreateDocBlockFromStringWithoutDocComment() : void
+    public function testCreateDocBlockFromStringWithoutDocComment(): void
     {
         $fixture = new DocBlockFactory(m::mock(DescriptionFactory::class), m::mock(TagFactory::class));
 
@@ -126,7 +126,7 @@ class DocBlockFactoryTest extends TestCase
      *
      * @dataProvider provideSummaryAndDescriptions
      */
-    public function testSummaryAndDescriptionAreSeparated(string $given, string $summary, string $description) : void
+    public function testSummaryAndDescriptionAreSeparated(string $given, string $summary, string $description): void
     {
         $tagFactory = m::mock(TagFactory::class);
         $fixture    = new DocBlockFactory(new DescriptionFactory($tagFactory), $tagFactory);
@@ -144,7 +144,7 @@ class DocBlockFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::create
      */
-    public function testDescriptionsRetainFormatting() : void
+    public function testDescriptionsRetainFormatting(): void
     {
         $tagFactory = m::mock(TagFactory::class);
         $fixture    = new DocBlockFactory(new DescriptionFactory($tagFactory), $tagFactory);
@@ -178,7 +178,7 @@ DESCRIPTION;
      * @covers ::__construct
      * @covers ::create
      */
-    public function testTagsAreInterpretedUsingFactory() : void
+    public function testTagsAreInterpretedUsingFactory(): void
     {
         $tagString = <<<TAG
 @author Mike van Riel <me@mikevanriel.com> This is with
@@ -208,7 +208,7 @@ DOCBLOCK;
     /**
      * @return string[]
      */
-    public function provideSummaryAndDescriptions() : array
+    public function provideSummaryAndDescriptions(): array
     {
         return [
             ['This is a DocBlock', 'This is a DocBlock', ''],
@@ -268,7 +268,7 @@ DOCBLOCK
      * @covers ::__construct
      * @covers ::create
      */
-    public function testTagsWithContextNamespace() : void
+    public function testTagsWithContextNamespace(): void
     {
         $tagFactoryMock = m::mock(TagFactory::class);
         $fixture        = new DocBlockFactory(m::mock(DescriptionFactory::class), $tagFactoryMock);

--- a/tests/unit/DocBlockTest.php
+++ b/tests/unit/DocBlockTest.php
@@ -30,7 +30,7 @@ class DocBlockTest extends TestCase
     /**
      * Call Mockery::close after each test.
      */
-    public function tearDown() : void
+    public function tearDown(): void
     {
         m::close();
     }
@@ -41,7 +41,7 @@ class DocBlockTest extends TestCase
      * @covers ::__construct
      * @covers ::getSummary
      */
-    public function testDocBlockCanHaveASummary() : void
+    public function testDocBlockCanHaveASummary(): void
     {
         $summary = 'This is a summary';
 
@@ -56,7 +56,7 @@ class DocBlockTest extends TestCase
      * @covers ::__construct
      * @covers ::getSummary
      */
-    public function testDocBlockCanHaveEllipsisInSummary() : void
+    public function testDocBlockCanHaveEllipsisInSummary(): void
     {
         $summary = 'This is a short (...) description.';
 
@@ -71,7 +71,7 @@ class DocBlockTest extends TestCase
      * @covers ::__construct
      * @covers ::getDescription
      */
-    public function testDocBlockCanHaveADescription() : void
+    public function testDocBlockCanHaveADescription(): void
     {
         $description = new DocBlock\Description('');
 
@@ -87,7 +87,7 @@ class DocBlockTest extends TestCase
      * @covers ::__construct
      * @covers ::getTags
      */
-    public function testDocBlockCanHaveTags() : void
+    public function testDocBlockCanHaveTags(): void
     {
         $tags = [
             m::mock(DocBlock\Tag::class),
@@ -105,7 +105,7 @@ class DocBlockTest extends TestCase
      * @covers ::__construct
      * @covers ::getTags
      */
-    public function testDocBlockAllowsOnlyTags() : void
+    public function testDocBlockAllowsOnlyTags(): void
     {
         $this->expectException('InvalidArgumentException');
         $tags    = [null];
@@ -120,7 +120,7 @@ class DocBlockTest extends TestCase
      * @covers ::__construct
      * @covers ::getTagsByName
      */
-    public function testFindTagsInDocBlockByName() : void
+    public function testFindTagsInDocBlockByName(): void
     {
         $tag1 = m::mock(DocBlock\Tag::class);
         $tag2 = m::mock(DocBlock\Tag::class);
@@ -147,7 +147,7 @@ class DocBlockTest extends TestCase
      * @covers ::__construct
      * @covers ::getTagsWithTypeByName
      */
-    public function testFindTagsWithTypeInDocBlockByName() : void
+    public function testFindTagsWithTypeInDocBlockByName(): void
     {
         $tag1 = new DocBlock\Tags\Var_('foo', new String_());
         $tag2 = new DocBlock\Tags\Var_('bar', new String_());
@@ -169,7 +169,7 @@ class DocBlockTest extends TestCase
      * @covers ::__construct
      * @covers ::hasTag
      */
-    public function testCheckIfThereAreTagsWithAGivenName() : void
+    public function testCheckIfThereAreTagsWithAGivenName(): void
     {
         $tag1 = m::mock(DocBlock\Tag::class);
         $tag2 = m::mock(DocBlock\Tag::class);
@@ -193,7 +193,7 @@ class DocBlockTest extends TestCase
      * @covers ::__construct
      * @covers ::getContext
      */
-    public function testDocBlockKnowsInWhichNamespaceItIsAndWhichAliasesThereAre() : void
+    public function testDocBlockKnowsInWhichNamespaceItIsAndWhichAliasesThereAre(): void
     {
         $context = new Context('');
 
@@ -209,7 +209,7 @@ class DocBlockTest extends TestCase
      * @covers ::__construct
      * @covers ::getLocation
      */
-    public function testDocBlockKnowsAtWhichLineItIs() : void
+    public function testDocBlockKnowsAtWhichLineItIs(): void
     {
         $location = new Location(10);
 
@@ -225,7 +225,7 @@ class DocBlockTest extends TestCase
      * @covers ::isTemplateStart
      * @covers ::isTemplateEnd
      */
-    public function testDocBlockIsNotATemplateByDefault() : void
+    public function testDocBlockIsNotATemplateByDefault(): void
     {
         $fixture = new DocBlock('', null, [], null, null);
 
@@ -239,7 +239,7 @@ class DocBlockTest extends TestCase
      * @covers ::__construct
      * @covers ::isTemplateStart
      */
-    public function testDocBlockKnowsIfItIsTheStartOfADocBlockTemplate() : void
+    public function testDocBlockKnowsIfItIsTheStartOfADocBlockTemplate(): void
     {
         $fixture = new DocBlock('', null, [], null, null, true);
 
@@ -252,7 +252,7 @@ class DocBlockTest extends TestCase
      * @covers ::__construct
      * @covers ::isTemplateEnd
      */
-    public function testDocBlockKnowsIfItIsTheEndOfADocBlockTemplate() : void
+    public function testDocBlockKnowsIfItIsTheEndOfADocBlockTemplate(): void
     {
         $fixture = new DocBlock('', null, [], null, null, false, true);
 
@@ -265,7 +265,7 @@ class DocBlockTest extends TestCase
      * @covers ::__construct
      * @covers ::removeTag
      */
-    public function testRemoveTag() : void
+    public function testRemoveTag(): void
     {
         $someTag    = new Deprecated();
         $anotherTag = new Deprecated();

--- a/tests/unit/Exception/PcreExceptionTest.php
+++ b/tests/unit/Exception/PcreExceptionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\Exception;
 
 use PHPUnit\Framework\TestCase;
+
 use const PREG_BACKTRACK_LIMIT_ERROR;
 use const PREG_BAD_UTF8_ERROR;
 use const PREG_BAD_UTF8_OFFSET_ERROR;

--- a/tests/unit/Exception/PcreExceptionTest.php
+++ b/tests/unit/Exception/PcreExceptionTest.php
@@ -22,7 +22,7 @@ final class PcreExceptionTest extends TestCase
      * @covers ::createFromPhpError
      * @dataProvider errorCodeProvider
      */
-    public function testErrorConversion(int $errorCode, string $message) : void
+    public function testErrorConversion(int $errorCode, string $message): void
     {
         $this->assertSame($message, PcreException::createFromPhpError($errorCode)->getMessage());
     }
@@ -30,7 +30,7 @@ final class PcreExceptionTest extends TestCase
     /**
      * @return array<int, (string|int)[]>
      */
-    public function errorCodeProvider() : array
+    public function errorCodeProvider(): array
     {
         return [
             [

--- a/tests/unit/PregSplitTest.php
+++ b/tests/unit/PregSplitTest.php
@@ -6,7 +6,9 @@ namespace phpDocumentor\Reflection;
 
 use phpDocumentor\Reflection\Exception\PcreException;
 use PHPUnit\Framework\TestCase;
+
 use function set_error_handler;
+
 use const E_WARNING;
 
 final class PregSplitTest extends TestCase

--- a/tests/unit/PregSplitTest.php
+++ b/tests/unit/PregSplitTest.php
@@ -14,7 +14,7 @@ final class PregSplitTest extends TestCase
     /** @var callable|null */
     private $errorHandler = null;
 
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
         if ($this->errorHandler === null) {
             return;
@@ -26,7 +26,7 @@ final class PregSplitTest extends TestCase
     /**
      * @covers \phpDocumentor\Reflection\Utils::pregSplit
      */
-    public function testSimplePregSplit() : void
+    public function testSimplePregSplit(): void
     {
         $result = Utils::pregSplit('/\s/', 'word split');
 
@@ -36,10 +36,10 @@ final class PregSplitTest extends TestCase
     /**
      * @covers \phpDocumentor\Reflection\Utils::pregSplit
      */
-    public function testPregSplitThrowsOnError() : void
+    public function testPregSplitThrowsOnError(): void
     {
         //We need to disable the error handler for phpunit... because we expect some errors here
-        $this->errorHandler = set_error_handler(static function () : void {
+        $this->errorHandler = set_error_handler(static function (): void {
         }, E_WARNING);
 
         $this->expectException(PcreException::class);


### PR DESCRIPTION
### PHPCS ruleset: update ruleset for upstream changes

* Fix the name and description to prevent confusion between the project ruleset and the organisation ruleset.
* Set the minimum PHP version for the PHPCompatibility standard.
* Don't require property type declarations.
* Ensure special characters used as literals in an exclude pattern are escaped.

### CS: no whitespace before return type colon

### CS: blank line between different use statement types

### CS: miscellaneous other whitespace fixes 