### PR TITLE
Fix compatibility issue with phpstan 2.0 parser

### DIFF
--- a/src/DocBlock/Tags/Factory/AbstractPHPStanFactory.php
+++ b/src/DocBlock/Tags/Factory/AbstractPHPStanFactory.php
@@ -75,11 +75,13 @@ class AbstractPHPStanFactory implements Factory
     {
         $tokens = $this->tokenizeLine($tagLine);
         $ast = $this->parser->parseTag($tokens);
-        if (property_exists($ast->value, 'description') === true) {
-            $ast->value->setAttribute(
-                'description',
-                $ast->value->description . $tokens->joinUntil(Lexer::TOKEN_END)
-            );
+        if (class_exists(ParserConfig::class) === false) {
+            if (property_exists($ast->value, 'description') === true) {
+                $ast->value->setAttribute(
+                    'description',
+                    $ast->value->description . $tokens->joinUntil(Lexer::TOKEN_END)
+                );
+            }
         }
 
         if ($context === null) {

--- a/tests/integration/InterpretingDocBlocksTest.php
+++ b/tests/integration/InterpretingDocBlocksTest.php
@@ -463,4 +463,22 @@ DOCBLOCK;
             $docblock->getTags()
         );
     }
+
+    public function testParamTagDescriptionIsCorrectly(): void
+    {
+        $docComment = '
+	/**
+	 * @param int $baz Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas varius, tellus in cursus
+	 *     dictum, justo odio sagittis velit, id iaculis mi dui id nisi.
+	 */
+';
+
+        $factory = DocBlockFactory::createInstance();
+        $docblock = $factory->create($docComment);
+
+        $paramTags = $docblock->getTagsWithTypeByName('param')[0];
+
+        self::assertSame('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas varius, tellus in cursus
+dictum, justo odio sagittis velit, id iaculis mi dui id nisi.', (string) $paramTags->getDescription());
+    }
 }


### PR DESCRIPTION
The phpstan 2.0 release contains a fix which resolves the existing bug in the old parser that didn't take the whole description when it was multiline. Now the workaround is disabled when using phpstan parser v2

Fixes #393