### PR TITLE
Register 'mixin' tag handler in StandardTagFactory

### DIFF
--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -168,6 +168,7 @@ final class StandardTagFactory implements TagFactory
         $tagFactory->registerTagHandler('property-read', $phpstanTagFactory);
         $tagFactory->registerTagHandler('property-write', $phpstanTagFactory);
         $tagFactory->registerTagHandler('method', $phpstanTagFactory);
+        $tagFactory->registerTagHandler('mixin', $phpstanTagFactory);
         $tagFactory->registerTagHandler('extends', $phpstanTagFactory);
         $tagFactory->registerTagHandler('implements', $phpstanTagFactory);
         $tagFactory->registerTagHandler('template', $phpstanTagFactory);


### PR DESCRIPTION
The `AbstractPHPStanFactory` (which is confusingly not abstract at all) has a `MixinFactory` to handle `@mixin` tags, but this was not registered in the mapping.