### PR TITLE
Do not call Reflection*::setAccessible() in PHP >= 8.1

### DIFF
--- a/src/DocBlock/Tags/InvalidTag.php
+++ b/src/DocBlock/Tags/InvalidTag.php
@@ -77,7 +77,9 @@ final class InvalidTag implements Tag
     private function flattenExceptionBacktrace(Throwable $exception): void
     {
         $traceProperty = (new ReflectionClass(Exception::class))->getProperty('trace');
-        $traceProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $traceProperty->setAccessible(true);
+        }
 
         do {
             $trace = $exception->getTrace();
@@ -96,7 +98,9 @@ final class InvalidTag implements Tag
             $exception = $exception->getPrevious();
         } while ($exception !== null);
 
-        $traceProperty->setAccessible(false);
+        if (PHP_VERSION_ID < 80100) {
+            $traceProperty->setAccessible(false);
+        }
     }
 
     /**


### PR DESCRIPTION
> As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.

(https://www.php.net/manual/en/reflectionmethod.setaccessible.php and https://www.php.net/manual/en/reflectionproperty.setaccessible.php).

There're even plans to deprecate the method in PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations