### PR TITLE
Register @example tag handler out of the box

### DIFF
--- a/src/DocBlock/StandardTagFactory.php
+++ b/src/DocBlock/StandardTagFactory.php
@@ -17,6 +17,7 @@ use InvalidArgumentException;
 use phpDocumentor\Reflection\DocBlock\Tags\Author;
 use phpDocumentor\Reflection\DocBlock\Tags\Covers;
 use phpDocumentor\Reflection\DocBlock\Tags\Deprecated;
+use phpDocumentor\Reflection\DocBlock\Tags\Example;
 use phpDocumentor\Reflection\DocBlock\Tags\Factory\AbstractPHPStanFactory;
 use phpDocumentor\Reflection\DocBlock\Tags\Factory\ExtendsFactory;
 use phpDocumentor\Reflection\DocBlock\Tags\Factory\Factory;
@@ -89,6 +90,7 @@ final class StandardTagFactory implements TagFactory
         'author'             => Author::class,
         'covers'             => Covers::class,
         'deprecated'         => Deprecated::class,
+        'example'            => Example::class,
         'link'               => LinkTag::class,
         'see'                => SeeTag::class,
         'since'              => Since::class,

--- a/tests/unit/DocBlock/StandardTagFactoryTest.php
+++ b/tests/unit/DocBlock/StandardTagFactoryTest.php
@@ -22,6 +22,7 @@ use phpDocumentor\Reflection\Assets\CustomServiceInterface;
 use phpDocumentor\Reflection\Assets\CustomTagFactory;
 use phpDocumentor\Reflection\DocBlock\Tags\Author;
 use phpDocumentor\Reflection\DocBlock\Tags\Deprecated;
+use phpDocumentor\Reflection\DocBlock\Tags\Example;
 use phpDocumentor\Reflection\DocBlock\Tags\Extends_;
 use phpDocumentor\Reflection\DocBlock\Tags\Formatter;
 use phpDocumentor\Reflection\DocBlock\Tags\Formatter\PassthroughFormatter;
@@ -133,6 +134,27 @@ class StandardTagFactoryTest extends TestCase
 
         $this->assertInstanceOf(Author::class, $tag);
         $this->assertSame('author', $tag->getName());
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Example
+     *
+     * @covers ::__construct
+     * @covers ::create
+     */
+    public function testExampleTagIsRecognisedOutOfTheBox(): void
+    {
+        $context    = new Context('');
+        $tagFactory = StandardTagFactory::createInstance(m::mock(FqsenResolver::class));
+
+        $tag = $tagFactory->create('@example "path/to/example.php" 3 10 Example description.', $context);
+
+        $this->assertInstanceOf(Example::class, $tag);
+        $this->assertSame('example', $tag->getName());
+        $this->assertSame('path/to/example.php', $tag->getFilePath());
+        $this->assertSame(3, $tag->getStartingLine());
+        $this->assertSame(10, $tag->getLineCount());
     }
 
     /**

--- a/tests/unit/DocBlock/StandardTagFactoryTest.php
+++ b/tests/unit/DocBlock/StandardTagFactoryTest.php
@@ -158,6 +158,32 @@ class StandardTagFactoryTest extends TestCase
     }
 
     /**
+     * @uses \phpDocumentor\Reflection\DocBlock\DescriptionFactory
+     * @uses \phpDocumentor\Reflection\DocBlock\Description
+     * @uses \phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag
+     * @uses \phpDocumentor\Reflection\DocBlock\Tags\Example
+     *
+     * @covers ::__construct
+     * @covers ::create
+     */
+    public function testExampleTagIsRecognisedInInlineForm(): void
+    {
+        $context    = new Context('');
+        $tagFactory = StandardTagFactory::createInstance(m::mock(FqsenResolver::class));
+        $tagFactory->addService(new DescriptionFactory($tagFactory), DescriptionFactory::class);
+
+        $tag = $tagFactory->create('@link https://phpdoc.org {@example "path/to/example.php"}', $context);
+
+        $description = $tag->getDescription();
+        $this->assertNotNull($description);
+        $inlineTags = $description->getTags();
+        $this->assertCount(1, $inlineTags);
+        $this->assertInstanceOf(Example::class, $inlineTags[0]);
+        $this->assertSame('path/to/example.php', $inlineTags[0]->getFilePath());
+    }
+
+    /**
      * @uses \phpDocumentor\Reflection\DocBlock\StandardTagFactory::addService
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\See
      * @uses \phpDocumentor\Reflection\DocBlock\Tags\BaseTag

--- a/tests/unit/DocBlock/StandardTagFactoryTest.php
+++ b/tests/unit/DocBlock/StandardTagFactoryTest.php
@@ -171,7 +171,6 @@ class StandardTagFactoryTest extends TestCase
     {
         $context    = new Context('');
         $tagFactory = StandardTagFactory::createInstance(m::mock(FqsenResolver::class));
-        $tagFactory->addService(new DescriptionFactory($tagFactory), DescriptionFactory::class);
 
         $tag = $tagFactory->create('@link https://phpdoc.org {@example "path/to/example.php"}', $context);
 


### PR DESCRIPTION
The `Example` tag handler exists and is fully functional, but was never wired into the default tag handler map of `StandardTagFactory`. As a result, `@example` and `{@example ...}` were always parsed as a `Generic` tag, which broke downstream tooling (phpDocumentor rendered the tag as a literal string instead of resolving the referenced file).

Fixes #412