### PR TITLE
fix: add escaped closing docblock to escaped sequences

### DIFF
--- a/src/DocBlock/DescriptionFactory.php
+++ b/src/DocBlock/DescriptionFactory.php
@@ -100,8 +100,9 @@ class DescriptionFactory
 
         return Utils::pregSplit(
             '/\{
-                # "{@}" is not a valid inline tag. This ensures that we do not treat it as one, but treat it literally.
-                (?!@\})
+                # "{@}" and "{@*}" are not a valid inline tags. This ensures that we do not treat them as one, but treat
+                # them literally.
+                (?!(?:@\}|@\*\}) )
                 # We want to capture the whole tag line, but without the inline tag delimiters.
                 (\@
                     # Match everything up to the next delimiter.

--- a/tests/unit/DocBlock/DescriptionFactoryTest.php
+++ b/tests/unit/DocBlock/DescriptionFactoryTest.php
@@ -245,6 +245,7 @@ DESCRIPTION;
     {
         return [
             ['This is text for a description with a {@}.', 'This is text for a description with a @.'],
+            ['This is text for a description with a {@*}.', 'This is text for a description with a {@*}.'],
             ['This is text for a description with a {}.', 'This is text for a description with a }.'],
         ];
     }


### PR DESCRIPTION
The sequence `{@*}` is valid in PHPdoc as an escape sequence for `*/`. See https://manual.phpdoc.org/HTMLframesConverter/default/phpDocumentor/tutorial_phpDocumentor.howto.pkg.html#basics.desc

> New 1.2.0rc1: If you need to use the closing comment "*/" in a DocBlock, use the special escape sequence "{@*}."

However, in our classfile, the sequence `{@*}` is now causing the following error:

```
Running phpdoc to generate structure.xml... 
In Process.php line 271:
                                                                                                                                                                                  
  The command "'phpdoc' '--visibility' 'public,protected,private,internal' '-d' 'src' '--template' 'xml' '--target' 'out'" failed.                                                                                                                                                                           
                                                                                                                                                                                  
  Exit Code: 1(General error)

  Error Output:                                                                                                                                                                   
  ================                                                                                                                                                                
  In docblock.xml.twig line 10:                                                                                                                                                   
                                                                                                                                                                                  
    An exception has been thrown during the rendering of a template ("The arguments array must contain 3 items, 0 given") in "docblock.xml.twig" at line 10 
    
     In DescriptionDescriptor.php line 79:                                                                                                                                           
    The arguments array must contain 3 items, 0 given        

```

This change updates the regex so that the sequence `{@*}` is escaped and kept as a literal instead of being parsed as a tag.