### PR TITLE
Test with multiple versions of the dependencies

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -56,6 +56,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        dependencies:
+          - highest
+          - locked
+          - lowest
         operating-system:
           - ubuntu-latest
           - windows-latest
@@ -105,10 +109,11 @@ jobs:
           GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: phive --no-progress install --copy --trust-gpg-keys ${{ env.phiveGPGKeys }} phpunit:^8.5
 
-      - name: Install Composer dependencies & cache dependencies
+      - name: Install Composer ${{ matrix.dependencies }} dependencies & cache dependencies
         uses: "ramsey/composer-install@v1"
         with:
           composer-options: --optimize-autoloader
+          dependency-versions: ${{ matrix.dependencies }}
 
       - name: Run PHPUnit
         run: php tools/phpunit

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-filter": "*"
     },
     "require-dev": {
-        "mockery/mockery": "~1.3.2",
+        "mockery/mockery": "~1.3.5",
         "psalm/phar": "^4.8"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f1e7818879f1626c05926f50c2c96f44",
+    "content-hash": "cdb71071544df3fd9152739ccf987d83",
     "packages": [
         {
             "name": "phpdocumentor/reflection-common",


### PR DESCRIPTION
Fixes #243.

The minimum version of Mockery failed with PHP 8.0 and 8.1 so I had to raise it.