### PR TITLE
PHP 8.4 fix explicit nullable deprecations

### DIFF
--- a/docs/examples/04-adding-your-own-tag.php
+++ b/docs/examples/04-adding-your-own-tag.php
@@ -53,7 +53,7 @@ final class MyTag extends BaseTag
      *
      * @see BaseTag for the declaration of the description property and getDescription method.
      */
-    public function __construct(Description $description = null)
+    public function __construct(?Description $description = null)
     {
         $this->description = $description;
     }


### PR DESCRIPTION
I know this change is just for an example, but this flagged as not being PHP 8.4 compatible.

Thanks!