### PR TITLE
[BUGFIX] Mitigate "Using null as an array offset is deprecated"

### DIFF
--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -282,8 +282,8 @@ final class StandardTagFactory implements TagFactory
             }
 
             $parameterName = $parameter->getName();
-            if (isset($locator[$typeHint])) {
-                $arguments[$parameterName] = $locator[$typeHint];
+            if (isset($locator[$typeHint ?? ''])) {
+                $arguments[$parameterName] = $locator[$typeHint ?? ''];
                 continue;
             }
 

--- a/tests/unit/DocBlock/StandardTagFactoryTest.php
+++ b/tests/unit/DocBlock/StandardTagFactoryTest.php
@@ -525,6 +525,11 @@ class StandardTagFactoryTest extends TestCase
                 'tag',
                 '@tag (is valid)',
             ],
+            'full-qualified-class-name following a tag name is valid' => [
+                '@tag \InvalidArgumentException',
+                'tag',
+                '@tag \InvalidArgumentException',
+            ],
         ];
     }
 


### PR DESCRIPTION
Using `DocBlockFactory->create()` with a phpdocblock
hanging a `@throws` tag followed by a exception class
name emits following PHP 8.5.0 deprecation:

```
Using null as an array offset is deprecated,
use an empty string instead
```

in `StandardTagFactory->getArgumentsForParametersFromWiring()`.

This change uses the null-coalsce operator to fallback to
an empty string for the value which should be used as an
array key instead of using `null` to mitigate the deprecation
notice with PHP8.5.0 and matches the behaviour in earlier
PHP versions without the deprecation message.


This is blocking the TYPO3 pipelines to raise to PHP8.5.0
release images for automatic testing, which means that
after merging it a release is required aka would be very
nice to have it as soon as possible and the time fits in.