### PR TITLE
Fix parsing of tag descriptions with continuation lines starting with *

### DIFF
--- a/src/DocBlock/Tags/Factory/AbstractPHPStanFactory.php
+++ b/src/DocBlock/Tags/Factory/AbstractPHPStanFactory.php
@@ -113,7 +113,13 @@ class AbstractPHPStanFactory implements Factory
             if ($token[Lexer::TYPE_OFFSET] === Lexer::TOKEN_PHPDOC_EOL) {
                 // Strip "* " prefix (and other horizontal whitespace) again so it doesn't and up in the
                 // description when we joinUntil() in create().
-                $token[Lexer::VALUE_OFFSET] = trim($token[Lexer::VALUE_OFFSET], "* \t");
+                $fixed[] = [
+                    Lexer::VALUE_OFFSET => trim($token[Lexer::VALUE_OFFSET], "* \t"),
+                    Lexer::TYPE_OFFSET => $token[Lexer::TYPE_OFFSET],
+                    Lexer::LINE_OFFSET => $token[Lexer::LINE_OFFSET] ?? 0,
+                ];
+
+                continue;
             }
 
             $fixed[] = $token;

--- a/src/DocBlock/Tags/Factory/AbstractPHPStanFactory.php
+++ b/src/DocBlock/Tags/Factory/AbstractPHPStanFactory.php
@@ -61,7 +61,7 @@ class AbstractPHPStanFactory implements Factory
     public function create(string $tagLine, ?TypeContext $context = null): Tag
     {
         try {
-            $tokens = $this->tokenizeLine($tagLine . "\n");
+            $tokens = $this->tokenizeLine($tagLine);
             $ast = $this->parser->parseTag($tokens);
             if (property_exists($ast->value, 'description') === true) {
                 $ast->value->setAttribute(
@@ -104,21 +104,15 @@ class AbstractPHPStanFactory implements Factory
      */
     private function tokenizeLine(string $tagLine): TokenIterator
     {
-        $tokens = $this->lexer->tokenize($tagLine);
+        // Prefix continuation lines with "* ", which is consumed by the phpstan parser as TOKEN_PHPDOC_EOL.
+        $tagLine = str_replace("\n", "\n* ", $tagLine);
+        $tokens = $this->lexer->tokenize($tagLine . "\n");
         $fixed = [];
         foreach ($tokens as $token) {
-            if (($token[1] === Lexer::TOKEN_PHPDOC_EOL) && rtrim($token[0], " \t") !== $token[0]) {
-                $fixed[] = [
-                    rtrim($token[Lexer::VALUE_OFFSET], " \t"),
-                    Lexer::TOKEN_PHPDOC_EOL,
-                    $token[2] ?? 0,
-                ];
-                $fixed[] = [
-                    ltrim($token[Lexer::VALUE_OFFSET], "\n\r"),
-                    Lexer::TOKEN_HORIZONTAL_WS,
-                    ($token[2] ?? 0) + 1,
-                ];
-                continue;
+            if ($token[Lexer::TYPE_OFFSET] === Lexer::TOKEN_PHPDOC_EOL) {
+                // Strip "* " prefix (and other horizontal whitespace) again so it doesn't and up in the
+                // description when we joinUntil() in create().
+                $token[Lexer::VALUE_OFFSET] = trim($token[Lexer::VALUE_OFFSET], "* \t");
             }
 
             $fixed[] = $token;

--- a/src/DocBlock/Tags/Factory/AbstractPHPStanFactory.php
+++ b/src/DocBlock/Tags/Factory/AbstractPHPStanFactory.php
@@ -25,9 +25,10 @@ use PHPStan\PhpDocParser\Parser\TypeParser;
 use PHPStan\PhpDocParser\ParserConfig;
 use RuntimeException;
 
-use function ltrim;
 use function property_exists;
 use function rtrim;
+use function str_replace;
+use function trim;
 
 /**
  * Factory class creating tags using phpstan's parser

--- a/tests/integration/InterpretingDocBlocksTest.php
+++ b/tests/integration/InterpretingDocBlocksTest.php
@@ -489,4 +489,42 @@ DOCBLOCK;
         self::assertSame('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas varius, tellus in cursus
 dictum, justo odio sagittis velit, id iaculis mi dui id nisi.', (string) $paramTags->getDescription());
     }
+
+    public function testParamBlockDescriptionPreservesStarContinuationLines(): void
+    {
+        $docComment = <<<DOC
+/**
+ * @param array \$foo {
+ *     Description of foo.
+ *
+ *     @type string \$bar Description of bar with
+ *                       * a list
+ *                       * spanning *multiple* lines
+ * }
+ */
+DOC;
+
+        $factory = DocBlockFactory::createInstance();
+        $docblock = $factory->create($docComment);
+
+        self::assertEquals(
+            [
+                new Param(
+                    'foo',
+                    new Array_(),
+                    false,
+                    new Description(
+                        '{' . "\n" .
+                        '    Description of foo.' . "\n" .
+                        "\n" .
+                        '    @type string $bar Description of bar with' . "\n" .
+                        '                      * a list' . "\n" .
+                        '                      * spanning *multiple* lines' . "\n" .
+                        '}'
+                    ),
+                ),
+            ],
+            $docblock->getTags()
+        );
+    }
 }

--- a/tests/integration/InterpretingDocBlocksTest.php
+++ b/tests/integration/InterpretingDocBlocksTest.php
@@ -513,14 +513,15 @@ DOC;
                     'foo',
                     new Array_(),
                     false,
-                    new Description(
-                        '{' . "\n" .
-                        '    Description of foo.' . "\n" .
-                        "\n" .
-                        '    @type string $bar Description of bar with' . "\n" .
-                        '                      * a list' . "\n" .
-                        '                      * spanning *multiple* lines' . "\n" .
-                        '}'
+                    new Description(<<<'DESCRIPTION'
+{
+    Description of foo.
+
+    @type string $bar Description of bar with
+                      * a list
+                      * spanning *multiple* lines
+}
+DESCRIPTION
                     ),
                 ),
             ],


### PR DESCRIPTION
When a tag description contains continuation lines that begin with `*`, the `*` appears twice in the parsed output. This affects block-style `@param` descriptions (common in WordPress docblocks) where list items or `@type` alignment uses a leading star:

```php
/**
 * @param array $foo {
 *     Description of foo.
 *
 *     @type string $bar Description of bar with
 *                       * a list
 *                       * spanning *multiple* lines
 * }
 */
```

The parsed description for `$foo` would incorrectly contain `** a list` instead of `* a list`.

## Root cause

`AbstractPHPStanFactory::tokenizeLine()` worked around a PHPStan lexer limitation by splitting `TOKEN_PHPDOC_EOL` tokens that contained trailing whitespace into two tokens: a bare EOL and a separate `TOKEN_HORIZONTAL_WS`. This placed `*` in both token values. When PHPStan's `parseText()` stopped early at a tag-like token (e.g. `@type`) and rolled back, `joinUntil()` concatenated both raw token values, doubling the star.

## Fix

Prefix every continuation line with `"* "` (star + space) before tokenizing. The PHPStan lexer's `TOKEN_PHPDOC_EOL` pattern matches exactly `\n` + optional whitespace + `* ` (star + one space), so it always consumes the inserted `"* "` as part of the EOL token, leaving the original indentation as a separate subsequent token. A `trim(..., "* \t")` on every EOL token value then strips the inserted `"* "` back out, reducing each EOL to a plain `"\n"`. The manual split into a separate `TOKEN_HORIZONTAL_WS` is no longer needed.

## Changes

- `src/DocBlock/Tags/Factory/AbstractPHPStanFactory.php` — revised `tokenizeLine()`
- `tests/integration/InterpretingDocBlocksTest.php` — regression test covering the
  block-description case with embedded `@type` lines and star-prefixed continuation lines
