### PR TITLE
Fix undefined index

### DIFF
--- a/src/DocBlock/Tags/InvalidTag.php
+++ b/src/DocBlock/Tags/InvalidTag.php
@@ -87,7 +87,7 @@ final class InvalidTag implements Tag
             if (isset($trace[0]['args'])) {
                 $trace = array_map(
                     function (array $call): array {
-                        $call['args'] = array_map([$this, 'flattenArguments'], $call['args']);
+                        $call['args'] = array_map([$this, 'flattenArguments'], $call['args'] ?? []);
 
                         return $call;
                     },


### PR DESCRIPTION
When I run the unit tests of the BetterReflection project I get this error:
```
1) Roave\BetterReflectionTest\TypesFinder\FindReturnTypeTest::testFindReturnTypeForMethod with data set #2 ('@return array{foo: string|int}', array())
Undefined index: args

/code/BetterReflection/src/TypesFinder/FindReturnType.php:48
/code/BetterReflection/test/unit/TypesFinder/FindReturnTypeTest.php:85
```

When the error happens `$call` contains the following array:
```
array(3) {
  ["file"]=>
  string(41) "/code/BetterReflection/vendor/bin/phpunit"
  ["line"]=>
  int(21)
  ["function"]=>
  string(4) "eval"
}
```

This modification fixes the problem.