### PR TITLE
Fix rendering a description when it contains escaped chars and no tags

### DIFF
--- a/src/DocBlock/Description.php
+++ b/src/DocBlock/Description.php
@@ -94,7 +94,7 @@ class Description
     public function render(?Formatter $formatter = null): string
     {
         if ($this->tags === []) {
-            return $this->bodyTemplate;
+            return vsprintf($this->bodyTemplate, []);
         }
 
         if ($formatter === null) {

--- a/tests/unit/DocBlock/DescriptionTest.php
+++ b/tests/unit/DocBlock/DescriptionTest.php
@@ -142,4 +142,31 @@ class DescriptionTest extends TestCase
         . 'inverseJoinColumns={@JoinColumn (name="column_id_2", referencedColumnName="id")})';
         $this->assertSame($expected, (string) $fixture);
     }
+
+    /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Formatter\PassthroughFormatter
+     *
+     * @covers ::__construct
+     * @covers ::render
+     * @covers ::__toString
+     */
+    public function testDescriptionWithEscapedCharactersAndNoTagsCanBeCastToString(): void
+    {
+        //% chars are escaped in \phpDocumentor\Reflection\DocBlock\DescriptionFactory::create
+        $body = <<<'EOT'
+        {%% for user in users %%}
+            {{ user.name }}
+        {%% endfor %%}';
+        EOT;
+
+        $expected = <<<'EOT'
+        {% for user in users %}
+            {{ user.name }}
+        {% endfor %}';
+        EOT;
+
+        $fixture  = new Description($body, []);
+
+        $this->assertSame($expected, (string) $fixture);
+    }
 }


### PR DESCRIPTION
Hi!

We are using twig templates in some doc comments (don't ask 🤣) and when lexing the `%` char is escaped. `vsprintf` unescapes normally and returns the original content correctly.

But when there are no tags an [optimisation is performed](https://github.com/phpDocumentor/ReflectionDocBlock/pull/318) which no longer calls  `vsprintf` so the description is returned with the `%` chars escaped. 

To fix I simply call `vsprintf` on the description always. 