### PR TITLE
fix: render tags for summary in docblock

### DIFF
--- a/src/DocBlockFactory.php
+++ b/src/DocBlockFactory.php
@@ -127,7 +127,7 @@ final class DocBlockFactory implements DocBlockFactoryInterface
         [$templateMarker, $summary, $description, $tags] = $parts;
 
         return new DocBlock(
-            $summary,
+            $this->descriptionFactory->create($summary, $context)->render(),
             $description ? $this->descriptionFactory->create($description, $context) : null,
             $this->parseTagBlock($tags, $context),
             $context,


### PR DESCRIPTION
fixes https://github.com/phpDocumentor/phpDocumentor/issues/3583

As `summary` is already a string, renders the string before passing it into the `DocBlock` class with the corresponding tags, as to maintain BC while allowing tags in the first lines of method phpdoc.