### PR TITLE
Feature/method params

### DIFF
--- a/tests/unit/DocBlock/Tags/ParamTest.php
+++ b/tests/unit/DocBlock/Tags/ParamTest.php
@@ -428,4 +428,15 @@ class ParamTest extends TestCase
         $this->expectException('InvalidArgumentException');
         Param::create('body', new TypeResolver());
     }
+
+    public function testSpacedNotations(): void
+    {
+        $descriptionFactory = m::mock(DescriptionFactory::class);
+        $descriptionFactory->shouldReceive('create')->andReturn(new Description('Description'));
+        $param = Param::create('array & ... $var description', new TypeResolver(), $descriptionFactory);
+
+        self::assertSame('var', $param->getVariableName());
+        self::assertTrue($param->isVariadic());
+        self::assertTrue($param->isReference());
+    }
 }


### PR DESCRIPTION
This pr will add variadict and reference support to the `@method` arguments. 
Since we need to expose more information now the original `getArguments` method is deprecated, and will be replaced by `getParameters` which will now return a `Param` that supports more complex notations. 

There should be no BC breaks in here. 