### PR TITLE
PHPCS ruleset: remove an outdated exclusion

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -22,8 +22,4 @@
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix">
         <exclude-pattern>*/src/*/Abstract*\.php</exclude-pattern>
     </rule>
-
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod">
-        <exclude-pattern>*/src/DocBlock/Tags/InvalidTag\.php</exclude-pattern>
-    </rule>
 </ruleset>


### PR DESCRIPTION
The `SlevomatCodingStandard.Classes.UnusedPrivateElements` sniff has been removed from Slevomat.