### PR TITLE
Allow balanced braces inside inline tag descriptions

### DIFF
--- a/src/DocBlock/DescriptionFactory.php
+++ b/src/DocBlock/DescriptionFactory.php
@@ -115,6 +115,10 @@ class DescriptionFactory
                             # Notice that this also matches "{}", as a way to later introduce it as an escape sequence.
                             \{(?1)?\}
                             |
+                            # Match a balanced pair of braces that is not an inline tag, e.g. "{braces}" used as part
+                            # of the description of a surrounding inline tag.
+                            \{[^{}]*\}
+                            |
                             # Make sure we match hanging "{".
                             \{
                         )

--- a/tests/unit/DocBlock/DescriptionFactoryTest.php
+++ b/tests/unit/DocBlock/DescriptionFactoryTest.php
@@ -109,6 +109,33 @@ class DescriptionFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::create
      */
+    /**
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Link
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Formatter\PassthroughFormatter
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::__construct
+     * @covers ::create
+     */
+    public function testDescriptionCanParseStringWithInlineTagContainingBalancedBraces(): void
+    {
+        $contents   = 'This description has a {@link http://phpdoc.org/ This contains {braces}} in it.';
+        $context    = new Context('');
+        $tagFactory = m::mock(TagFactory::class);
+        $tagFactory->shouldReceive('create')
+            ->once()
+            ->with('@link http://phpdoc.org/ This contains {braces}', $context)
+            ->andReturn(new LinkTag('http://phpdoc.org/', new Description('This contains {braces}')));
+
+        $factory     = new DescriptionFactory($tagFactory);
+        $description = $factory->create($contents, $context);
+
+        $this->assertSame($contents, $description->render());
+        $this->assertSame('This description has a %1$s in it.', $description->getBodyTemplate());
+    }
+
     public function testDescriptionCanParseAStringStartingWithInlineTag(): void
     {
         $contents   = '{@link http://phpdoc.org/ This} is text for a description that starts with an inline tag.';

--- a/tests/unit/DocBlock/DescriptionFactoryTest.php
+++ b/tests/unit/DocBlock/DescriptionFactoryTest.php
@@ -109,6 +109,22 @@ class DescriptionFactoryTest extends TestCase
      * @covers ::__construct
      * @covers ::create
      */
+    public function testDescriptionCanParseAStringStartingWithInlineTag(): void
+    {
+        $contents   = '{@link http://phpdoc.org/ This} is text for a description that starts with an inline tag.';
+        $context    = new Context('');
+        $tagFactory = m::mock(TagFactory::class);
+        $tagFactory->shouldReceive('create')
+            ->once()
+            ->with('@link http://phpdoc.org/ This', $context)
+            ->andReturn(new LinkTag('http://phpdoc.org/', new Description('This')));
+
+        $factory     = new DescriptionFactory($tagFactory);
+        $description = $factory->create($contents, $context);
+
+        $this->assertSame($contents, $description->render());
+    }
+
     /**
      * @uses \phpDocumentor\Reflection\DocBlock\Description
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\Link
@@ -134,22 +150,6 @@ class DescriptionFactoryTest extends TestCase
 
         $this->assertSame($contents, $description->render());
         $this->assertSame('This description has a %1$s in it.', $description->getBodyTemplate());
-    }
-
-    public function testDescriptionCanParseAStringStartingWithInlineTag(): void
-    {
-        $contents   = '{@link http://phpdoc.org/ This} is text for a description that starts with an inline tag.';
-        $context    = new Context('');
-        $tagFactory = m::mock(TagFactory::class);
-        $tagFactory->shouldReceive('create')
-            ->once()
-            ->with('@link http://phpdoc.org/ This', $context)
-            ->andReturn(new LinkTag('http://phpdoc.org/', new Description('This')));
-
-        $factory     = new DescriptionFactory($tagFactory);
-        $description = $factory->create($contents, $context);
-
-        $this->assertSame($contents, $description->render());
     }
 
     /**


### PR DESCRIPTION
The inline-tag tokenizer in `DescriptionFactory::lex` recognised nested inline tags and hanging `{`, but a bare balanced pair such as `{braces}` inside an inline tag body made the outer tag truncate at the first closing brace. The tokenizer now accepts a balanced `{...}` pair alongside the existing alternatives.

Fixes #255