### PR TITLE
Be more strict about type definitions on param

### DIFF
--- a/src/DocBlock/Tags/Factory/ParamFactory.php
+++ b/src/DocBlock/Tags/Factory/ParamFactory.php
@@ -7,6 +7,7 @@ namespace phpDocumentor\Reflection\DocBlock\Tags\Factory;
 use Doctrine\Deprecations\Deprecation;
 use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
 use phpDocumentor\Reflection\DocBlock\Tag;
+use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
 use phpDocumentor\Reflection\DocBlock\Tags\Param;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context;
@@ -15,6 +16,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\TypelessParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\OffsetAccessTypeNode;
 use Webmozart\Assert\Assert;
 
 use function sprintf;
@@ -58,6 +60,13 @@ final class ParamFactory implements PHPStanFactory
                 TypelessParamTagValueNode::class,
             ]
         );
+
+        if (($tagValue->type ?? null) instanceof OffsetAccessTypeNode) {
+            return InvalidTag::create(
+                (string) $tagValue,
+                'param'
+            );
+        }
 
         return new Param(
             trim($tagValue->parameterName, '$'),

--- a/src/DocBlock/Tags/TagWithType.php
+++ b/src/DocBlock/Tags/TagWithType.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Reflection\DocBlock\Tags;
 
+use InvalidArgumentException;
 use phpDocumentor\Reflection\Type;
 
 use function in_array;
+use function sprintf;
 use function strlen;
 use function substr;
 use function trim;
@@ -57,6 +59,12 @@ abstract class TagWithType extends BaseTag
                 $nestingLevel--;
                 continue;
             }
+        }
+
+        if ($nestingLevel < 0 || $nestingLevel > 0) {
+            throw new InvalidArgumentException(
+                sprintf('Could not find type in %s, please check for malformed notations', $body)
+            );
         }
 
         $description = trim(substr($body, strlen($type)));

--- a/tests/integration/InterpretingDocBlocksTest.php
+++ b/tests/integration/InterpretingDocBlocksTest.php
@@ -17,6 +17,7 @@ use Mockery as m;
 use phpDocumentor\Reflection\DocBlock\Description;
 use phpDocumentor\Reflection\DocBlock\StandardTagFactory;
 use phpDocumentor\Reflection\DocBlock\Tag;
+use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
 use phpDocumentor\Reflection\DocBlock\Tags\Method;
 use phpDocumentor\Reflection\DocBlock\Tags\MethodParameter;
 use phpDocumentor\Reflection\DocBlock\Tags\Param;
@@ -213,6 +214,32 @@ DOC;
                     [
                         new MethodParameter('integer', new Integer())
                     ]
+                ),
+            ],
+            $docblock->getTags()
+        );
+    }
+
+    public function testInvalidTypeParamResultsInInvalidTag(): void
+    {
+        $docCommment = '
+/**
+ * This is an example of a summary.
+ *
+ * @param array\Foo> $test
+ */
+';
+        $factory = DocBlockFactory::createInstance();
+        $docblock = $factory->create($docCommment);
+
+        self::assertEquals(
+            [
+                InvalidTag::create(
+                    'array\Foo> $test',
+                    'param',
+                )->withError(
+                    new \InvalidArgumentException(
+                        'Could not find type in array\Foo> $test, please check for malformed notations')
                 ),
             ],
             $docblock->getTags()

--- a/tests/unit/DocBlock/Tags/Factory/ParamFactoryTest.php
+++ b/tests/unit/DocBlock/Tags/Factory/ParamFactoryTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\DocBlock\Tags\Factory;
 
 use phpDocumentor\Reflection\DocBlock\Description;
+use phpDocumentor\Reflection\DocBlock\Tag;
+use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
 use phpDocumentor\Reflection\DocBlock\Tags\Param;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\PseudoTypes\IntegerValue;
@@ -33,7 +35,7 @@ final class ParamFactoryTest extends TagFactoryTestCase
      * @covers \phpDocumentor\Reflection\DocBlock\Tags\Factory\ParamFactory::supports
      * @dataProvider paramInputProvider
      */
-    public function testParamIsCreated(string $input, Param $expected): void
+    public function testParamIsCreated(string $input, Tag $expected): void
     {
         $ast = $this->parseTag($input);
         $factory = new ParamFactory($this->giveTypeResolver(), $this->givenDescriptionFactory());
@@ -121,6 +123,10 @@ final class ParamFactoryTest extends TagFactoryTestCase
                     new Description('My Description'),
                     false
                 ),
+            ],
+            [
+                '@param array[\Illuminate\Notifications\Channels\Notification] $notification',
+                InvalidTag::create('array[\Illuminate\Notifications\Channels\Notification] $notification', 'param'),
             ],
         ];
     }


### PR DESCRIPTION
Throw on invalid type definitions and unexpected type definitions. Not all types resolved by phpstan's parser are valid for docblocks, they might in a more complex type system but I do not see how these types would ever apply to param tags.