### PR TITLE
Fix PHP 8.4 deprecations (see phpDocumentor#451)

### DIFF
--- a/docs/examples/04-adding-your-own-tag.php
+++ b/docs/examples/04-adding-your-own-tag.php
@@ -85,7 +85,7 @@ final class MyTag extends BaseTag
      * @see Tag for the interface declaration of the `create` method.
      * @see Tag::create() for more information on this method's workings.
      */
-    public static function create(string $body, DescriptionFactory $descriptionFactory = null, Context $context = null): self
+    public static function create(string $body, ?DescriptionFactory $descriptionFactory = null, ?Context $context = null): self
     {
         Assert::notNull($descriptionFactory);
 

--- a/tests/unit/Assets/CustomParam.php
+++ b/tests/unit/Assets/CustomParam.php
@@ -21,7 +21,7 @@ final class CustomParam implements Tag
         return 'spy';
     }
 
-    public static function create(string $body, FqsenResolver $fqsenResolver = null, ?string $myParam = null)
+    public static function create(string $body, ?FqsenResolver $fqsenResolver = null, ?string $myParam = null)
     {
         $tag = new self();
         $tag->fqsenResolver = $fqsenResolver;

--- a/tests/unit/Assets/CustomServiceClass.php
+++ b/tests/unit/Assets/CustomServiceClass.php
@@ -18,7 +18,7 @@ final class CustomServiceClass implements Tag
         return 'spy';
     }
 
-    public static function create(string $body, PassthroughFormatter $formatter = null)
+    public static function create(string $body, ?PassthroughFormatter $formatter = null)
     {
         $tag = new self();
         $tag->formatter = $formatter;

--- a/tests/unit/Assets/CustomServiceInterface.php
+++ b/tests/unit/Assets/CustomServiceInterface.php
@@ -19,7 +19,7 @@ final class CustomServiceInterface implements Tag
         return 'spy';
     }
 
-    public static function create(string $body, Formatter $formatter = null)
+    public static function create(string $body, ?Formatter $formatter = null)
     {
         $tag = new self();
         $tag->formatter = $formatter;

--- a/tests/unit/Assets/CustomTagFactory.php
+++ b/tests/unit/Assets/CustomTagFactory.php
@@ -23,7 +23,7 @@ class CustomTagFactory implements Factory
     /** @var CustomServiceClass|null */
     public $class;
 
-    public function create(string $tagLine, ?Context $context = null, CustomServiceClass $class = null): Tag
+    public function create(string $tagLine, ?Context $context = null, ?CustomServiceClass $class = null): Tag
     {
         $this->class = $class;
 


### PR DESCRIPTION
This fixes implicit nullable deprecation warnings when in an PHP 8.4 environment (see issue #451)